### PR TITLE
Tidy-up scatter testing.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/attestantio/vouch
 go 1.16
 
 require (
-	github.com/attestantio/dirk v1.1.0
 	github.com/attestantio/go-eth2-client v0.8.1
 	github.com/aws/aws-sdk-go v1.41.19
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -322,7 +322,6 @@ github.com/klauspost/cpuid/v2 v2.0.6/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -441,7 +440,6 @@ github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0 h1:Xuk8ma/ibJ1
 github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0/go.mod h1:7AwjWCpdPhkSmNAgUv5C7EJ4AbmjEB3r047r3DXWu3Y=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/util/scatter_benchmark_test.go
+++ b/util/scatter_benchmark_test.go
@@ -16,10 +16,11 @@ package util_test
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"runtime"
 	"sync"
 	"testing"
 
-	"github.com/attestantio/dirk/util"
+	"github.com/attestantio/vouch/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,7 +65,7 @@ func BenchmarkHash(b *testing.B) {
 func BenchmarkHashMP(b *testing.B) {
 	output := make([][]byte, len(input))
 	for i := 0; i < b.N; i++ {
-		workerResults, err := util.Scatter(len(input), func(offset int, entries int, _ *sync.RWMutex) (interface{}, error) {
+		workerResults, err := util.Scatter(len(input), runtime.GOMAXPROCS(0), func(offset int, entries int, _ *sync.RWMutex) (interface{}, error) {
 			return hash(input[offset : offset+entries]), nil
 		})
 		require.NoError(b, err)

--- a/util/scatter_test.go
+++ b/util/scatter_test.go
@@ -15,10 +15,11 @@ package util_test
 
 import (
 	"errors"
+	"runtime"
 	"sync"
 	"testing"
 
-	"github.com/attestantio/dirk/util"
+	"github.com/attestantio/vouch/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +60,7 @@ func TestDouble(t *testing.T) {
 				inValues[i] = i
 			}
 			outValues := make([]int, test.inValues)
-			workerResults, err := util.Scatter(len(inValues), func(offset int, entries int, _ *sync.RWMutex) (interface{}, error) {
+			workerResults, err := util.Scatter(len(inValues), runtime.GOMAXPROCS(0), func(offset int, entries int, _ *sync.RWMutex) (interface{}, error) {
 				extent := make([]int, entries)
 				for i := 0; i < entries; i++ {
 					extent[i] = inValues[offset+i] * 2
@@ -85,7 +86,7 @@ func TestDouble(t *testing.T) {
 func TestMutex(t *testing.T) {
 	totalRuns := 1048576
 	val := 0
-	_, err := util.Scatter(totalRuns, func(offset int, entries int, mu *sync.RWMutex) (interface{}, error) {
+	_, err := util.Scatter(totalRuns, runtime.GOMAXPROCS(0), func(offset int, entries int, mu *sync.RWMutex) (interface{}, error) {
 		for i := 0; i < entries; i++ {
 			mu.Lock()
 			val++
@@ -100,7 +101,7 @@ func TestMutex(t *testing.T) {
 func TestError(t *testing.T) {
 	totalRuns := 1024
 	val := 0
-	_, err := util.Scatter(totalRuns, func(offset int, entries int, mu *sync.RWMutex) (interface{}, error) {
+	_, err := util.Scatter(totalRuns, runtime.GOMAXPROCS(0), func(offset int, entries int, mu *sync.RWMutex) (interface{}, error) {
 		for i := 0; i < entries; i++ {
 			mu.Lock()
 			val++


### PR DESCRIPTION
Scatter testing relied on Dirk.  It doesn't need to, so this removes the dependency.