### PR TITLE
Add scatter utility.

### DIFF
--- a/util/scatter.go
+++ b/util/scatter.go
@@ -1,0 +1,101 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+)
+
+// ScatterResult is the result of a single scatter worker.
+type ScatterResult struct {
+	// Offset is the offset at which the worker started.
+	Offset int
+	// Extent is the user-defined result of running the scatter function.
+	Extent interface{}
+}
+
+// Scatter scatters a computation across multiple goroutines, returning a set of per-worker results
+func Scatter(inputLen int, concurrency int, work func(int, int, *sync.RWMutex) (interface{}, error)) ([]*ScatterResult, error) {
+	if inputLen <= 0 {
+		return nil, errors.New("no data with which to work")
+	}
+
+	extentSize := calculateExtentSize(inputLen, concurrency)
+	workers := inputLen / extentSize
+	if inputLen%extentSize != 0 {
+		workers++
+	}
+
+	resultCh := make(chan *ScatterResult, workers)
+	defer close(resultCh)
+	errorCh := make(chan error, workers)
+	defer close(errorCh)
+	mutex := new(sync.RWMutex)
+	for worker := 0; worker < workers; worker++ {
+		offset := worker * extentSize
+		entries := extentSize
+		if offset+entries > inputLen {
+			entries = inputLen - offset
+		}
+		go func(offset int, entries int) {
+			extent, err := work(offset, entries, mutex)
+			if err != nil {
+				errorCh <- err
+			} else {
+				resultCh <- &ScatterResult{
+					Offset: offset,
+					Extent: extent,
+				}
+			}
+		}(offset, entries)
+	}
+
+	// Collect results from workers
+	results := make([]*ScatterResult, workers)
+	var err error
+	for i := 0; i < workers; i++ {
+		select {
+		case result := <-resultCh:
+			results[i] = result
+		case err = <-errorCh:
+			// Error occurred; don't return because that closes the channels
+			// and can cause other workers to write to the closed channel.
+		}
+	}
+	return results, err
+}
+
+// calculateExtentSize calculates the extent size given the number of items and maximum processors available.
+func calculateExtentSize(items int, desiredConcurrency int) int {
+	if desiredConcurrency <= 0 {
+		desiredConcurrency = runtime.GOMAXPROCS(0)
+	}
+
+	// Start with an even split.
+	extentSize := items / desiredConcurrency
+
+	if extentSize == 0 {
+		// We must have an extent size of at least 1.
+		return 1
+	}
+
+	if items%extentSize > 0 {
+		// We have a remainder; add one to the extent size to ensure we capture it.
+		extentSize++
+	}
+
+	return extentSize
+}

--- a/util/scatter_benchmark_test.go
+++ b/util/scatter_benchmark_test.go
@@ -42,7 +42,7 @@ func init() {
 	}
 }
 
-// hash is a simple worker function that carries out repeated hashging of its input to provide an output.
+// hash is a simple worker function that carries out repeated hashing of its input to provide an output.
 func hash(input [][]byte) [][]byte {
 	output := make([][]byte, len(input))
 	for i := range input {

--- a/util/scatter_benchmark_test.go
+++ b/util/scatter_benchmark_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/attestantio/dirk/util"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 

--- a/util/scatter_benchmark_test.go
+++ b/util/scatter_benchmark_test.go
@@ -37,7 +37,7 @@ func init() {
 		input[i] = make([]byte, benchmarkElementSize)
 		_, err := rand.Read(input[i])
 		if err != nil {
-			log.WithError(err).Debug("Cannot read from rand")
+			panic(err)
 		}
 	}
 }

--- a/util/scatter_benchmark_test.go
+++ b/util/scatter_benchmark_test.go
@@ -1,0 +1,76 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"sync"
+	"testing"
+
+	"github.com/attestantio/dirk/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+var input [][]byte
+
+const (
+	benchmarkElements    = 65536
+	benchmarkElementSize = 32
+	benchmarkHashRuns    = 128
+)
+
+func init() {
+	input = make([][]byte, benchmarkElements)
+	for i := 0; i < benchmarkElements; i++ {
+		input[i] = make([]byte, benchmarkElementSize)
+		_, err := rand.Read(input[i])
+		if err != nil {
+			log.WithError(err).Debug("Cannot read from rand")
+		}
+	}
+}
+
+// hash is a simple worker function that carries out repeated hashging of its input to provide an output.
+func hash(input [][]byte) [][]byte {
+	output := make([][]byte, len(input))
+	for i := range input {
+		copy(output, input)
+		for j := 0; j < benchmarkHashRuns; j++ {
+			hash := sha256.Sum256(output[i])
+			output[i] = hash[:]
+		}
+	}
+	return output
+}
+
+func BenchmarkHash(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		hash(input)
+	}
+}
+
+func BenchmarkHashMP(b *testing.B) {
+	output := make([][]byte, len(input))
+	for i := 0; i < b.N; i++ {
+		workerResults, err := util.Scatter(len(input), func(offset int, entries int, _ *sync.RWMutex) (interface{}, error) {
+			return hash(input[offset : offset+entries]), nil
+		})
+		require.NoError(b, err)
+		for _, result := range workerResults {
+			copy(output[result.Offset:], result.Extent.([][]byte))
+		}
+	}
+}

--- a/util/scatter_test.go
+++ b/util/scatter_test.go
@@ -1,0 +1,116 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/attestantio/dirk/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDouble(t *testing.T) {
+	tests := []struct {
+		name     string
+		inValues int
+		err      string
+	}{
+		{
+			name:     "0",
+			inValues: 0,
+			err:      "no data with which to work",
+		},
+		{
+			name:     "1",
+			inValues: 1,
+		},
+		{
+			name:     "1023",
+			inValues: 1023,
+		},
+		{
+			name:     "1024",
+			inValues: 1024,
+		},
+		{
+			name:     "1025",
+			inValues: 1025,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inValues := make([]int, test.inValues)
+			for i := 0; i < test.inValues; i++ {
+				inValues[i] = i
+			}
+			outValues := make([]int, test.inValues)
+			workerResults, err := util.Scatter(len(inValues), func(offset int, entries int, _ *sync.RWMutex) (interface{}, error) {
+				extent := make([]int, entries)
+				for i := 0; i < entries; i++ {
+					extent[i] = inValues[offset+i] * 2
+				}
+				return extent, nil
+			})
+			if test.err != "" {
+				assert.Equal(t, test.err, err.Error())
+			} else {
+				require.NoError(t, err)
+				for _, result := range workerResults {
+					copy(outValues[result.Offset:], result.Extent.([]int))
+				}
+
+				for i := 0; i < test.inValues; i++ {
+					require.Equal(t, inValues[i]*2, outValues[i], "Outvalue at %d incorrect", i)
+				}
+			}
+		})
+	}
+}
+
+func TestMutex(t *testing.T) {
+	totalRuns := 1048576
+	val := 0
+	_, err := util.Scatter(totalRuns, func(offset int, entries int, mu *sync.RWMutex) (interface{}, error) {
+		for i := 0; i < entries; i++ {
+			mu.Lock()
+			val++
+			mu.Unlock()
+		}
+		return nil, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, totalRuns, val)
+}
+
+func TestError(t *testing.T) {
+	totalRuns := 1024
+	val := 0
+	_, err := util.Scatter(totalRuns, func(offset int, entries int, mu *sync.RWMutex) (interface{}, error) {
+		for i := 0; i < entries; i++ {
+			mu.Lock()
+			val++
+			if val == 1011 {
+				mu.Unlock()
+				return nil, errors.New("bad number")
+			}
+			mu.Unlock()
+		}
+		return nil, nil
+	})
+	require.EqualError(t, err, "bad number")
+}


### PR DESCRIPTION
Scatter provides a helper for breaking a single range of processing in to multiple goroutines.