### PR TITLE
Avoid deadlock in advanced scheduler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 1.2.1:
   - make advanced scheduler the default
   - do not process empty sync committee messages
+  - avoid deadlock in advanced scheduler
 
 1.2.0:
   - fetch attestation duties for next epoch approximately half way through current epoch


### PR DESCRIPTION
It was possible for a job to be triggered just before it was due to run due to its timer.  This situation would cause a deadlock, resulting in Vouch terminating itself.  This adds explicit early removal from the jobs list as well as additional checks when trigger conditions are met.