### PR TITLE
Improved block proposal scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+development:
+  - increase accuracy of beacon block proposal scorer by incorporating attestation history
+
 1.3.2:
   - fix crash if beacon block root is returned as nil
   - separate multiclient cache from individual client cache

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/attestantio/vouch
 go 1.17
 
 require (
-	github.com/attestantio/go-eth2-client v0.9.4
+	github.com/attestantio/go-eth2-client v0.9.6
 	github.com/aws/aws-sdk-go v1.42.25
 	github.com/cncf/xds/go v0.0.0-20211216145620-d92e9ce0af51 // indirect
 	github.com/herumi/bls-eth-go-binary v0.0.0-20211122012301-02ac68186ac0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/attestantio/dirk v1.1.0 h1:hwMTYZkwj/Y0um3OD0LQxg2xSl4/5xqVWV2MRePE4ec=
 github.com/attestantio/dirk v1.1.0/go.mod h1:2jkOw/XHjvIDdhDcmj+Z3kuVPpxMcQ6zxzzjSSv71PY=
 github.com/attestantio/go-eth2-client v0.8.1/go.mod h1:kEK9iAAOBoADO5wEkd84FEOzjT1zXgVWveQsqn+uBGg=
-github.com/attestantio/go-eth2-client v0.9.4 h1:tELTJEd0Nq7tr5dw38mRbuWJWAOcz6b8FhULAqIv594=
-github.com/attestantio/go-eth2-client v0.9.4/go.mod h1:Qf+B4ZFb8gSwpmH8mndllZP+YIfdBnPwFqoZZ/lqmB0=
+github.com/attestantio/go-eth2-client v0.9.6 h1:T8kkoUP8NY2bthGbWKp2QUpEmhBBQ0a3RI5L64CEQng=
+github.com/attestantio/go-eth2-client v0.9.6/go.mod h1:Qf+B4ZFb8gSwpmH8mndllZP+YIfdBnPwFqoZZ/lqmB0=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.33.17/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "1.3.2"
+var ReleaseVersion = "1.4.0-dev"
 
 func main() {
 	os.Exit(main2())
@@ -339,7 +339,7 @@ func startServices(ctx context.Context, majordomo majordomo.Service) error {
 	}
 
 	log.Trace().Msg("Selecting beacon block proposal provider")
-	beaconBlockProposalProvider, err := selectBeaconBlockProposalProvider(ctx, monitor, eth2Client)
+	beaconBlockProposalProvider, err := selectBeaconBlockProposalProvider(ctx, monitor, eth2Client, chainTime)
 	if err != nil {
 		return errors.Wrap(err, "failed to select beacon block proposal provider")
 	}
@@ -914,6 +914,7 @@ func selectAggregateAttestationProvider(ctx context.Context,
 func selectBeaconBlockProposalProvider(ctx context.Context,
 	monitor metrics.Service,
 	eth2Client eth2client.Service,
+	chainTime chaintime.Service,
 ) (eth2client.BeaconBlockProposalProvider, error) {
 	var beaconBlockProposalProvider eth2client.BeaconBlockProposalProvider
 	var err error
@@ -932,6 +933,9 @@ func selectBeaconBlockProposalProvider(ctx context.Context,
 			bestbeaconblockproposalstrategy.WithClientMonitor(monitor.(metrics.ClientMonitor)),
 			bestbeaconblockproposalstrategy.WithProcessConcurrency(util.ProcessConcurrency("strategies.beaconblockproposal.best")),
 			bestbeaconblockproposalstrategy.WithLogLevel(util.LogLevel("strategies.beaconblockproposal.best")),
+			bestbeaconblockproposalstrategy.WithEventsProvider(eth2Client.(eth2client.EventsProvider)),
+			bestbeaconblockproposalstrategy.WithChainTimeService(chainTime),
+			bestbeaconblockproposalstrategy.WithSpecProvider(eth2Client.(eth2client.SpecProvider)),
 			bestbeaconblockproposalstrategy.WithBeaconBlockProposalProviders(beaconBlockProposalProviders),
 			bestbeaconblockproposalstrategy.WithSignedBeaconBlockProvider(eth2Client.(eth2client.SignedBeaconBlockProvider)),
 			bestbeaconblockproposalstrategy.WithTimeout(util.Timeout("strategies.beaconblockproposal.best")),

--- a/mock/eth2client.go
+++ b/mock/eth2client.go
@@ -252,6 +252,19 @@ func (*EventsProvider) Events(_ context.Context, _ []string, _ eth2client.EventH
 	return nil
 }
 
+// ErroringEventsProvider is a mock for eth2client.EventsProvider.
+type ErroringEventsProvider struct{}
+
+// NewErroringEventsProvider returns a mock events provider.
+func NewErroringEventsProvider() eth2client.EventsProvider {
+	return &ErroringEventsProvider{}
+}
+
+// Events submits sync committee contributions.
+func (*ErroringEventsProvider) Events(_ context.Context, _ []string, _ eth2client.EventHandlerFunc) error {
+	return errors.New("error")
+}
+
 // AttestationsSubmitter is a mock for eth2client.AttestationsSubmitter.
 type AttestationsSubmitter struct{}
 

--- a/strategies/beaconblockproposal/best/beaconblockproposal.go
+++ b/strategies/beaconblockproposal/best/beaconblockproposal.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2022 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -93,11 +93,11 @@ func (s *Service) BeaconBlockProposal(ctx context.Context, slot phase0.Slot, ran
 				if err != nil {
 					log.Error().Str("version", proposal.Version.String()).Err(err).Msg("Failed to obtain proposal slot for parent block")
 				}
-				parentSlot = slot - 1
+				parentSlot = slot
 			}
 
 			mu.Lock()
-			score := scoreBeaconBlockProposal(ctx, name, parentSlot, proposal)
+			score := s.scoreBeaconBlockProposal(ctx, name, parentSlot, proposal)
 			if score > bestScore || bestProposal == nil {
 				bestScore = score
 				bestProposal = proposal

--- a/strategies/beaconblockproposal/best/events.go
+++ b/strategies/beaconblockproposal/best/events.go
@@ -1,0 +1,117 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package best
+
+import (
+	"context"
+	"fmt"
+
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/prysmaticlabs/go-bitfield"
+)
+
+// HandleHeadEvent handles the "head" events from the beacon node.
+func (s *Service) HandleHeadEvent(event *api.Event) {
+	if event.Data == nil {
+		return
+	}
+
+	ctx := context.Background()
+
+	data := event.Data.(*api.HeadEvent)
+	log := log.With().Uint64("slot", uint64(data.Slot)).Logger()
+	log.Trace().Msg("Received head event")
+
+	if data.Slot != s.chainTime.CurrentSlot() {
+		return
+	}
+
+	block, err := s.signedBeaconBlockProvider.SignedBeaconBlock(ctx, fmt.Sprintf("%#x", data.Block))
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to obtain head beacon block")
+		return
+	}
+
+	s.updateBlockVotes(ctx, block)
+}
+
+// updateBlockVotes updates the votes made in attestations for this block.
+func (s *Service) updateBlockVotes(ctx context.Context,
+	block *spec.VersionedSignedBeaconBlock,
+) {
+	if block == nil {
+		return
+	}
+
+	slot, err := block.Slot()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to obtain proposed block's slot")
+		return
+	}
+	attestations, err := block.Attestations()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to obtain proposed block's attestations")
+		return
+	}
+
+	votes := make(map[phase0.Slot]map[phase0.CommitteeIndex]bitfield.Bitlist)
+	for _, attestation := range attestations {
+		data := attestation.Data
+		_, exists := votes[data.Slot]
+		if !exists {
+			votes[data.Slot] = make(map[phase0.CommitteeIndex]bitfield.Bitlist)
+		}
+		_, exists = votes[data.Slot][data.Index]
+		if !exists {
+			votes[data.Slot][data.Index] = bitfield.NewBitlist(attestation.AggregationBits.Len())
+		}
+		for i := uint64(0); i < attestation.AggregationBits.Len(); i++ {
+			if attestation.AggregationBits.BitAt(i) {
+				votes[data.Slot][data.Index].SetBitAt(i, true)
+			}
+		}
+	}
+
+	parentRoot, err := block.ParentRoot()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to obtain proposed block's parent root")
+		return
+	}
+
+	root, err := block.Root()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to obtain proposed block's root")
+		return
+	}
+
+	priorBlockVotes := &priorBlockVotes{
+		root:   root,
+		parent: parentRoot,
+		slot:   slot,
+		votes:  votes,
+	}
+
+	s.priorBlocksMu.Lock()
+	s.priorBlocks[root] = priorBlockVotes
+	for k, v := range s.priorBlocks {
+		if v.slot < slot-phase0.Slot(s.slotsPerEpoch) {
+			delete(s.priorBlocks, k)
+		}
+	}
+	s.priorBlocksMu.Unlock()
+
+	log.Trace().Uint64("slot", uint64(slot)).Msg("Set votes for slot")
+}

--- a/strategies/beaconblockproposal/best/events.go
+++ b/strategies/beaconblockproposal/best/events.go
@@ -49,7 +49,7 @@ func (s *Service) HandleHeadEvent(event *api.Event) {
 }
 
 // updateBlockVotes updates the votes made in attestations for this block.
-func (s *Service) updateBlockVotes(ctx context.Context,
+func (s *Service) updateBlockVotes(_ context.Context,
 	block *spec.VersionedSignedBeaconBlock,
 ) {
 	if block == nil {

--- a/strategies/beaconblockproposal/best/events_internal_test.go
+++ b/strategies/beaconblockproposal/best/events_internal_test.go
@@ -1,0 +1,176 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package best
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/mock"
+	standardchaintime "github.com/attestantio/vouch/services/chaintime/standard"
+	"github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/attestantio/vouch/testutil"
+	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateBlockVotes tests the internal function updateBlockVotes.
+func TestUpdateBlockVotes(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		block      *spec.VersionedSignedBeaconBlock
+		logEntries []string
+	}{
+		{
+			name:  "Nil",
+			block: nil,
+		},
+		{
+			name:  "Empty",
+			block: &spec.VersionedSignedBeaconBlock{},
+			logEntries: []string{
+				"Failed to obtain proposed block's slot",
+			},
+		},
+		{
+			name: "MissingAttestations",
+			block: &spec.VersionedSignedBeaconBlock{
+				Version: spec.DataVersionAltair,
+				Altair: &altair.SignedBeaconBlock{
+					Message: &altair.BeaconBlock{
+						Slot: 12345,
+					},
+				},
+			},
+			logEntries: []string{
+				"Failed to obtain proposed block's attestations",
+			},
+		},
+		{
+			name: "EmptyAttestations",
+			block: &spec.VersionedSignedBeaconBlock{
+				Version: spec.DataVersionAltair,
+				Altair: &altair.SignedBeaconBlock{
+					Message: &altair.BeaconBlock{
+						Slot: 12345,
+						Body: &altair.BeaconBlockBody{
+							ETH1Data:     &phase0.ETH1Data{},
+							Attestations: []*phase0.Attestation{},
+						},
+					},
+				},
+			},
+			logEntries: []string{
+				"Failed to obtain proposed block's root",
+			},
+		},
+		{
+			name: "SingleAttestation",
+			block: &spec.VersionedSignedBeaconBlock{
+				Version: spec.DataVersionAltair,
+				Altair: &altair.SignedBeaconBlock{
+					Message: &altair.BeaconBlock{
+						Slot:       12345,
+						ParentRoot: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+						StateRoot:  testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+						Body: &altair.BeaconBlockBody{
+							RANDAOReveal: testutil.HexToSignature("0x030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303"),
+							ETH1Data: &phase0.ETH1Data{
+								DepositRoot: testutil.HexToRoot("0x1010101010101010101010101010101010101010101010101010101010101010"),
+								BlockHash:   testutil.HexToBytes("0x1111111111111111111111111111111111111111111111111111111111111111"),
+							},
+							Graffiti: testutil.HexToBytes("0x0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad0bad"),
+							Attestations: []*phase0.Attestation{
+								{
+									AggregationBits: bitList(10, 128),
+									Data: &phase0.AttestationData{
+										Slot:            12344,
+										Index:           0,
+										BeaconBlockRoot: testutil.HexToRoot("0x0404040404040404040404040404040404040404040404040404040404040404"),
+										Source: &phase0.Checkpoint{
+											Root:  testutil.HexToRoot("0x0505050505050505050505050505050505050505050505050505050505050505"),
+											Epoch: 384,
+										},
+										Target: &phase0.Checkpoint{
+											Root:  testutil.HexToRoot("0x0606060606060606060606060606060606060606060606060606060606060606"),
+											Epoch: 385,
+										},
+									},
+								},
+							},
+							SyncAggregate: &altair.SyncAggregate{
+								SyncCommitteeBits:      bitfield.NewBitvector512(),
+								SyncCommitteeSignature: testutil.HexToSignature("0x080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808"),
+							},
+						},
+					},
+					Signature: testutil.HexToSignature("0x070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707070707"),
+				},
+			},
+			logEntries: []string{
+				"Set votes for slot",
+			},
+		},
+	}
+
+	genesisTime := time.Now()
+	slotDuration := 12 * time.Second
+	slotsPerEpoch := uint64(32)
+	genesisTimeProvider := mock.NewGenesisTimeProvider(genesisTime)
+	slotDurationProvider := mock.NewSlotDurationProvider(slotDuration)
+	slotsPerEpochProvider := mock.NewSlotsPerEpochProvider(slotsPerEpoch)
+	specProvider := mock.NewSpecProvider()
+
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisTimeProvider(genesisTimeProvider),
+		standardchaintime.WithSlotDurationProvider(slotDurationProvider),
+		standardchaintime.WithSlotsPerEpochProvider(slotsPerEpochProvider),
+	)
+	require.NoError(t, err)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capture := logger.NewLogCapture()
+			s, err := New(ctx,
+				WithLogLevel(zerolog.TraceLevel),
+				WithTimeout(2*time.Second),
+				WithClientMonitor(null.New(context.Background())),
+				WithEventsProvider(mock.NewEventsProvider()),
+				WithChainTimeService(chainTime),
+				WithSpecProvider(specProvider),
+				WithProcessConcurrency(6),
+				WithBeaconBlockProposalProviders(map[string]eth2client.BeaconBlockProposalProvider{
+					"one": mock.NewBeaconBlockProposalProvider(),
+				}),
+				WithSignedBeaconBlockProvider(mock.NewSignedBeaconBlockProvider()),
+			)
+			require.NoError(t, err)
+
+			s.updateBlockVotes(ctx, test.block)
+			for _, entry := range test.logEntries {
+				capture.AssertHasEntry(t, entry)
+			}
+		})
+	}
+}

--- a/strategies/beaconblockproposal/best/score.go
+++ b/strategies/beaconblockproposal/best/score.go
@@ -1,4 +1,4 @@
-// Copyright © 2020, 2021 Attestant Limited.
+// Copyright © 2020 - 2022 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,16 +14,24 @@
 package best
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/prysmaticlabs/go-bitfield"
 )
 
 // scoreBeaconBlockPropsal generates a score for a beacon block.
 // The score is relative to the reward expected by proposing the block.
-func scoreBeaconBlockProposal(_ context.Context, name string, parentSlot phase0.Slot, blockProposal *spec.VersionedBeaconBlock) float64 {
+func (s *Service) scoreBeaconBlockProposal(ctx context.Context,
+	name string,
+	parentSlot phase0.Slot,
+	blockProposal *spec.VersionedBeaconBlock,
+) float64 {
 	if blockProposal == nil {
 		return 0
 	}
@@ -31,98 +39,155 @@ func scoreBeaconBlockProposal(_ context.Context, name string, parentSlot phase0.
 		return 0
 	}
 
+	switch blockProposal.Version {
+	case spec.DataVersionPhase0:
+		return s.scorePhase0BeaconBlockProposal(ctx, name, parentSlot, blockProposal.Phase0)
+	case spec.DataVersionAltair:
+		return s.scoreAltairBeaconBlockProposal(ctx, name, parentSlot, blockProposal.Altair)
+	default:
+		log.Error().Int("version", int(blockProposal.Version)).Msg("Unhandled block version")
+		return 0
+	}
+}
+
+// scorePhase0BeaconBlockPropsal generates a score for a phase 0 beacon block.
+func (*Service) scorePhase0BeaconBlockProposal(_ context.Context,
+	name string,
+	parentSlot phase0.Slot,
+	blockProposal *phase0.BeaconBlock,
+) float64 {
 	immediateAttestationScore := float64(0)
 	attestationScore := float64(0)
 
 	// We need to avoid duplicates in attestations.
-	// Map is slot -> committee index -> validator committee index -> attested.
-	attested := make(map[phase0.Slot]map[phase0.CommitteeIndex]map[uint64]bool)
-	attestations, err := blockProposal.Attestations()
-	if err != nil {
-		log.Warn().Err(err).Msg("Failed to obtain attestations")
-		return 0
-	}
-	for _, attestation := range attestations {
-		slotAttested, exists := attested[attestation.Data.Slot]
-		if !exists {
-			slotAttested = make(map[phase0.CommitteeIndex]map[uint64]bool)
-			attested[attestation.Data.Slot] = slotAttested
+	// Map is attestation slot -> committee index -> validator committee index -> aggregate.
+	attested := make(map[phase0.Slot]map[phase0.CommitteeIndex]bitfield.Bitlist)
+	for _, attestation := range blockProposal.Body.Attestations {
+		data := attestation.Data
+		if _, exists := attested[data.Slot]; !exists {
+			attested[data.Slot] = make(map[phase0.CommitteeIndex]bitfield.Bitlist)
 		}
-		committeeAttested, exists := slotAttested[attestation.Data.Index]
-		if !exists {
-			committeeAttested = make(map[uint64]bool)
-			slotAttested[attestation.Data.Index] = committeeAttested
+		if _, exists := attested[data.Slot][data.Index]; !exists {
+			if !exists {
+				attested[data.Slot][data.Index] = bitfield.NewBitlist(attestation.AggregationBits.Len())
+			}
 		}
+
+		// Calculate inclusion score.
+		inclusionDistance := float64(blockProposal.Slot - data.Slot)
 		for i := uint64(0); i < attestation.AggregationBits.Len(); i++ {
-			if attestation.AggregationBits.BitAt(i) {
-				committeeAttested[i] = true
+			if attestation.AggregationBits.BitAt(i) && !attested[attestation.Data.Slot][attestation.Data.Index].BitAt(i) {
+				attestationScore += float64(0.75) + float64(0.25)/inclusionDistance
+				if inclusionDistance == 1 {
+					immediateAttestationScore += 1.0
+				}
+				attested[attestation.Data.Slot][attestation.Data.Index].SetBitAt(i, true)
 			}
 		}
 	}
 
-	blockProposalSlot, err := blockProposal.Slot()
-	if err != nil {
-		log.Error().Str("version", blockProposal.Version.String()).Msg("Unknown proposal version")
-		return 0
-	}
-
-	// Calculate inclusion score.
-	for slot, slotAttested := range attested {
-		inclusionDistance := float64(blockProposalSlot - slot)
-		for _, committeeAttested := range slotAttested {
-			attestationScore += float64(len(committeeAttested)) * (float64(0.75) + float64(0.25)/inclusionDistance)
-			if inclusionDistance == 1 {
-				immediateAttestationScore += float64(len(committeeAttested)) * (float64(0.75) + float64(0.25)/inclusionDistance)
-			}
-		}
-	}
-
-	// Add slashing scores.
-	// Slashing reward will be at most MAX_EFFECTIVE_BALANCE/WHISTLEBLOWER_REWARD_QUOTIENT,
-	// which is 0.0625 Ether.
-	// Individual attestation reward at 16K validators will be around 90,000 GWei, or .00009 Ether.
-	// So we state that a single slashing event has the same weight as about 700 attestations.
-	slashingWeight := float64(700)
-
-	// Add proposer slashing scores.
-	proposerSlashings, err := blockProposal.ProposerSlashings()
-	if err != nil {
-		log.Warn().Err(err).Msg("Failed to obtain proposer slashings")
-		proposerSlashings = make([]*phase0.ProposerSlashing, 0)
-	}
-	proposerSlashingScore := float64(len(proposerSlashings)) * slashingWeight
-
-	// Add attester slashing scores.
-	attesterSlashings, err := blockProposal.AttesterSlashings()
-	if err != nil {
-		log.Warn().Err(err).Msg("Failed to obtain attester slashings")
-		attesterSlashings = make([]*phase0.AttesterSlashing, 0)
-	}
-	indicesSlashed := 0
-	for i := range attesterSlashings {
-		slashing := attesterSlashings[i]
-		indicesSlashed += len(intersection(slashing.Attestation1.AttestingIndices, slashing.Attestation2.AttestingIndices))
-	}
-	attesterSlashingScore := slashingWeight * float64(indicesSlashed)
-
-	// Add sync committee score.
-	syncCommitteeScore := float64(0)
-	if blockProposal.Version == spec.DataVersionAltair {
-		// An individual sync proposal is worth roughly 0.3 of a fully correct attestation.
-		syncCommitteeScore = float64(blockProposal.Altair.Body.SyncAggregate.SyncCommitteeBits.Count()) * 0.3
-	}
+	attesterSlashingScore, proposerSlashingScore := scoreSlashings(blockProposal.Body.AttesterSlashings, blockProposal.Body.ProposerSlashings)
 
 	// Scale scores by the distance between the proposal and parent slots.
 	var scale uint64
-	if blockProposalSlot <= parentSlot {
-		log.Warn().Uint64("slot", uint64(blockProposalSlot)).Uint64("parent_slot", uint64(parentSlot)).Msg("Invalid parent slot for proposal")
+	if blockProposal.Slot <= parentSlot {
+		log.Warn().Uint64("slot", uint64(blockProposal.Slot)).Uint64("parent_slot", uint64(parentSlot)).Msg("Invalid parent slot for proposal")
 		scale = 32
 	} else {
-		scale = uint64(blockProposalSlot - parentSlot)
+		scale = uint64(blockProposal.Slot - parentSlot)
 	}
 
 	log.Trace().
-		Uint64("slot", uint64(blockProposalSlot)).
+		Uint64("slot", uint64(blockProposal.Slot)).
+		Uint64("parent_slot", uint64(parentSlot)).
+		Str("provider", name).
+		Float64("immediate_attestations", immediateAttestationScore).
+		Float64("attestations", attestationScore).
+		Float64("proposer_slashings", proposerSlashingScore).
+		Float64("attester_slashings", attesterSlashingScore).
+		Uint64("scale", scale).
+		Float64("total", attestationScore*float64(scale)+proposerSlashingScore+attesterSlashingScore).
+		Msg("Scored phase 0 block")
+
+	return attestationScore/float64(scale) + proposerSlashingScore + attesterSlashingScore
+}
+
+// scoreAltairBeaconBlockPropsal generates a score for an altair beacon block.
+func (s *Service) scoreAltairBeaconBlockProposal(ctx context.Context,
+	name string,
+	parentSlot phase0.Slot,
+	blockProposal *altair.BeaconBlock,
+) float64 {
+	attestationScore := float64(0)
+	immediateAttestationScore := float64(0)
+
+	// We need to avoid duplicates in attestations.
+	// Map is attestation slot -> committee index -> validator committee index -> aggregate.
+	attested := make(map[phase0.Slot]map[phase0.CommitteeIndex]bitfield.Bitlist)
+	for _, attestation := range blockProposal.Body.Attestations {
+		data := attestation.Data
+		if _, exists := attested[data.Slot]; !exists {
+			attested[data.Slot] = make(map[phase0.CommitteeIndex]bitfield.Bitlist)
+		}
+		if _, exists := attested[data.Slot][data.Index]; !exists {
+			if !exists {
+				attested[data.Slot][data.Index] = bitfield.NewBitlist(attestation.AggregationBits.Len())
+			}
+		}
+
+		priorVotes, err := s.priorVotesForAttestation(ctx, attestation, blockProposal.ParentRoot)
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to obtain prior votes for attestation; assuming no votes")
+		}
+		log.Trace().Str("prior_votes", fmt.Sprintf("%#x", priorVotes.Bytes())).Msg("Prior votes")
+
+		votes := 0
+		for i := uint64(0); i < attestation.AggregationBits.Len(); i++ {
+			if attestation.AggregationBits.BitAt(i) {
+				if attested[attestation.Data.Slot][attestation.Data.Index].BitAt(i) {
+					// Already attested in this block; skip.
+					continue
+				}
+				if priorVotes.BitAt(i) {
+					// Attested in a previous block; skip.
+					continue
+				}
+				votes++
+				attested[attestation.Data.Slot][attestation.Data.Index].SetBitAt(i, true)
+			}
+		}
+
+		// Now we know how many new votes are in this attestation we can score it.
+		// We can calculate if the head vote is correct, but not target so for the
+		// purposes of the calculation we assume that it is.
+		switch blockProposal.Slot - attestation.Data.Slot {
+		case 1:
+			// If the attesation was for the past slot we know that the head vote
+			// can only be correct if it matches the parent root in the block.
+			score := float64(votes)
+			if bytes.Equal(blockProposal.ParentRoot[:], attestation.Data.BeaconBlockRoot[:]) {
+				score *= float64(s.timelySourceWeight+s.timelyTargetWeight+s.timelyHeadWeight) / float64(s.weightDenominator)
+			} else {
+				score *= float64(s.timelySourceWeight+s.timelyTargetWeight) / float64(s.weightDenominator)
+			}
+			attestationScore += score
+			immediateAttestationScore += score
+		case 2, 3, 4, 5:
+			// Head vote is no longer timely; source and target counts.
+			attestationScore += float64(votes) * float64(s.timelySourceWeight+s.timelyTargetWeight) / float64(s.weightDenominator)
+		default:
+			// Head and source votes are no longer timely; target counts.
+			attestationScore += float64(votes) * float64(s.timelyTargetWeight) / float64(s.weightDenominator)
+		}
+	}
+
+	attesterSlashingScore, proposerSlashingScore := scoreSlashings(blockProposal.Body.AttesterSlashings, blockProposal.Body.ProposerSlashings)
+
+	// Add sync committee score.
+	syncCommitteeScore := float64(blockProposal.Body.SyncAggregate.SyncCommitteeBits.Count()) * float64(s.syncRewardWeight) / float64(s.weightDenominator)
+
+	log.Trace().
+		Uint64("slot", uint64(blockProposal.Slot)).
 		Uint64("parent_slot", uint64(parentSlot)).
 		Str("provider", name).
 		Float64("immediate_attestations", immediateAttestationScore).
@@ -130,11 +195,81 @@ func scoreBeaconBlockProposal(_ context.Context, name string, parentSlot phase0.
 		Float64("proposer_slashings", proposerSlashingScore).
 		Float64("attester_slashings", attesterSlashingScore).
 		Float64("sync_committee", syncCommitteeScore).
-		Uint64("scale", scale).
-		Float64("total", (attestationScore+proposerSlashingScore+attesterSlashingScore)/float64(scale)).
-		Msg("Scored block")
+		Float64("total", attestationScore+proposerSlashingScore+attesterSlashingScore+syncCommitteeScore).
+		Msg("Scored Altair block")
 
-	return (attestationScore + proposerSlashingScore + attesterSlashingScore + syncCommitteeScore) / float64(scale)
+	return attestationScore + proposerSlashingScore + attesterSlashingScore + syncCommitteeScore
+}
+
+func scoreSlashings(attesterSlashings []*phase0.AttesterSlashing,
+	proposerSlashings []*phase0.ProposerSlashing,
+) (float64, float64) {
+	// Slashing reward will be at most MAX_EFFECTIVE_BALANCE/WHISTLEBLOWER_REWARD_QUOTIENT,
+	// which is 0.0625 Ether.
+	// Individual attestation reward at 250K validators will be around 23,000 GWei, or .000023 Ether.
+	// So we state that a single slashing event has the same weight as about 2,700 attestations.
+	slashingWeight := float64(2700)
+
+	// Add proposer slashing scores.
+	proposerSlashingScore := float64(len(proposerSlashings)) * slashingWeight
+
+	// Add attester slashing scores.
+	indicesSlashed := 0
+	for _, slashing := range attesterSlashings {
+		indicesSlashed += len(intersection(slashing.Attestation1.AttestingIndices, slashing.Attestation2.AttestingIndices))
+	}
+	attesterSlashingScore := slashingWeight * float64(indicesSlashed)
+
+	return attesterSlashingScore, proposerSlashingScore
+}
+
+func (s *Service) priorVotesForAttestation(ctx context.Context,
+	attestation *phase0.Attestation,
+	root phase0.Root,
+) (
+	bitfield.Bitlist,
+	error,
+) {
+	var res bitfield.Bitlist
+	var err error
+	found := false
+	s.priorBlocksMu.RLock()
+	for {
+		priorBlock, exists := s.priorBlocks[root]
+		if !exists {
+			// This means we do not have a parent block.
+			break
+		}
+		if priorBlock.slot < attestation.Data.Slot-phase0.Slot(s.slotsPerEpoch) {
+			// Block is too far back for its attestations to count.
+			break
+		}
+
+		slotVotes, exists := priorBlock.votes[attestation.Data.Slot]
+		if exists {
+			votes, exists := slotVotes[attestation.Data.Index]
+			if exists {
+				if !found {
+					res = bitfield.NewBitlist(votes.Len())
+					found = true
+				}
+				res, err = res.Or(votes)
+				if err != nil {
+					return bitfield.Bitlist{}, err
+				}
+			}
+		}
+
+		root = priorBlock.parent
+	}
+	s.priorBlocksMu.RUnlock()
+
+	if !found {
+		// No prior votes found, return an empty list.
+		return bitfield.NewBitlist(attestation.AggregationBits.Len()), nil
+	}
+
+	return res, nil
 }
 
 // intersection returns a list of items common between the two sets.

--- a/strategies/beaconblockproposal/best/score.go
+++ b/strategies/beaconblockproposal/best/score.go
@@ -223,7 +223,7 @@ func scoreSlashings(attesterSlashings []*phase0.AttesterSlashing,
 	return attesterSlashingScore, proposerSlashingScore
 }
 
-func (s *Service) priorVotesForAttestation(ctx context.Context,
+func (s *Service) priorVotesForAttestation(_ context.Context,
 	attestation *phase0.Attestation,
 	root phase0.Root,
 ) (


### PR DESCRIPTION
The existing block proposal scoring system used only the contents of the block itself to decide a score.  However, this has limitations in the situation where some of the attestations included have an inclusion distance above 1.

This change alters the strategy to keep track the attestations in up to 32 slots' of historical blocks.  This data is then used in the block scoring process to give a zero score to attestations that are duplicates of previously-included attestations within the same chain as the block.