### PR TITLE
Do not process empty sync committee messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 1.2.1:
   - make advanced scheduler the default
+  - do not process empty sync committee messages
 
 1.2.0:
   - fetch attestation duties for next epoch approximately half way through current epoch

--- a/services/controller/standard/synccommitteemessenger.go
+++ b/services/controller/standard/synccommitteemessenger.go
@@ -64,6 +64,10 @@ func (s *Service) scheduleSyncCommitteeMessages(ctx context.Context,
 		return
 	}
 	log.Trace().Dur("elapsed", time.Since(started)).Int("duties", len(duties)).Msg("Fetched sync committee message duties")
+	if len(duties) == 0 {
+		// No duties; nothing to do.
+		return
+	}
 
 	// We combine the duties for the epoch.
 	messageIndices := make(map[phase0.ValidatorIndex][]phase0.CommitteeIndex, len(duties))


### PR DESCRIPTION
If the request for sync committee duties comes back empty then do not schedule a job.  This avoids an error when the empty sync committee messages list is sent to the beacon node.