### PR TITLE
Prepare sync committee jobs near change of period.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+dev:
+  - prepare sync committee duties a few epochs before change of period
+
 1.3.0:
   - make scheduler channels asynchronous, to avoid potential deadlock
   - add metrics for sync committee operations


### PR DESCRIPTION
Sync committee jobs were being created for period x at the beginning of period x-1.  Some beacon nodes were failing to update their internal information regarding the current sync committee period in time, resulting in them rejecting a request for sync committee duties.

This addresses the issue by only requesting data a few epochs before the new sync committee period comes in to effect.  This ensures that the node will be able to serve the requested data.