### PR TITLE
Add metrics for sync committee aggregation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 development:
   - make scheduler channels asynchronous, to avoid potential deadlock
+  - add metrics for sync committee operations
 
 1.2.2:
   - fix crash when no metrics configuration is supplied

--- a/services/metrics/null/service.go
+++ b/services/metrics/null/service.go
@@ -86,6 +86,10 @@ func (s *Service) StrategyOperation(strategy string, provider string, operation 
 func (s *Service) SyncCommitteeAggregationsCompleted(started time.Time, count int, result string) {
 }
 
+// SyncCommitteeAggregationCoverage measures the message ratio of the sync committee aggregation.
+func (s *Service) SyncCommitteeAggregationCoverage(frac float64) {
+}
+
 // SyncCommitteeMessagesCompleted is called when a sync committee message process has completed.
 func (s *Service) SyncCommitteeMessagesCompleted(started time.Time, count int, result string) {
 }

--- a/services/metrics/prometheus/service.go
+++ b/services/metrics/prometheus/service.go
@@ -48,6 +48,7 @@ type Service struct {
 
 	syncCommitteeAggregationProcessTimer    prometheus.Histogram
 	syncCommitteeAggregationProcessRequests *prometheus.CounterVec
+	syncCommitteeAggregationCoverageRatio   prometheus.Histogram
 
 	beaconCommitteeSubscriptionProcessTimer    prometheus.Histogram
 	beaconCommitteeSubscriptionProcessRequests *prometheus.CounterVec

--- a/services/metrics/service.go
+++ b/services/metrics/service.go
@@ -73,6 +73,9 @@ type SyncCommitteeMessageMonitor interface {
 type SyncCommitteeAggregationMonitor interface {
 	// SyncCommitteeAggregationsCompleted is called when a sync committee aggregation process has completed.
 	SyncCommitteeAggregationsCompleted(started time.Time, count int, result string)
+
+	// SyncCommitteeAggregationCoverage measures the contribution ratio of the sync committee aggregation.
+	SyncCommitteeAggregationCoverage(frac float64)
 }
 
 // BeaconCommitteeSubscriptionMonitor provides methods to monitor the outcome of beacon committee subscriptions.

--- a/services/synccommitteeaggregator/standard/service.go
+++ b/services/synccommitteeaggregator/standard/service.go
@@ -210,5 +210,10 @@ func (s *Service) Aggregate(ctx context.Context, data interface{}) {
 	}
 
 	log.Trace().Msg("Submitted signed contribution and proofs")
+	for i := range signedContributionAndProofs {
+		frac := float64(signedContributionAndProofs[i].Message.Contribution.AggregationBits.Count()) /
+			float64(signedContributionAndProofs[i].Message.Contribution.AggregationBits.Len())
+		s.monitor.SyncCommitteeAggregationCoverage(frac)
+	}
 	s.monitor.SyncCommitteeAggregationsCompleted(started, len(signedContributionAndProofs), "succeeded")
 }


### PR DESCRIPTION
This adds the coverage ratio for aggregate sync committee messages to metrics, providing the ability to see the outcome of the sync committee aggregation process.