### PR TITLE
Add mark metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ development:
   - add `controller.sync-committee-message-delay` option
   - add `controller.sync-committee-aggregation-delay` option
   - submit attestations in batches, to speed up initial broadcast
+  - add mark metrics, to provide timeliness information for validator operations
 
 1.2.2:
   - fix crash when no metrics configuration is supplied

--- a/services/metrics/prometheus/attestation.go
+++ b/services/metrics/prometheus/attestation.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -35,6 +35,31 @@ func (s *Service) setupAttestationMetrics() error {
 		return err
 	}
 
+	s.attestationMarkTimer =
+		prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "vouch",
+			Subsystem: "attestation",
+			Name:      "mark_seconds",
+			Help:      "The time in to the slot at which the attestations were broadcast.",
+			Buckets: []float64{
+				0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+				1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
+				2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0,
+				3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0,
+				4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0,
+				5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0,
+				6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0,
+				7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0,
+				8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0,
+				9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0,
+				10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0,
+				11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0,
+			},
+		})
+	if err := prometheus.Register(s.attestationMarkTimer); err != nil {
+		return err
+	}
+
 	s.attestationProcessRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "vouch",
 		Subsystem: "attestation_process",
@@ -46,9 +71,14 @@ func (s *Service) setupAttestationMetrics() error {
 
 // AttestationsCompleted is called when an attestation process has completed.
 func (s *Service) AttestationsCompleted(started time.Time, count int, result string) {
-	duration := time.Since(started).Seconds()
-	for i := 0; i < count; i++ {
-		s.attestationProcessTimer.Observe(duration)
+	// Only log times for successful completions.
+	if result == "succeeded" {
+		duration := time.Since(started).Seconds()
+		for i := 0; i < count; i++ {
+			s.attestationProcessTimer.Observe(duration)
+		}
+		secsSinceStartOfSlot := time.Since(s.chainTime.StartOfSlot(s.chainTime.CurrentSlot())).Seconds()
+		s.attestationMarkTimer.Observe(secsSinceStartOfSlot)
 	}
 	s.attestationProcessRequests.WithLabelValues(result).Add(float64(count))
 }

--- a/services/metrics/prometheus/attestationaggregation.go
+++ b/services/metrics/prometheus/attestationaggregation.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -35,6 +35,31 @@ func (s *Service) setupAttestationAggregationMetrics() error {
 		return err
 	}
 
+	s.attestationAggregationMarkTimer =
+		prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "vouch",
+			Subsystem: "attestationaggregation",
+			Name:      "mark_seconds",
+			Help:      "The time in to the slot at which the aggregate attestations were broadcast.",
+			Buckets: []float64{
+				0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+				1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
+				2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0,
+				3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0,
+				4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0,
+				5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0,
+				6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0,
+				7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0,
+				8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0,
+				9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0,
+				10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0,
+				11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0,
+			},
+		})
+	if err := prometheus.Register(s.attestationAggregationMarkTimer); err != nil {
+		return err
+	}
+
 	s.attestationAggregationProcessRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "vouch",
 		Subsystem: "attestationaggregation_process",
@@ -58,7 +83,12 @@ func (s *Service) setupAttestationAggregationMetrics() error {
 
 // AttestationAggregationCompleted is called when an attestation aggregationprocess has completed.
 func (s *Service) AttestationAggregationCompleted(started time.Time, result string) {
-	s.attestationAggregationProcessTimer.Observe(time.Since(started).Seconds())
+	// Only log times for successful completions.
+	if result == "succeeded" {
+		s.attestationAggregationProcessTimer.Observe(time.Since(started).Seconds())
+		secsSinceStartOfSlot := time.Since(s.chainTime.StartOfSlot(s.chainTime.CurrentSlot())).Seconds()
+		s.attestationAggregationMarkTimer.Observe(secsSinceStartOfSlot)
+	}
 	s.attestationAggregationProcessRequests.WithLabelValues(result).Inc()
 }
 

--- a/services/metrics/prometheus/beaconblockproposal.go
+++ b/services/metrics/prometheus/beaconblockproposal.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -35,6 +35,31 @@ func (s *Service) setupBeaconBlockProposalMetrics() error {
 		return err
 	}
 
+	s.beaconBlockProposalMarkTimer =
+		prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "vouch",
+			Subsystem: "beaconblockproposal",
+			Name:      "mark_seconds",
+			Help:      "The time in to the slot at which the beacon block was broadcast.",
+			Buckets: []float64{
+				0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+				1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
+				2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0,
+				3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0,
+				4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0,
+				5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0,
+				6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0,
+				7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0,
+				8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0,
+				9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0,
+				10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0,
+				11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0,
+			},
+		})
+	if err := prometheus.Register(s.beaconBlockProposalMarkTimer); err != nil {
+		return err
+	}
+
 	s.beaconBlockProposalProcessRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "vouch",
 		Subsystem: "beaconblockproposal_process",
@@ -46,6 +71,11 @@ func (s *Service) setupBeaconBlockProposalMetrics() error {
 
 // BeaconBlockProposalCompleted is called when a block proposal process has completed.
 func (s *Service) BeaconBlockProposalCompleted(started time.Time, result string) {
-	s.beaconBlockProposalProcessTimer.Observe(time.Since(started).Seconds())
+	// Only log times for successful completions.
+	if result == "succeeded" {
+		s.beaconBlockProposalProcessTimer.Observe(time.Since(started).Seconds())
+		secsSinceStartOfSlot := time.Since(s.chainTime.StartOfSlot(s.chainTime.CurrentSlot())).Seconds()
+		s.beaconBlockProposalMarkTimer.Observe(secsSinceStartOfSlot)
+	}
 	s.beaconBlockProposalProcessRequests.WithLabelValues(result).Inc()
 }

--- a/services/metrics/prometheus/beaconcommitteesubscription.go
+++ b/services/metrics/prometheus/beaconcommitteesubscription.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -66,7 +66,10 @@ func (s *Service) setupBeaconCommitteeSubscriptionMetrics() error {
 
 // BeaconCommitteeSubscriptionCompleted is called when an beacon committee subscription process has completed.
 func (s *Service) BeaconCommitteeSubscriptionCompleted(started time.Time, result string) {
-	s.beaconCommitteeSubscriptionProcessTimer.Observe(time.Since(started).Seconds())
+	// Only log times for successful completions.
+	if result == "succeeded" {
+		s.beaconCommitteeSubscriptionProcessTimer.Observe(time.Since(started).Seconds())
+	}
 	s.beaconCommitteeSubscriptionProcessRequests.WithLabelValues(result).Inc()
 }
 

--- a/services/metrics/prometheus/parameters.go
+++ b/services/metrics/prometheus/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,12 +16,14 @@ package prometheus
 import (
 	"errors"
 
+	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/rs/zerolog"
 )
 
 type parameters struct {
-	logLevel zerolog.Level
-	address  string
+	logLevel  zerolog.Level
+	address   string
+	chainTime chaintime.Service
 }
 
 // Parameter is the interface for service parameters.
@@ -49,6 +51,13 @@ func WithAddress(address string) Parameter {
 	})
 }
 
+// WithChainTime sets the chaintime service.
+func WithChainTime(chainTime chaintime.Service) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.chainTime = chainTime
+	})
+}
+
 // parseAndCheckParameters parses and checks parameters to ensure that mandatory parameters are present and correct.
 func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	parameters := parameters{
@@ -62,6 +71,9 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 
 	if parameters.address == "" {
 		return nil, errors.New("no address specified")
+	}
+	if parameters.chainTime == nil {
+		return nil, errors.New("no chain time service specified")
 	}
 
 	return &parameters, nil

--- a/services/metrics/prometheus/service_test.go
+++ b/services/metrics/prometheus/service_test.go
@@ -1,0 +1,86 @@
+// Copyright © 2021 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/vouch/mock"
+	standardchaintime "github.com/attestantio/vouch/services/chaintime/standard"
+	"github.com/attestantio/vouch/services/metrics/prometheus"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService(t *testing.T) {
+	ctx := context.Background()
+
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisTimeProvider(mock.NewGenesisTimeProvider(time.Now())),
+		standardchaintime.WithSlotDurationProvider(mock.NewSlotDurationProvider(12*time.Second)),
+		standardchaintime.WithSlotsPerEpochProvider(mock.NewSlotsPerEpochProvider(32)),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		params   []prometheus.Parameter
+		err      string
+		logEntry string
+	}{
+		{
+			name: "AddressMissing",
+			params: []prometheus.Parameter{
+				prometheus.WithLogLevel(zerolog.Disabled),
+				prometheus.WithChainTime(chainTime),
+			},
+			err: "problem with parameters: no address specified",
+		},
+		{
+			name: "ChainTimeMissing",
+			params: []prometheus.Parameter{
+				prometheus.WithLogLevel(zerolog.Disabled),
+				prometheus.WithAddress("http://localhost:12345/"),
+			},
+			err: "problem with parameters: no chain time service specified",
+		},
+		{
+			name: "Good",
+			params: []prometheus.Parameter{
+				prometheus.WithLogLevel(zerolog.Disabled),
+				prometheus.WithAddress("http://localhost:12345/"),
+				prometheus.WithChainTime(chainTime),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capture := logger.NewLogCapture()
+			_, err := prometheus.New(context.Background(), test.params...)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+				if test.logEntry != "" {
+					capture.AssertHasEntry(t, test.logEntry)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/services/metrics/prometheus/synccommitteeaggregation.go
+++ b/services/metrics/prometheus/synccommitteeaggregation.go
@@ -35,6 +35,31 @@ func (s *Service) setupSyncCommitteeAggregationMetrics() error {
 		return err
 	}
 
+	s.syncCommitteeAggregationMarkTimer =
+		prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "vouch",
+			Subsystem: "sync_committee_aggregation",
+			Name:      "mark_seconds",
+			Help:      "The time in to the slot at which the sync committee aggregates were broadcast.",
+			Buckets: []float64{
+				0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+				1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
+				2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0,
+				3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0,
+				4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0,
+				5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0,
+				6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0,
+				7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0,
+				8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0,
+				9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0,
+				10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0,
+				11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0,
+			},
+		})
+	if err := prometheus.Register(s.syncCommitteeAggregationMarkTimer); err != nil {
+		return err
+	}
+
 	s.syncCommitteeAggregationProcessRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "vouch",
 		Subsystem: "sync_committee_aggregation_process",
@@ -64,6 +89,8 @@ func (s *Service) SyncCommitteeAggregationsCompleted(started time.Time, count in
 		for i := 0; i < count; i++ {
 			s.syncCommitteeAggregationProcessTimer.Observe(duration)
 		}
+		secsSinceStartOfSlot := time.Since(s.chainTime.StartOfSlot(s.chainTime.CurrentSlot())).Seconds()
+		s.syncCommitteeAggregationMarkTimer.Observe(secsSinceStartOfSlot)
 	}
 	s.syncCommitteeAggregationProcessRequests.WithLabelValues(result).Add(float64(count))
 }

--- a/services/metrics/prometheus/synccommitteemessenger.go
+++ b/services/metrics/prometheus/synccommitteemessenger.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -35,6 +35,31 @@ func (s *Service) setupSyncCommitteeMessageMetrics() error {
 		return err
 	}
 
+	s.syncCommitteeMessageMarkTimer =
+		prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "vouch",
+			Subsystem: "sync_committee_message",
+			Name:      "mark_seconds",
+			Help:      "The time in to the slot at which the sync committee messages were broadcast.",
+			Buckets: []float64{
+				0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+				1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
+				2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0,
+				3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0,
+				4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0,
+				5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0,
+				6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0,
+				7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0,
+				8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0,
+				9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0,
+				10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0,
+				11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0,
+			},
+		})
+	if err := prometheus.Register(s.syncCommitteeMessageMarkTimer); err != nil {
+		return err
+	}
+
 	s.syncCommitteeMessageProcessRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "vouch",
 		Subsystem: "sync_committee_message_process",
@@ -46,9 +71,14 @@ func (s *Service) setupSyncCommitteeMessageMetrics() error {
 
 // SyncCommitteeMessagesCompleted is called when a sync committee message process has completed.
 func (s *Service) SyncCommitteeMessagesCompleted(started time.Time, count int, result string) {
-	duration := time.Since(started).Seconds()
-	for i := 0; i < count; i++ {
-		s.syncCommitteeMessageProcessTimer.Observe(duration)
+	// Only log times for successful completions.
+	if result == "succeeded" {
+		duration := time.Since(started).Seconds()
+		for i := 0; i < count; i++ {
+			s.syncCommitteeMessageProcessTimer.Observe(duration)
+		}
+		secsSinceStartOfSlot := time.Since(s.chainTime.StartOfSlot(s.chainTime.CurrentSlot())).Seconds()
+		s.syncCommitteeMessageMarkTimer.Observe(secsSinceStartOfSlot)
 	}
 	s.syncCommitteeMessageProcessRequests.WithLabelValues(result).Add(float64(count))
 }

--- a/services/metrics/prometheus/synccommitteesubscriber.go
+++ b/services/metrics/prometheus/synccommitteesubscriber.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -56,7 +56,10 @@ func (s *Service) setupSyncCommitteeSubscriptionMetrics() error {
 
 // SyncCommitteeSubscriptionCompleted is called when an sync committee subscription process has completed.
 func (s *Service) SyncCommitteeSubscriptionCompleted(started time.Time, result string) {
-	s.syncCommitteeSubscriptionProcessTimer.Observe(time.Since(started).Seconds())
+	// Only log times for successful completions.
+	if result == "succeeded" {
+		s.syncCommitteeSubscriptionProcessTimer.Observe(time.Since(started).Seconds())
+	}
 	s.syncCommitteeSubscriptionProcessRequests.WithLabelValues(result).Inc()
 }
 

--- a/services/synccommitteemessenger/standard/service.go
+++ b/services/synccommitteemessenger/standard/service.go
@@ -209,6 +209,7 @@ func (s *Service) Message(ctx context.Context, data interface{}) ([]*altair.Sync
 		return nil, errors.Wrap(err, "failed to submit sync committee messages")
 	}
 	log.Trace().Dur("elapsed", time.Since(started)).Msg("Submitted sync committee messages")
+	s.monitor.SyncCommitteeMessagesCompleted(started, len(msgs), "succeeded")
 
 	return msgs, nil
 }


### PR DESCRIPTION
Mark metrics state how far through a slot a particular operation takes place.  They are used to ensure that Vouch is performing in a timely fashion for all time-critical components of the validator client operation.