### PR TITLE
Decrypt local accounts in parallel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 1.1.0:
+  - decrypt local accounts in parallel to reduce startup time
   - add 'advanced' scheduler, designed to be more robust with higher parallel job load
   - fetch wallet accounts from Dirk in parallel
   - fetch process-concurrency configuration value from most specific point in hierarchy

--- a/main.go
+++ b/main.go
@@ -670,6 +670,7 @@ func startAccountManager(ctx context.Context, monitor metrics.Service, eth2Clien
 		accountManager, err = walletaccountmanager.New(ctx,
 			walletaccountmanager.WithLogLevel(logLevel(viper.GetString("accountmanager.wallet.log-level"))),
 			walletaccountmanager.WithMonitor(monitor.(metrics.AccountManagerMonitor)),
+			walletaccountmanager.WithProcessConcurrency(util.ProcessConcurrency("accountmanager.wallet")),
 			walletaccountmanager.WithValidatorsManager(validatorsManager),
 			walletaccountmanager.WithAccountPaths(viper.GetStringSlice("accountmanager.wallet.accounts")),
 			walletaccountmanager.WithPassphrases(passphrases),

--- a/services/accountmanager/wallet/parameters.go
+++ b/services/accountmanager/wallet/parameters.go
@@ -25,6 +25,7 @@ import (
 type parameters struct {
 	logLevel               zerolog.Level
 	monitor                metrics.AccountManagerMonitor
+	processConcurrency     int64
 	locations              []string
 	accountPaths           []string
 	passphrases            [][]byte
@@ -57,6 +58,13 @@ func WithLogLevel(logLevel zerolog.Level) Parameter {
 func WithMonitor(monitor metrics.AccountManagerMonitor) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.monitor = monitor
+	})
+}
+
+// WithProcessConcurrency sets the concurrency for the service.
+func WithProcessConcurrency(concurrency int64) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.processConcurrency = concurrency
 	})
 }
 
@@ -129,6 +137,9 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 
 	if parameters.monitor == nil {
 		return nil, errors.New("no monitor specified")
+	}
+	if parameters.processConcurrency == 0 {
+		return nil, errors.New("no process concurrency specified")
 	}
 	if parameters.accountPaths == nil {
 		return nil, errors.New("no account paths specified")


### PR DESCRIPTION
This changes the wallet account manager to decrypt accounts in parallel, to reduce the time taken to update accounts on startup and refresh.