### PR TITLE
Max attestation delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 Development:
+  - add `controller.max_attestation_delay` option
   - add 'epoch_slot' label to 'vouch_block_receipt_delay_seconds' metric
 
 1.0.3:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,3 +108,9 @@ Modules levels are used for each module, overriding the global log level.  The a
   - **validatorsmanager** obtaining validator state from beacon nodes and providing it to other modules
 
 This can be configured using the environment variables `VOUCH_<MODULE>_LOG_LEVEL` or the configuration option `<module>.log-level`.  For example, the controller module logging could be configured using the environment variable `VOUCH_CONTROLLER_LOG_LEVEL` or the configuration option `controller.log-level`.
+
+## Advanced options
+Advanced options can change the performance of Vouch to be severely detrimental to its operation.  It is strongly recommended that these options are not changed unless the user understands completely what they do and their possible performance impact.
+
+### controller.max-attestation-delay
+This is a duration parameter, that defaults to `4s`.  It defines the maximum time that Vouch will wait from the start of a slot for a block before attesting on the basis that the slot is empty.

--- a/main.go
+++ b/main.go
@@ -397,6 +397,7 @@ func startServices(ctx context.Context, majordomo majordomo.Service) error {
 		standardcontroller.WithAttestationAggregator(attestationAggregator),
 		standardcontroller.WithBeaconCommitteeSubscriber(beaconCommitteeSubscriber),
 		standardcontroller.WithAccountsRefresher(accountManager.(accountmanager.Refresher)),
+		standardcontroller.WithMaxAttestationDelay(viper.GetDuration("controller.max-attestation-delay")),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to start controller service")

--- a/mock/eth2client.go
+++ b/mock/eth2client.go
@@ -60,6 +60,19 @@ func (m *SlotDurationProvider) SlotDuration(ctx context.Context) (time.Duration,
 	return m.slotDuration, nil
 }
 
+// ErroringSlotDurationProvider is a mock for eth2client.SlotDurationProvider.
+type ErroringSlotDurationProvider struct{}
+
+// NewErroringSlotDurationProvider returns a mock slot duration provider that errors.
+func NewErroringSlotDurationProvider() eth2client.SlotDurationProvider {
+	return &ErroringSlotDurationProvider{}
+}
+
+// SlotDuration is a mock.
+func (m *ErroringSlotDurationProvider) SlotDuration(ctx context.Context) (time.Duration, error) {
+	return 0, errors.New("mock")
+}
+
 // FarFutureEpochProvider is a mock for eth2client.FarFutureEpochProvider.
 type FarFutureEpochProvider struct {
 	farFutureEpoch spec.Epoch
@@ -105,6 +118,45 @@ func NewErroringSlotsPerEpochProvider() eth2client.SlotsPerEpochProvider {
 // SlotsPerEpoch is a mock.
 func (m *ErroringSlotsPerEpochProvider) SlotsPerEpoch(ctx context.Context) (uint64, error) {
 	return 0, errors.New("error")
+}
+
+// ProposerDutiesProvider is a mock for eth2client.ProposerDutiesProvider.
+type ProposerDutiesProvider struct{}
+
+// NewProposerDutiesProvider returns a mock proposer duties provider.
+func NewProposerDutiesProvider() eth2client.ProposerDutiesProvider {
+	return &ProposerDutiesProvider{}
+}
+
+// ProposerDuties is a mock.
+func (m *ProposerDutiesProvider) ProposerDuties(ctx context.Context, epoch spec.Epoch, validatorIndices []spec.ValidatorIndex) ([]*api.ProposerDuty, error) {
+	return make([]*api.ProposerDuty, 0), nil
+}
+
+// AttesterDutiesProvider is a mock for eth2client.AttesterDutiesProvider.
+type AttesterDutiesProvider struct{}
+
+// NewAttesterDutiesProvider returns a mock attester duties provider.
+func NewAttesterDutiesProvider() eth2client.AttesterDutiesProvider {
+	return &AttesterDutiesProvider{}
+}
+
+// AttesterDuties is a mock.
+func (m *AttesterDutiesProvider) AttesterDuties(ctx context.Context, epoch spec.Epoch, validatorIndices []spec.ValidatorIndex) ([]*api.AttesterDuty, error) {
+	return make([]*api.AttesterDuty, 0), nil
+}
+
+// EventsProvider is a mock for eth2client.EventsProvider.
+type EventsProvider struct{}
+
+// NewEventsProvider returns a mock events provider.
+func NewEventsProvider() eth2client.EventsProvider {
+	return &EventsProvider{}
+}
+
+// Events is a mock
+func (m *EventsProvider) Events(ctx context.Context, topics []string, handler eth2client.EventHandlerFunc) error {
+	return nil
 }
 
 // AttestationsSubmitter is a mock for eth2client.AttestationsSubmitter.

--- a/services/accountmanager/mock/service.go
+++ b/services/accountmanager/mock/service.go
@@ -1,0 +1,55 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/accountmanager"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+type validatingAccountsProvider struct{}
+
+// NewValidatingAccountsProvider is a mock.
+func NewValidatingAccountsProvider() accountmanager.ValidatingAccountsProvider {
+	return &validatingAccountsProvider{}
+}
+
+// ValidatingAccountsForEpoch is a mock.
+func (v *validatingAccountsProvider) ValidatingAccountsForEpoch(ctx context.Context, epoch spec.Epoch) (map[spec.ValidatorIndex]e2wtypes.Account, error) {
+	return make(map[spec.ValidatorIndex]e2wtypes.Account), nil
+}
+
+// ValidatingAccountsForEpochByIndex obtains the specified validating accounts for a given epoch.
+func (v *validatingAccountsProvider) ValidatingAccountsForEpochByIndex(ctx context.Context,
+	epoch spec.Epoch,
+	indices []spec.ValidatorIndex,
+) (
+	map[spec.ValidatorIndex]e2wtypes.Account,
+	error,
+) {
+	return make(map[spec.ValidatorIndex]e2wtypes.Account), nil
+}
+
+type refresher struct{}
+
+// NewRefresher is a mock.
+func NewRefresher() accountmanager.Refresher {
+	return &refresher{}
+}
+
+// Refresh is a mock.
+func (r *refresher) Refresh(ctx context.Context) {}

--- a/services/attestationaggregator/mock/service.go
+++ b/services/attestationaggregator/mock/service.go
@@ -1,0 +1,31 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+
+	"github.com/attestantio/vouch/services/attestationaggregator"
+)
+
+// service is a mock.
+type service struct{}
+
+// New creates a mock attestation aggregator.
+func New() attestationaggregator.Service {
+	return &service{}
+}
+
+// Aggregate is a mock.
+func (s *service) Aggregate(ctx context.Context, data interface{}) {}

--- a/services/attester/mock/service.go
+++ b/services/attester/mock/service.go
@@ -1,0 +1,33 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// Service is a mock attester.
+type Service struct{}
+
+// New creates a new mock  attester.
+func New() *Service {
+	return &Service{}
+}
+
+// Attest carries out attestations for a slot.
+func (s *Service) Attest(ctx context.Context, data interface{}) ([]*spec.Attestation, error) {
+	return make([]*spec.Attestation, 0), nil
+}

--- a/services/beaconblockproposer/mock/service.go
+++ b/services/beaconblockproposer/mock/service.go
@@ -1,0 +1,35 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+
+	"github.com/attestantio/vouch/services/beaconblockproposer"
+)
+
+type service struct{}
+
+// New is a mock.
+func New() beaconblockproposer.Service {
+	return &service{}
+}
+
+// Prepare is a mock.
+func (s *service) Prepare(ctx context.Context, details interface{}) error {
+	return nil
+}
+
+// Propose is a mock.
+func (s *service) Propose(ctx context.Context, details interface{}) {}

--- a/services/beaconcommitteesubscriber/mock/service.go
+++ b/services/beaconcommitteesubscriber/mock/service.go
@@ -1,0 +1,37 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+
+	spec "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/beaconcommitteesubscriber"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+type service struct{}
+
+// New is a mock beacon committee subscriber service.
+func New() beaconcommitteesubscriber.Service {
+	return &service{}
+}
+
+// Subscribe is a mock.
+func (s *service) Subscribe(ctx context.Context,
+	epoch spec.Epoch,
+	accounts map[spec.ValidatorIndex]e2wtypes.Account,
+) (map[spec.Slot]map[spec.CommitteeIndex]*beaconcommitteesubscriber.Subscription, error) {
+	return make(map[spec.Slot]map[spec.CommitteeIndex]*beaconcommitteesubscriber.Subscription), nil
+}

--- a/services/controller/standard/attester.go
+++ b/services/controller/standard/attester.go
@@ -95,10 +95,11 @@ func (s *Service) scheduleAttestations(ctx context.Context,
 			continue
 		}
 		go func(duty *attester.Duty) {
+			// Adding 200 ms to ensure that head is up to date before we fetch attester duties.
+			jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.maxAttestationDelay).Add(200 * time.Millisecond)
 			if err := s.scheduler.ScheduleJob(ctx,
-				fmt.Sprintf("Beacon block attestations for slot %d", duty.Slot()),
-				// Adding 200 ms to ensure that head is up to date before we fetch attester duties.
-				s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.slotDuration/3).Add(200*time.Millisecond),
+				fmt.Sprintf("Attestations for slot %d", duty.Slot()),
+				jobTime,
 				s.AttestAndScheduleAggregate,
 				duty,
 			); err != nil {

--- a/services/controller/standard/events.go
+++ b/services/controller/standard/events.go
@@ -37,7 +37,7 @@ func (s *Service) HandleHeadEvent(event *api.Event) {
 	// We give the block half a second to propagate around the rest of the network before
 	// kicking off attestations for the block's slot.
 	time.Sleep(500 * time.Millisecond)
-	jobName := fmt.Sprintf("Beacon block attestations for slot %d", data.Slot)
+	jobName := fmt.Sprintf("Attestations for slot %d", data.Slot)
 	if s.scheduler.JobExists(ctx, jobName) {
 		log.Trace().Uint64("slot", uint64(data.Slot)).Msg("Kicking off attestations for slot early due to receiving relevant block")
 		if err := s.scheduler.RunJobIfExists(ctx, jobName); err != nil {

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -55,6 +55,7 @@ type Service struct {
 	subscriptionInfos          map[spec.Epoch]map[spec.Slot]map[spec.CommitteeIndex]*beaconcommitteesubscriber.Subscription
 	subscriptionInfosMutex     sync.Mutex
 	accountsRefresher          accountmanager.Refresher
+	maxAttestationDelay        time.Duration
 }
 
 // module-wide log.
@@ -97,6 +98,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		attestationAggregator:      parameters.attestationAggregator,
 		beaconCommitteeSubscriber:  parameters.beaconCommitteeSubscriber,
 		accountsRefresher:          parameters.accountsRefresher,
+		maxAttestationDelay:        parameters.maxAttestationDelay,
 		subscriptionInfos:          make(map[spec.Epoch]map[spec.Slot]map[spec.CommitteeIndex]*beaconcommitteesubscriber.Subscription),
 	}
 

--- a/services/controller/standard/service_test.go
+++ b/services/controller/standard/service_test.go
@@ -1,0 +1,467 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/vouch/mock"
+	mockaccountmanager "github.com/attestantio/vouch/services/accountmanager/mock"
+	mockattestationaggregator "github.com/attestantio/vouch/services/attestationaggregator/mock"
+	mockattester "github.com/attestantio/vouch/services/attester/mock"
+	mockbeaconblockproposer "github.com/attestantio/vouch/services/beaconblockproposer/mock"
+	mockbeaconcommitteesubscriber "github.com/attestantio/vouch/services/beaconcommitteesubscriber/mock"
+	standardchaintime "github.com/attestantio/vouch/services/chaintime/standard"
+	"github.com/attestantio/vouch/services/controller/standard"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	mockscheduler "github.com/attestantio/vouch/services/scheduler/mock"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService(t *testing.T) {
+	ctx := context.Background()
+
+	genesisTime := time.Now()
+	slotDuration := 12 * time.Second
+	slotsPerEpoch := uint64(32)
+	mockGenesisTimeProvider := mock.NewGenesisTimeProvider(genesisTime)
+	mockSlotDurationProvider := mock.NewSlotDurationProvider(slotDuration)
+	mockSlotsPerEpochProvider := mock.NewSlotsPerEpochProvider(slotsPerEpoch)
+
+	proposerDutiesProvider := mock.NewProposerDutiesProvider()
+	attesterDutiesProvider := mock.NewAttesterDutiesProvider()
+	mockScheduler := mockscheduler.New()
+	mockAttester := mockattester.New()
+	mockAttestationAggregator := mockattestationaggregator.New()
+	mockValidatingAccountsProvider := mockaccountmanager.NewValidatingAccountsProvider()
+	mockAccountsRefresher := mockaccountmanager.NewRefresher()
+	mockBeaconBlockProposer := mockbeaconblockproposer.New()
+	mockEventsProvider := mock.NewEventsProvider()
+	mockBeaconCommitteeSubscriber := mockbeaconcommitteesubscriber.New()
+
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithGenesisTimeProvider(mockGenesisTimeProvider),
+		standardchaintime.WithSlotDurationProvider(mockSlotDurationProvider),
+		standardchaintime.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		params   []standard.Parameter
+		err      string
+		logEntry string
+	}{
+		{
+			name: "MonitorNil",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no monitor specified",
+		},
+		{
+			name: "SlotDurationProviderNotSpecified",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no slot duration provider specified",
+		},
+		{
+			name: "SlotDurationProviderErrors",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mock.NewErroringSlotDurationProvider()),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "failed to obtain slot duration: mock",
+		},
+		{
+			name: "SlotsPerEpochProviderMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no slots per epoch provider specified",
+		},
+		{
+			name: "SlotsPerEpochProviderErrors",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mock.NewErroringSlotsPerEpochProvider()),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "failed to obtain slots per epoch: error",
+		},
+		{
+			name: "ChainTimeServiceMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no chain time service specified",
+		},
+		{
+			name: "ProposerDutiesProviderMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no proposer duties provider specified",
+		},
+		{
+			name: "AttesterDutiesProviderMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no attester duties provider specified",
+		},
+		{
+			name: "EventsProviderMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no events provider specified",
+		},
+		{
+			name: "ValidatingAccountsProviderMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no validating accounts provider specified",
+		},
+		{
+			name: "SchedulerMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no scheduler service specified",
+		},
+		{
+			name: "AttesterMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no attester specified",
+		},
+		{
+			name: "BeaconBlockProposerMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no beacon block proposer specified",
+		},
+		{
+			name: "BeaconCommitteeSubscriberMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no beacon committee subscriber specified",
+		},
+		{
+			name: "AttestationAggregatorMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no attestation aggregator specified",
+		},
+		{
+			name: "AccountsRefresherMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+			err: "problem with parameters: no accounts refresher specified",
+		},
+		{
+			name: "MaxAttestationDelayZero",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(0),
+			},
+			err: "problem with parameters: no maximum attestation delay specified",
+		},
+		{
+			name: "Good",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithSlotDurationProvider(mockSlotDurationProvider),
+				standard.WithSlotsPerEpochProvider(mockSlotsPerEpochProvider),
+				standard.WithChainTimeService(chainTime),
+				standard.WithProposerDutiesProvider(proposerDutiesProvider),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithEventsProvider(mockEventsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithScheduler(mockScheduler),
+				standard.WithAttester(mockAttester),
+				standard.WithBeaconBlockProposer(mockBeaconBlockProposer),
+				standard.WithBeaconCommitteeSubscriber(mockBeaconCommitteeSubscriber),
+				standard.WithAttestationAggregator(mockAttestationAggregator),
+				standard.WithAccountsRefresher(mockAccountsRefresher),
+				standard.WithMaxAttestationDelay(4 * time.Second),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capture := logger.NewLogCapture()
+			_, err := standard.New(ctx, test.params...)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+				if test.logEntry != "" {
+					capture.AssertHasEntry(t, test.logEntry)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/services/scheduler/mock/service.go
+++ b/services/scheduler/mock/service.go
@@ -1,0 +1,69 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+	"time"
+
+	"github.com/attestantio/vouch/services/scheduler"
+)
+
+// Service is a mock scheduler service.
+type service struct{}
+
+// New creates a new mock scheduling service.
+func New() scheduler.Service {
+	return &service{}
+}
+
+// ScheduleJob schedules a one-off job for a given time.
+func (s *service) ScheduleJob(ctx context.Context, name string, runtime time.Time, jobFunc scheduler.JobFunc, data interface{}) error {
+	return nil
+}
+
+// SchedulePeriodicJob schedules a job to run in a loop.
+func (s *service) SchedulePeriodicJob(ctx context.Context, name string, runtimeFunc scheduler.RuntimeFunc, runtimeData interface{}, jobFunc scheduler.JobFunc, jobData interface{}) error {
+	return nil
+}
+
+// RunJob runs a named job immediately.
+func (s *service) RunJob(ctx context.Context, name string) error {
+	return nil
+}
+
+// JobExists returns true if a job exists.
+func (s *service) JobExists(ctx context.Context, name string) bool {
+	return false
+}
+
+// ListJobs returns the names of all jobs.
+func (s *service) ListJobs(ctx context.Context) []string {
+	return []string{}
+}
+
+// RunJobIfExists runs a job if it exists.
+func (s *service) RunJobIfExists(ctx context.Context, name string) error {
+	return nil
+}
+
+// CancelJob removes a named job.
+func (s *service) CancelJob(ctx context.Context, name string) error {
+	return nil
+}
+
+// CancelJobs cancels all jobs with the given prefix.
+func (s *service) CancelJobs(ctx context.Context, prefix string) error {
+	return nil
+}


### PR DESCRIPTION
This adds a flag `controller.max-attestation-delay` that controls the maximum time that Vouch will wait until it starts to generates attestations for a slot.