### PR TITLE
Avoid crash if beacon block root returns nil.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.3.2:
+  - fix crash if beacon block root is returned as nil
+  - separate multiclient cache from individual client cache
+
 1.3.1:
   - prepare sync committee duties a few epochs before change of period
   - add `controller.max-proposal-delay` option

--- a/services/synccommitteemessenger/standard/service.go
+++ b/services/synccommitteemessenger/standard/service.go
@@ -163,6 +163,10 @@ func (s *Service) Message(ctx context.Context, data interface{}) ([]*altair.Sync
 		s.monitor.SyncCommitteeMessagesCompleted(started, duty.Slot(), len(duty.ValidatorIndices()), "failed")
 		return nil, errors.Wrap(err, "failed to obtain beacon block root")
 	}
+	if beaconBlockRoot == nil {
+		s.monitor.SyncCommitteeMessagesCompleted(started, duty.Slot(), len(duty.ValidatorIndices()), "failed")
+		return nil, errors.Wrap(err, "empty beacon block root obtained")
+	}
 	log.Trace().Dur("elapsed", time.Since(started)).Msg("Obtained beacon block root")
 	s.syncCommitteeAggregator.SetBeaconBlockRoot(duty.Slot(), *beaconBlockRoot)
 


### PR DESCRIPTION
It is possible for a syncing beacon node to return nil for the beacon block root.  If this happens, log and return to avoid a crash.