### PR TITLE
Tidy metrics.

### DIFF
--- a/docs/metrics/prometheus.md
+++ b/docs/metrics/prometheus.md
@@ -1,19 +1,38 @@
 # Prometheus metrics
-vouch provides a number of metrics to check the health and performance of its activities.  vouch's default implementation uses Prometheus to provide these metrics.  The metrics server listens on the address provided by the `metrics.address` configuration value.
+Vouch provides comprehensive metrics to check the health and performance of its activities.  This document describes the metrics available for Prometheus and similar monitoring systems.
 
-## Version
-The version of Vouch can be found in the `vouch_release` metric, in the `version` label.
+The metrics server listens on the address provided by the `metrics.address` configuration value, and makes metrics available at the `/metrics` endpoint.
 
-## Health
-Health metrics provide a mechanism to confirm if vouch is active.  Due to vouch's nature there are multiple metrics that can be used to provide health and activity information that can be monitored.
+## General information
 
-`vouch_start_time_secs` is the Unix timestamp at which vouch was started.  This value will remain the same throughout a run of vouch; if it increments it implies that vouch has restarted.
+There are a number of metrics that provide general information about Vouch.  Specifically:
 
-`vouch_ready` is `1` if Vouch's services are all on-line and it is able to operate.  If not, this will be `0`.
+  - `vouch_release` contains the version of Vouch, in the `version` label
+  - `vouch_ready` is set to `1` when Vouch is ready to start attesting, and `0` otherwise.  If this number stays at 0 it implies a configuration or connection issue that should be addressed
+  - `vouch_epochs_processed_total` is set to the number of epochs for which Vouch has been attesting.  This number resets to 0 when Vouch restarts, and increments every time Vouch starts to process an epoch; if it fails to increment it implies that Vouch has stopped processing
+  - `vouch_start_time_secs` is the unix timestamp of the time that Vouch started.  This value will remain the same throughout a run of Vouch; if it increments it implies that Vouch has restarted.
 
-`vouch_epochs_processed_total` the number of epochs vouch has processed.  This number resets to 0 when vouch restarts, and increments every time vouch starts to process an epoch; if it fails to increment it implies that vouch has stopped processing.
+In addition, high level metrics track the latest slot for which Vouch carried out a successful operation:
 
-`vouch_accountmanager_accounts_total` is the number of accounts for which vouch is validating.  This metric has one label, `state`, which can take one of the following values:
+  - `vouch_attestation_process_latest_slot` the latest slot for which Vouch carried out an attestation.  As long as Vouch has validators, this is expected to increment approximately every 6.5 minutes, although it is possible to have to wait up to 13 minutes due to the random assignment of slots to validators
+  - `vouch_attestationaggregation_process_latest_slot` the latest slot for which Vouch carried out an attestation aggregation.  This is a relatively infrequent occurrence
+  - `vouch_beaconblockproposal_process_latest_slot` the latest slot for which Vouch carried out a proposal.  This is a relatively infrequent occurrence
+  - `vouch_synccommitteeaggregation_process_latest_slot` the latest slot for which Vouch carried out a sync committee aggregation.  This is a very infrequent occurrence
+  - `vouch_synccommitteemessage_process_latest_slot` the latest slot for which Vouch generated a sync committee message.  This is a very infrequent occurrence
+
+There are also counts for each process.  The specific metrics are:
+
+  - `vouch_beaconblockproposal_process_requests_total` number of beacon block proposal processes;
+  - `vouch_attestation_process_requests_total` number of attestation processes;
+  - `vouch_beaconcommitteesubscription_process_requests_total` number of beacon committee subscription processes; and
+  - `vouch_attestationaggregation_process_requests_total` number of attestation aggregation processes.
+
+All of the metrics have the label "result" with the value either "succeeded" or "failed".  Any increase in the latter values implies the validator is not completing all of its activities, and should be investigated.
+
+## Accounts
+
+Vouch keeps track of the number of accounts for which it is validating in the `vouch_accountmanager_accounts_total` metric.  This metric has one label, `state`, which can take one of the following values:
+
   - `unknown` the validator is not known to the Ethereum 2 network
   - `pending_initialized` the validator is known to the Ethereum 2 network but not yet in the queue to be activated
   - `pending_queued` the validator is in the queue to be activated
@@ -25,35 +44,54 @@ Health metrics provide a mechanism to confirm if vouch is active.  Due to vouch'
 
 Vouch will attest for accounts that are either `active_ongoing` or `active_exiting`.  Any increase in `active_exiting` should be matched with valid exit requests.  Any increase in `active_slashed` suggests a problem with the validator setup that should be investigated as a matter of urgency.
 
-There are also counts for each process.  The specific metrics are:
+## Marks
 
-  - `vouch_beaconblockproposal_process_requests_total` number of beacon block proposal processes;
-  - `vouch_attestation_process_requests_total` number of attestation processes;
-  - `vouch_beaconcommitteesubscription_process_requests_total` number of beacon committee subscription processes; and
-  - `vouch_attestationaggregation_process_failure_total` number of attestation aggregation processes.
+Vouch uses marks to show the point in time within a slot at which it completes its various operations.  The mark is made after the operation has submitted any results of its work to its beacon nodes, and so can be used to confirm that Vouch is acting in a timely fashion.  Each mark is a histogram from 0 to 12 seconds, in 0.1 second increments.  The marks are as follows:
 
-All of the metrics have the label "result" with the value either "succeeded" or "failed2.  Any increase in the latter values implies the validator is not completing all of its activities, and should be investigated.
+  - `vouch_attestation_mark_seconds` is the time in the slot at which the attestation(s) for the slot have been submitted to the beacon nodes.  In a healthy network it would be expected that the majority of these would be before the 2 second mark.  Any significant number of these after the 3 second mark suggests that part of the validating infrastructure may be slow, and should be investigated
+  - `vouch_beaconblockproposal_mark_seconds` is the time in the slot at which the block for the slot has been submitted to the beacon nodes.  In a healthy network it would be expected that the majority of these would be before the 1 second mark.  Any significant number of these after the 2 second mark suggests that part of the validating infrastructure may be slow, and should be investigated
+  - `vouch_synccommitteemessage_mark_seconds` is the time in the slot at which the sync committee message(s) for the slot has been submitted to the beacon nodes.  In a healthy network it would be expected that the majority of these would be before the 2 second mark.  Any significant number of these after the 2 second mark suggests that part of the validating infrastructure may be slow, and should be investigated
+  - `vouch_attestationaggregation_mark_seconds` is the time in the slot at which attestation aggregation message(s) for the slot has been submitted to the beacon nodes.  In a healthy network it would be expected that the majority of these would be before the 9 second mark.  Any significant number of these after the 10 second mark suggests that part of the validating infrastructure may be slow, and should be investigated.  It would also be expected that all of these message would be after the 8 second mark.  Any number of these before the 8 second mark suggests a problem with system time, and should be investigated
+  - `vouch_synccommitteeaggregation_mark_seconds` is the time in the slot at which sync committee aggregation message(s) for the slot has been submitted to the beacon nodes.  In a healthy network it would be expected that the majority of these would be before the 9 second mark.  Any significant number of these after the 10 second mark suggests that part of the validating infrastructure may be slow, and should be investigated.  It would also be expected that all of these message would be after the 8 second mark.  Any number of these before the 8 second mark suggests a problem with system time, and should be investigated
 
 ## Performance
-Performance metrics provide a mechanism to understand how quickly vouch is carrying out its activities.  The following information is provided:
+Performance metrics provide a mechanism to understand how quickly Vouch is carrying out its activities.  The following information is provided:
 
-  - `vouch_beaconblockproposal_process_duration_seconds` time taken to carry out the beacon block proposal process;
-  - `vouch_attestation_process_duration_seconds` time taken to carry out the attestation process;
-  - `vouch_beaconcommitteesubscription_process_duration_seconds` time taken to carry out the beacon committee subscription process; and
-  - `vouch_attestationaggregation_process_duration_seconds` time taken to carry out the attestation aggregation process.
+  - `vouch_attestation_process_duration_seconds` time taken to carry out the attestation process
+  - `vouch_attestationaggregation_process_duration_seconds` time taken to carry out the attestation aggregation process
+  - `vouch_beaconblockproposal_process_duration_seconds` time taken to carry out the beacon block proposal process
+  - `vouch_beaconcommitteesubscription_process_duration_seconds` time taken to carry out the beacon committee subscription process
+  - `vouch_synccommitteeaggregation_process_duration_seconds` time taken to carry out the sync committee aggregation process
+  - `vouch_synccommitteemessage_process_duration_seconds` time taken to carry out the sync committee message process
+  - `vouch_synccommitteesubscription_process_duration_seconds` time taken to carry out the sync committee subscription process
 
-These metrics are provided as histograms, with buckets in increments of 0.1 seconds up to 1 second.
+These metrics are provided as histograms, with buckets in increments of 0.1 seconds up to 2 seconds.
+
+A major part of Vouch's work is in the strategy section, where it selects the appropriate data to sign.  Data that combines the provider of the data along with the time taken to obtain and evaluate it contained in the `vouch_strategy_operation_duration_seconds` metric.  This is a histogram with buckets in increments of 0.1 seconds up to 4 seconds.  It has three labels:
+
+  - `strategy` is the strategy for the operation
+  - `provider` is the provider for the operation
+  - `operation` is the operation that took place (_e.g._ "beacon block proposal")
 
 ## Operations
-Operations metrics provide information about numbers of operations performed.  These are generally lower-level information that can be useful to monitor activities for fine-tuning of server parameters, comparing one instance to another, _etc._
+Operations metrics provide information about Vouch's internal operations.  These are generally lower-level information that can be useful to monitor activities for fine-tuning of server parameters, comparing one instance to another, _etc._
 
 Vouch's job scheduler provides a number of metrics.  The specific metrics are:
 
-  - `vouch_scheduler_jobs_scheduled_total` number of jobs scheduled;
-  - `vouch_scheduler_jobs_cancelled_total` number of jobs cancelled; and
-  - `vouch_scheduler_jobs_started_total` number of jobs started.  This has a label `trigger` which can be "timer" if the job ran due to reaching its designated start time or "signal" if the job ran due to being triggered before its designated start time.
+  - `vouch_scheduler_jobs_scheduled_total` number of jobs scheduled.  This is expected to increment periodically throughout Vouch's runtime
+  - `vouch_scheduler_jobs_cancelled_total` number of jobs cancelled.  This increments when chain reorganizations occur, and pre-scheduled jobs are no longer valid
+  - `vouch_scheduler_jobs_started_total` number of jobs started.  This has a label `trigger` which can be "timer" if the job ran due to reaching its designated start time or "signal" if the job ran due to being triggered before its designated start time
 
-## Client operations
+Each of the above metrics also has a `class` label which defines the general class of the job running.  Possible values include:
+  - `Aggregate attestations` jobs relating to aggregating attestations
+  - `Aggregate sync committee messages` jobs relating to aggregating sync committee messages
+  - `Attest` jobs relating to attesting
+  - `Epoch` jobs relating to operations run in preparation for or at the start of epochs
+  - `Generate sync committee messages` jobs relating to generating sync committee messages
+  - `Prepare for sync committee messages` jobs relating to preparation of sync committee message generation
+  - `Propose` jobs relating to proposing blocks
+  - `Refresh accounts` jobs relating to updating internal account information
+
 Client operations metrics provide information about the response time of beacon nodes, as well as if the request to them succeeded or failed.  This can be used to understand how quickly and how well beacon nodes are responding to requests, for example if Vouch using multiple beacon nodes in different data centres this can be used to obtain data about their response times due to network latency.
 
 `vouch_client_operation_duration_seconds` is provided as a histogram, with buckets in increments of 0.1 seconds up to 4 seconds.  It has two labels:
@@ -67,23 +105,14 @@ There is also a companion metric `vouch_client_operation_requests_total`, which 
   - `operation` is the operation that took place (_e.g._ "beacon block proposal")
   - `result` is the result of the operation, either "succeeded" or "failed"
 
-## Strategy operations
-Strategy operations metrics provide information the results and calculation times of strategies.  This can be used to understand which beacon nodes are providing the most useful information to Vouch, and how quickly Vouch is deciding on which data to use in its attestations and proposals.
+`vouch_strategy_operation_used` provides details of the outcome of strategies, where one piece of data is obtained from a number of providers.  It has three labels:
 
-`vouch_strategy_operation_duration_seconds` is provided as a histogram, with buckets in increments of 0.1 seconds up to 4 seconds.  It has three labels:
-
-  - `strategy` is the strategy for the operation
-  - `provider` is the provider for the operation
   - `operation` is the operation that took place (_e.g._ "beacon block proposal")
+  - `provider` is the provider of the information selected by the strategy
+  - `strategy` is the strategy used to select the outcome
 
-There is also a companion metric `vouch_strategy_operation_requests_total`, which is a simple count of the number of operations that have taken place.  It has three labels:
+Network metrics provide information about the network from Vouch's point of view.  Although these are not under Vouch's control, they have an impact on the performance of the validator.  The specific metrics are:
 
-  - `strategy` is the strategy for the operation
-  - `provider` is the provider for the operation
-  - `operation` is the operation that took place (_e.g._ "beacon block proposal")
-
-## Network
-Network metrics provide information about the network from vouch's point of view.  Although these are not under vouch's control, they have an impact on the performance of the validator.  The specific metrics are:
-
-  - `vouch_block_receipt_delay_seconds` the delay between the start of a slot and the arrival of the block for that slot.  This metric is provided as a histogram, with buckets in increments of 0.1 seconds up to 12 seconds.  This has a label `epoch_slot` which is the position of the slot in the epoch (0 through 31, inclusive).
+  - `vouch_block_receipt_delay_seconds` the delay between the start of a slot and the arrival of the block for that slot.  This metric is provided as a histogram, with buckets in increments of 0.1 seconds up to 12 seconds.  This has a label `epoch_slot` which is the position of the slot in the epoch (0 through 31, inclusive)
   - `vouch_attestationaggregation_coverage_ratio` the ratio of the number of attestations included in the aggregate to the total number of attestations for the aggregate.  This metric is provided as a histogram, with buckets in increments of 0.1 up to 1.
+  - `vouch_synccommitteeaggregation_coverage_ratio` the ratio of the number of sync committee messages included in the aggregate to the total number of members of the sync committee for the aggregate.  This metric is provided as a histogram, with buckets in increments of 0.1 up to 1.

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -278,7 +278,7 @@ func (s *Service) startEpochTicker(ctx context.Context, waitedForGenesis bool) e
 		atGenesis:      waitedForGenesis,
 	}
 	if err := s.scheduler.SchedulePeriodicJob(ctx,
-		"Handle new epoch",
+		"Epoch",
 		"Epoch ticker",
 		runtimeFunc,
 		data,
@@ -346,7 +346,7 @@ func (s *Service) epochTicker(ctx context.Context, data interface{}) {
 	// half-way through the epoch to set them up (and half-way through that slot).
 	// This allows us to set them up at a time when the beacon node should be less busy.
 	if err := s.scheduler.ScheduleJob(ctx,
-		"Prepare for epoch",
+		"Epoch",
 		fmt.Sprintf("Prepare for epoch %d", currentEpoch+1),
 		s.chainTimeService.StartOfSlot(s.chainTimeService.FirstSlotOfEpoch(currentEpoch)+phase0.Slot(s.slotsPerEpoch/2)).Add(s.slotDuration/2),
 		s.prepareForEpoch,

--- a/services/metrics/prometheus/synccommitteeaggregation.go
+++ b/services/metrics/prometheus/synccommitteeaggregation.go
@@ -24,7 +24,7 @@ func (s *Service) setupSyncCommitteeAggregationMetrics() error {
 	s.syncCommitteeAggregationProcessTimer =
 		prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vouch",
-			Subsystem: "sync_committee_aggregation_process",
+			Subsystem: "synccommitteeaggregation_process",
 			Name:      "duration_seconds",
 			Help:      "The time vouch spends from starting the sync committee aggregation process to submitting the sync committee aggregations.",
 			Buckets: []float64{
@@ -39,7 +39,7 @@ func (s *Service) setupSyncCommitteeAggregationMetrics() error {
 	s.syncCommitteeAggregationMarkTimer =
 		prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vouch",
-			Subsystem: "sync_committee_aggregation",
+			Subsystem: "synccommitteeaggregation",
 			Name:      "mark_seconds",
 			Help:      "The time in to the slot at which the sync committee aggregates were broadcast.",
 			Buckets: []float64{
@@ -63,7 +63,7 @@ func (s *Service) setupSyncCommitteeAggregationMetrics() error {
 
 	s.syncCommitteeAggregationProcessLatestSlot = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "vouch",
-		Subsystem: "sync_committee_aggregation_process",
+		Subsystem: "synccommitteeaggregation_process",
 		Name:      "latest_slot",
 		Help:      "The latest slot for which Vouch created a sync committee aggregate.",
 	})
@@ -73,7 +73,7 @@ func (s *Service) setupSyncCommitteeAggregationMetrics() error {
 
 	s.syncCommitteeAggregationProcessRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "vouch",
-		Subsystem: "sync_committee_aggregation_process",
+		Subsystem: "synccommitteeaggregation_process",
 		Name:      "requests_total",
 		Help:      "The number of sync committee aggregation processes.",
 	}, []string{"result"})
@@ -84,7 +84,7 @@ func (s *Service) setupSyncCommitteeAggregationMetrics() error {
 	s.syncCommitteeAggregationCoverageRatio =
 		prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vouch",
-			Subsystem: "sync_committee_aggregation",
+			Subsystem: "synccommitteeaggregation",
 			Name:      "coverage_ratio",
 			Help:      "The ratio of included to possible messages in the aggregate.",
 			Buckets:   []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},

--- a/services/metrics/prometheus/synccommitteemessenger.go
+++ b/services/metrics/prometheus/synccommitteemessenger.go
@@ -24,7 +24,7 @@ func (s *Service) setupSyncCommitteeMessageMetrics() error {
 	s.syncCommitteeMessageProcessTimer =
 		prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vouch",
-			Subsystem: "sync_committee_message_process",
+			Subsystem: "synccommitteemessage_process",
 			Name:      "duration_seconds",
 			Help:      "The time vouch spends from starting the sync committee message process to submitting the sync committee messages.",
 			Buckets: []float64{
@@ -39,7 +39,7 @@ func (s *Service) setupSyncCommitteeMessageMetrics() error {
 	s.syncCommitteeMessageMarkTimer =
 		prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vouch",
-			Subsystem: "sync_committee_message",
+			Subsystem: "synccommitteemessage",
 			Name:      "mark_seconds",
 			Help:      "The time in to the slot at which the sync committee messages were broadcast.",
 			Buckets: []float64{
@@ -63,7 +63,7 @@ func (s *Service) setupSyncCommitteeMessageMetrics() error {
 
 	s.syncCommitteeMessageProcessLatestSlot = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "vouch",
-		Subsystem: "sync_committee_message_process",
+		Subsystem: "synccommitteemessage_process",
 		Name:      "latest_slot",
 		Help:      "The latest slot for which Vouch created a sync committee message.",
 	})
@@ -73,7 +73,7 @@ func (s *Service) setupSyncCommitteeMessageMetrics() error {
 
 	s.syncCommitteeMessageProcessRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "vouch",
-		Subsystem: "sync_committee_message_process",
+		Subsystem: "synccommitteemessage_process",
 		Name:      "requests_total",
 		Help:      "The number of sync committee message processes.",
 	}, []string{"result"})


### PR DESCRIPTION
Ensure that all metrics follow the same naming convention, and update documentation explaining the metrics' names and purposes.