### PR TITLE
Separate multiclient definitions from individual.

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -72,7 +73,8 @@ func fetchMultiClient(ctx context.Context, addresses []string) (eth2client.Servi
 
 	var client eth2client.Service
 	var exists bool
-	if client, exists = clients[strings.Join(addresses, ",")]; !exists {
+	multiID := fmt.Sprintf("multi:%s", strings.Join(addresses, ","))
+	if client, exists = clients[multiID]; !exists {
 		var err error
 		client, err = multiclient.New(ctx,
 			multiclient.WithMonitor(monitor),
@@ -82,7 +84,7 @@ func fetchMultiClient(ctx context.Context, addresses []string) (eth2client.Servi
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to initiate client")
 		}
-		clients[strings.Join(addresses, ",")] = client
+		clients[multiID] = client
 	}
 	return client, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/attestantio/vouch
 go 1.17
 
 require (
-	github.com/attestantio/go-eth2-client v0.9.1
+	github.com/attestantio/go-eth2-client v0.9.2
 	github.com/aws/aws-sdk-go v1.42.25
 	github.com/cncf/xds/go v0.0.0-20211216145620-d92e9ce0af51 // indirect
 	github.com/herumi/bls-eth-go-binary v0.0.0-20211122012301-02ac68186ac0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,10 +83,8 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/attestantio/dirk v1.1.0 h1:hwMTYZkwj/Y0um3OD0LQxg2xSl4/5xqVWV2MRePE4ec=
 github.com/attestantio/dirk v1.1.0/go.mod h1:2jkOw/XHjvIDdhDcmj+Z3kuVPpxMcQ6zxzzjSSv71PY=
 github.com/attestantio/go-eth2-client v0.8.1/go.mod h1:kEK9iAAOBoADO5wEkd84FEOzjT1zXgVWveQsqn+uBGg=
-github.com/attestantio/go-eth2-client v0.9.0 h1:fGakJrYpCTLNvIA0DfJlM1ebTgXtJ7NtJr1A0KgNeFo=
-github.com/attestantio/go-eth2-client v0.9.0/go.mod h1:Qf+B4ZFb8gSwpmH8mndllZP+YIfdBnPwFqoZZ/lqmB0=
-github.com/attestantio/go-eth2-client v0.9.1 h1:iLUvRP8syOLhNbYN0HGvnFHtlZ8f35gm2UCGm6PA5Co=
-github.com/attestantio/go-eth2-client v0.9.1/go.mod h1:Qf+B4ZFb8gSwpmH8mndllZP+YIfdBnPwFqoZZ/lqmB0=
+github.com/attestantio/go-eth2-client v0.9.2 h1:ghz2OxpjvDyqzfAy9Fp36mpr1vNLZOtS5jvPUppXDxA=
+github.com/attestantio/go-eth2-client v0.9.2/go.mod h1:Qf+B4ZFb8gSwpmH8mndllZP+YIfdBnPwFqoZZ/lqmB0=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.33.17/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=


### PR DESCRIPTION
Vouch caches client definitions.  A multiclient definition with a single entry was indistinguishable from a standalone client, causing Vouch to confuse them.  This adds a 'multi:' namespace for the multiclient definition, ensuring that these remain separate.