### PR TITLE
Remove redundant Prysm gRPC calls.

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -20,7 +20,7 @@ accountmanager:
       - secret
 ```
 
-`beacon-node-address` should be changed to access a suitable beacon node (Prysm, Lighthouse or Teku).
+`beacon-node-address` should be changed to access a suitable beacon node.
 
 `secret` should be changed to be the passphrase you used to secure the accounts.
 

--- a/services/attestationaggregator/service.go
+++ b/services/attestationaggregator/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import (
 	"context"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
 )
 
 // Duty contains information about an attestation aggregation duty.
@@ -30,12 +29,6 @@ type Duty struct {
 	ValidatorIndex phase0.ValidatorIndex
 	// SlotSignature is the signature of the slot by the validator carrying out the aggregation; reuqired for submitting the aggregate.
 	SlotSignature phase0.BLSSignature
-	// Attestation is the attestation from the validator that is part of the related to the aggregate.
-	// Required for Prysm non-spec GRPC method.
-	Attestation *phase0.Attestation
-	// Account is the account carrying out the aggregation.
-	// Required for Prysm non-spec GRPC method.
-	Account e2wtypes.Account
 }
 
 // IsAggregatorProvider provides information about if a validator is an aggregator.

--- a/services/attestationaggregator/standard/parameters.go
+++ b/services/attestationaggregator/standard/parameters.go
@@ -30,7 +30,6 @@ type parameters struct {
 	targetAggregatorsPerCommitteeProvider eth2client.TargetAggregatorsPerCommitteeProvider
 	validatingAccountsProvider            accountmanager.ValidatingAccountsProvider
 	aggregateAttestationProvider          eth2client.AggregateAttestationProvider
-	prysmAggregateAttestationProvider     eth2client.PrysmAggregateAttestationProvider
 	aggregateAttestationsSubmitter        submitter.AggregateAttestationsSubmitter
 	slotSelectionSigner                   signer.SlotSelectionSigner
 	aggregateAndProofSigner               signer.AggregateAndProofSigner
@@ -89,13 +88,6 @@ func WithAggregateAttestationProvider(provider eth2client.AggregateAttestationPr
 	})
 }
 
-// WithPrysmAggregateAttestationProvider sets the non-spec aggregate attestation provider.
-func WithPrysmAggregateAttestationProvider(provider eth2client.PrysmAggregateAttestationProvider) Parameter {
-	return parameterFunc(func(p *parameters) {
-		p.prysmAggregateAttestationProvider = provider
-	})
-}
-
 // WithAggregateAttestationsSubmitter sets the aggregate attestation submitter.
 func WithAggregateAttestationsSubmitter(submitter submitter.AggregateAttestationsSubmitter) Parameter {
 	return parameterFunc(func(p *parameters) {
@@ -140,7 +132,7 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	if parameters.validatingAccountsProvider == nil {
 		return nil, errors.New("no validating accounts provider specified")
 	}
-	if parameters.aggregateAttestationProvider == nil && parameters.prysmAggregateAttestationProvider == nil {
+	if parameters.aggregateAttestationProvider == nil {
 		return nil, errors.New("no aggregate attestation provider specified")
 	}
 	if parameters.aggregateAttestationsSubmitter == nil {

--- a/services/controller/standard/attester.go
+++ b/services/controller/standard/attester.go
@@ -184,8 +184,6 @@ func (s *Service) AttestAndScheduleAggregate(ctx context.Context, data interface
 				AttestationDataRoot: attestationDataRoot,
 				ValidatorIndex:      info.Duty.ValidatorIndex,
 				SlotSignature:       info.Signature,
-				Account:             accounts[info.Duty.ValidatorIndex],
-				Attestation:         attestation,
 			}
 			if err := s.scheduler.ScheduleJob(ctx,
 				fmt.Sprintf("Beacon block attestation aggregation for slot %d committee %d", attestation.Data.Slot, attestation.Data.Index),


### PR DESCRIPTION
Vouch now talks to Prysm via the HTTP API, so the gRPC-specific calls can now be removed.