### PR TITLE
Wait for waitgroup to complete.

### DIFF
--- a/services/accountmanager/dirk/service.go
+++ b/services/accountmanager/dirk/service.go
@@ -193,6 +193,7 @@ func (s *Service) refreshAccounts(ctx context.Context) error {
 			log.Trace().Dur("elapsed", time.Since(started)).Int("accounts", len(walletAccounts)).Msg("Imported accounts")
 		}(ctx, sem, &wg, i, &accountsMu)
 	}
+	wg.Wait()
 	log.Trace().Int("accounts", len(accounts)).Msg("Obtained accounts")
 
 	if len(accounts) == 0 && len(s.accounts) != 0 {


### PR DESCRIPTION
#22 introduced an issue with updating accounts, where the code failed to wait for the waitgroup participants to finish.  This adds an explicit wait to ensure the waitgroup completes.