### PR TITLE
Do not crash with no metrics configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+Development:
+  - fix crash when no metrics configuration is supplied
+
 1.2.1:
   - make advanced scheduler the default
   - do not process empty sync committee messages

--- a/services/metrics/null/service.go
+++ b/services/metrics/null/service.go
@@ -89,3 +89,11 @@ func (s *Service) SyncCommitteeAggregationsCompleted(started time.Time, count in
 // SyncCommitteeMessagesCompleted is called when a sync committee message process has completed.
 func (s *Service) SyncCommitteeMessagesCompleted(started time.Time, count int, result string) {
 }
+
+// SyncCommitteeSubscriptionCompleted is called when a sync committee subscription process has completed.
+func (s *Service) SyncCommitteeSubscriptionCompleted(started time.Time, result string) {
+}
+
+// SyncCommitteeSubscribers sets the number of sync committees to which our validators are subscribed.
+func (s *Service) SyncCommitteeSubscribers(subscribers int) {
+}


### PR DESCRIPTION
If there is no metrics configuration Vouch falls back to a null implementation.  This implementation was missing an interface, causing a cast exception.

This patch adds the required functions to implement the interface.