### PR TITLE
Add async channels to scheduler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+development:
+  - make scheduler channels asynchronous, to avoid potential deadlock
+
 1.2.2:
   - fix crash when no metrics configuration is supplied
 


### PR DESCRIPTION
The scheduler can hit a deadlock condition due to its use of synchronous channels.  This changes the scheduler channels to be asynchronous with a buffer size of 1, avoiding a deadlock situation.