### PR TITLE
Return on first submission.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 development:
   - increase accuracy of beacon block proposal scorer by incorporating attestation history
+  - multinode submitter returns after first successful submission rather than waiting for all to complete
 
 1.3.2:
   - fix crash if beacon block root is returned as nil

--- a/main.go
+++ b/main.go
@@ -200,7 +200,7 @@ func fetchConfig() error {
 
 	// Defaults.
 	viper.SetDefault("process-concurrency", int64(runtime.GOMAXPROCS(-1)))
-	viper.SetDefault("strategies.timeout", 2*time.Second)
+	viper.SetDefault("timeout", 2*time.Second)
 	viper.SetDefault("eth2client.timeout", 2*time.Minute)
 	viper.SetDefault("controller.max-proposal-delay", 0)
 	viper.SetDefault("controller.max-attestation-delay", 4*time.Second)
@@ -1056,6 +1056,7 @@ func selectSubmitterStrategy(ctx context.Context, monitor metrics.Service, eth2C
 			multinodesubmitter.WithClientMonitor(monitor.(metrics.ClientMonitor)),
 			multinodesubmitter.WithProcessConcurrency(util.ProcessConcurrency("submitter.multinode")),
 			multinodesubmitter.WithLogLevel(util.LogLevel("submitter.multinode")),
+			multinodesubmitter.WithTimeout(util.Timeout("submitter.multinode")),
 			multinodesubmitter.WithBeaconBlockSubmitters(beaconBlockSubmitters),
 			multinodesubmitter.WithAttestationsSubmitters(attestationsSubmitters),
 			multinodesubmitter.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),

--- a/mock/eth2client.go
+++ b/mock/eth2client.go
@@ -187,6 +187,26 @@ func (*ErroringSyncCommitteeSubscriptionsSubmitter) SubmitSyncCommitteeSubscript
 	return errors.New("error")
 }
 
+// SleepySyncCommitteeSubscriptionsSubmitter is a mock for eth2client.SyncCommitteeSubscriptionsSubmitter.
+type SleepySyncCommitteeSubscriptionsSubmitter struct {
+	wait time.Duration
+	next eth2client.SyncCommitteeSubscriptionsSubmitter
+}
+
+// NewSleepySyncCommitteeSubscriptionsSubmitter returns a mock sync committee subscriptions submitter.
+func NewSleepySyncCommitteeSubscriptionsSubmitter(wait time.Duration, next eth2client.SyncCommitteeSubscriptionsSubmitter) eth2client.SyncCommitteeSubscriptionsSubmitter {
+	return &SleepySyncCommitteeSubscriptionsSubmitter{
+		wait: wait,
+		next: next,
+	}
+}
+
+// SubmitSyncCommitteeSubscriptions is a mock.
+func (m *SleepySyncCommitteeSubscriptionsSubmitter) SubmitSyncCommitteeSubscriptions(ctx context.Context, subscriptions []*api.SyncCommitteeSubscription) error {
+	time.Sleep(m.wait)
+	return m.next.SubmitSyncCommitteeSubscriptions(ctx, subscriptions)
+}
+
 // SyncCommitteeMessagesSubmitter is a mock for eth2client.SyncCommitteeMessagesSubmitter.
 type SyncCommitteeMessagesSubmitter struct{}
 
@@ -213,6 +233,26 @@ func (*ErroringSyncCommitteeMessagesSubmitter) SubmitSyncCommitteeMessages(_ con
 	return errors.New("error")
 }
 
+// SleepySyncCommitteeMessagesSubmitter is a mock for eth2client.SyncCommitteeMessagesSubmitter.
+type SleepySyncCommitteeMessagesSubmitter struct {
+	wait time.Duration
+	next eth2client.SyncCommitteeMessagesSubmitter
+}
+
+// NewSleepySyncCommitteeMessagesSubmitter returns a mock sync committee messages submitter.
+func NewSleepySyncCommitteeMessagesSubmitter(wait time.Duration, next eth2client.SyncCommitteeMessagesSubmitter) eth2client.SyncCommitteeMessagesSubmitter {
+	return &SleepySyncCommitteeMessagesSubmitter{
+		wait: wait,
+		next: next,
+	}
+}
+
+// SubmitSyncCommitteeMessages is a mock.
+func (m *SleepySyncCommitteeMessagesSubmitter) SubmitSyncCommitteeMessages(ctx context.Context, messages []*altair.SyncCommitteeMessage) error {
+	time.Sleep(m.wait)
+	return m.next.SubmitSyncCommitteeMessages(ctx, messages)
+}
+
 // SyncCommitteeContributionsSubmitter is a mock for eth2client.SyncCommitteeContributionsSubmitter.
 type SyncCommitteeContributionsSubmitter struct{}
 
@@ -237,6 +277,26 @@ func NewErroringSyncCommitteeContributionsSubmitter() eth2client.SyncCommitteeCo
 // SubmitSyncCommitteeContributions submits sync committee contributions.
 func (*ErroringSyncCommitteeContributionsSubmitter) SubmitSyncCommitteeContributions(_ context.Context, _ []*altair.SignedContributionAndProof) error {
 	return errors.New("error")
+}
+
+// SleepySyncCommitteeContributionsSubmitter is a mock for eth2client.SyncCommitteeContributionsSubmitter.
+type SleepySyncCommitteeContributionsSubmitter struct {
+	wait time.Duration
+	next eth2client.SyncCommitteeContributionsSubmitter
+}
+
+// NewSleepySyncCommitteeContributionsSubmitter returns a mock contribution and proofs submitter.
+func NewSleepySyncCommitteeContributionsSubmitter(wait time.Duration, next eth2client.SyncCommitteeContributionsSubmitter) eth2client.SyncCommitteeContributionsSubmitter {
+	return &SleepySyncCommitteeContributionsSubmitter{
+		wait: wait,
+		next: next,
+	}
+}
+
+// SubmitSyncCommitteeContributions is a mock.
+func (m *SleepySyncCommitteeContributionsSubmitter) SubmitSyncCommitteeContributions(ctx context.Context, proofs []*altair.SignedContributionAndProof) error {
+	time.Sleep(m.wait)
+	return m.next.SubmitSyncCommitteeContributions(ctx, proofs)
 }
 
 // EventsProvider is a mock for eth2client.EventsProvider.
@@ -291,6 +351,26 @@ func (*ErroringAttestationsSubmitter) SubmitAttestations(_ context.Context, _ []
 	return errors.New("error")
 }
 
+// SleepyAttestationsSubmitter is a mock for eth2client.AttestationsSubmitter.
+type SleepyAttestationsSubmitter struct {
+	wait time.Duration
+	next eth2client.AttestationsSubmitter
+}
+
+// NewSleepyAttestationsSubmitter returns a mock attestations submitter.
+func NewSleepyAttestationsSubmitter(wait time.Duration, next eth2client.AttestationsSubmitter) eth2client.AttestationsSubmitter {
+	return &SleepyAttestationsSubmitter{
+		wait: wait,
+		next: next,
+	}
+}
+
+// SubmitAttestations is a mock.
+func (m *SleepyAttestationsSubmitter) SubmitAttestations(ctx context.Context, attestations []*phase0.Attestation) error {
+	time.Sleep(m.wait)
+	return m.next.SubmitAttestations(ctx, attestations)
+}
+
 // BeaconBlockSubmitter is a mock for eth2client.BeaconBlockSubmitter.
 type BeaconBlockSubmitter struct{}
 
@@ -315,6 +395,26 @@ func NewErroringBeaconBlockSubmitter() eth2client.BeaconBlockSubmitter {
 // SubmitBeaconBlock is a mock.
 func (*ErroringBeaconBlockSubmitter) SubmitBeaconBlock(_ context.Context, _ *spec.VersionedSignedBeaconBlock) error {
 	return errors.New("error")
+}
+
+// SleepyBeaconBlockSubmitter is a mock for eth2client.BeaconBlockSubmitter.
+type SleepyBeaconBlockSubmitter struct {
+	wait time.Duration
+	next eth2client.BeaconBlockSubmitter
+}
+
+// NewSleepyBeaconBlockSubmitter returns a mock beacon block submitter.
+func NewSleepyBeaconBlockSubmitter(wait time.Duration, next eth2client.BeaconBlockSubmitter) eth2client.BeaconBlockSubmitter {
+	return &SleepyBeaconBlockSubmitter{
+		wait: wait,
+		next: next,
+	}
+}
+
+// SubmitBeaconBlock is a mock.
+func (m *SleepyBeaconBlockSubmitter) SubmitBeaconBlock(ctx context.Context, block *spec.VersionedSignedBeaconBlock) error {
+	time.Sleep(m.wait)
+	return m.next.SubmitBeaconBlock(ctx, block)
 }
 
 // AggregateAttestationsSubmitter is a mock for eth2client.AggregateAttestationsSubmitter.
@@ -343,6 +443,26 @@ func (*ErroringAggregateAttestationsSubmitter) SubmitAggregateAttestations(_ con
 	return errors.New("error")
 }
 
+// SleepyAggregateAttestationsSubmitter is a mock for eth2client.AggregateAttestationsSubmitter.
+type SleepyAggregateAttestationsSubmitter struct {
+	wait time.Duration
+	next eth2client.AggregateAttestationsSubmitter
+}
+
+// NewSleepyAggregateAttestationsSubmitter returns a mock aggregate attestations submitter.
+func NewSleepyAggregateAttestationsSubmitter(wait time.Duration, next eth2client.AggregateAttestationsSubmitter) eth2client.AggregateAttestationsSubmitter {
+	return &SleepyAggregateAttestationsSubmitter{
+		wait: wait,
+		next: next,
+	}
+}
+
+// SubmitAggregateAttestations is a mock.
+func (m *SleepyAggregateAttestationsSubmitter) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs []*phase0.SignedAggregateAndProof) error {
+	time.Sleep(m.wait)
+	return m.next.SubmitAggregateAttestations(ctx, aggregateAndProofs)
+}
+
 // BeaconCommitteeSubscriptionsSubmitter is a mock for eth2client.BeaconCommitteeSubscriptionsSubmitter.
 type BeaconCommitteeSubscriptionsSubmitter struct{}
 
@@ -367,6 +487,26 @@ func NewErroringBeaconCommitteeSubscriptionsSubmitter() eth2client.BeaconCommitt
 // SubmitBeaconCommitteeSubscriptions is a mock.
 func (*ErroringBeaconCommitteeSubscriptionsSubmitter) SubmitBeaconCommitteeSubscriptions(_ context.Context, _ []*api.BeaconCommitteeSubscription) error {
 	return errors.New("error")
+}
+
+// SleepyBeaconCommitteeSubscriptionsSubmitter is a mock for eth2client.BeaconCommitteeSubscriptionsSubmitter.
+type SleepyBeaconCommitteeSubscriptionsSubmitter struct {
+	wait time.Duration
+	next eth2client.BeaconCommitteeSubscriptionsSubmitter
+}
+
+// NewSleepyBeaconCommitteeSubscriptionsSubmitter returns a mock beacon committee subscriptions submitter.
+func NewSleepyBeaconCommitteeSubscriptionsSubmitter(wait time.Duration, next eth2client.BeaconCommitteeSubscriptionsSubmitter) eth2client.BeaconCommitteeSubscriptionsSubmitter {
+	return &SleepyBeaconCommitteeSubscriptionsSubmitter{
+		wait: wait,
+		next: next,
+	}
+}
+
+// SubmitBeaconCommitteeSubscriptions is a mock.
+func (m *SleepyBeaconCommitteeSubscriptionsSubmitter) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*api.BeaconCommitteeSubscription) error {
+	time.Sleep(m.wait)
+	return m.next.SubmitBeaconCommitteeSubscriptions(ctx, subscriptions)
 }
 
 // BeaconBlockProposalProvider is a mock for eth2client.BeaconBlockProposalProvider.

--- a/services/submitter/immediate/service_test.go
+++ b/services/submitter/immediate/service_test.go
@@ -189,6 +189,9 @@ func TestInterfaces(t *testing.T) {
 	require.Implements(t, (*submitter.AttestationsSubmitter)(nil), s)
 	require.Implements(t, (*submitter.BeaconCommitteeSubscriptionsSubmitter)(nil), s)
 	require.Implements(t, (*submitter.AggregateAttestationsSubmitter)(nil), s)
+	require.Implements(t, (*submitter.SyncCommitteeMessagesSubmitter)(nil), s)
+	require.Implements(t, (*submitter.SyncCommitteeSubscriptionsSubmitter)(nil), s)
+	require.Implements(t, (*submitter.SyncCommitteeContributionsSubmitter)(nil), s)
 }
 
 func TestSubmitBeaconBlock(t *testing.T) {

--- a/services/submitter/multinode/service.go
+++ b/services/submitter/multinode/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2022 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package multinode
 
 import (
 	"context"
+	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/vouch/services/metrics"
@@ -26,6 +27,7 @@ import (
 // Service is the provider for beacon block proposals.
 type Service struct {
 	clientMonitor                         metrics.ClientMonitor
+	timeout                               time.Duration
 	processConcurrency                    int64
 	beaconBlockSubmitters                 map[string]eth2client.BeaconBlockSubmitter
 	attestationsSubmitters                map[string]eth2client.AttestationsSubmitter
@@ -54,6 +56,7 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 
 	s := &Service{
 		clientMonitor:                         parameters.clientMonitor,
+		timeout:                               parameters.timeout,
 		processConcurrency:                    parameters.processConcurrency,
 		beaconBlockSubmitters:                 parameters.beaconBlockSubmitters,
 		attestationsSubmitters:                parameters.attestationsSubmitters,

--- a/services/submitter/multinode/service_test.go
+++ b/services/submitter/multinode/service_test.go
@@ -1,0 +1,387 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService(t *testing.T) {
+	attestationsSubmitters := map[string]eth2client.AttestationsSubmitter{
+		"1": mock.NewAttestationsSubmitter(),
+	}
+	beaconBlockSubmitters := map[string]eth2client.BeaconBlockSubmitter{
+		"1": mock.NewBeaconBlockSubmitter(),
+	}
+	beaconCommitteeSubscriptionsSubmitters := map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+		"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+	}
+	aggregateAttestationsSubmitters := map[string]eth2client.AggregateAttestationsSubmitter{
+		"1": mock.NewAggregateAttestationsSubmitter(),
+	}
+	syncCommitteeMessagesSubmitters := map[string]eth2client.SyncCommitteeMessagesSubmitter{
+		"1": mock.NewSyncCommitteeMessagesSubmitter(),
+	}
+	syncCommitteeSubscriptionsSubmitters := map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+		"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+	}
+	syncCommitteeContributionsSubmitters := map[string]eth2client.SyncCommitteeContributionsSubmitter{
+		"1": mock.NewSyncCommitteeContributionsSubmitter(),
+	}
+
+	tests := []struct {
+		name   string
+		params []multinode.Parameter
+		err    string
+	}{
+		{
+			name: "ClientMonitorMissing",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithClientMonitor(nil),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no client monitor specified",
+		},
+		{
+			name: "TimeoutZero",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(0),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no timeout specified",
+		},
+		{
+			name: "ProcessConcurrencyZero",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(0),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no process concurrency specified",
+		},
+		{
+			name: "BeaconBlockSubmittersMissing",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no beacon block submitters specified",
+		},
+		{
+			name: "BeaconBlockSubmittersEmpty",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{}),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no beacon block submitters specified",
+		},
+		{
+			name: "AttestationsSubmittersMissing",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no attestations submitters specified",
+		},
+		{
+			name: "AttestationsSubmittersEmpty",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{}),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no attestations submitters specified",
+		},
+		{
+			name: "BeaconCommitteeSubscriptionsSubmittersMissing",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no beacon committee subscription submitters specified",
+		},
+		{
+			name: "BeaconCommitteeSubscriptionsSubmittersEmpty",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{}),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no beacon committee subscription submitters specified",
+		},
+		{
+			name: "AggregateAttestationsSubmittersMissing",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no aggregate attestations submitters specified",
+		},
+		{
+			name: "AggregateAttestationsSubmittersEmpty",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{}),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no aggregate attestations submitters specified",
+		},
+		{
+			name: "SyncCommitteeMessagesSubmittersMissing",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no sync committee messages submitters specified",
+		},
+		{
+			name: "SyncCommitteeMessagesSubmittersEmpty",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{}),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no sync committee messages submitters specified",
+		},
+		{
+			name: "SyncCommitteeSubscriptionsSubmittersMissing",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no sync committee subscriptions submitters specified",
+		},
+		{
+			name: "SyncCommitteeSubscriptionsSubmittersEmpty",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{}),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+			err: "problem with parameters: no sync committee subscriptions submitters specified",
+		},
+		{
+			name: "SyncCommitteeContributionsSubmittersMissing",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+			},
+			err: "problem with parameters: no sync committee contributions submitters specified",
+		},
+		{
+			name: "SyncCommitteeContributionsSubmittersEmpty",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{}),
+			},
+			err: "problem with parameters: no sync committee contributions submitters specified",
+		},
+		{
+			name: "Good",
+			params: []multinode.Parameter{
+				multinode.WithLogLevel(zerolog.Disabled),
+				multinode.WithTimeout(2 * time.Second),
+				multinode.WithProcessConcurrency(2),
+				multinode.WithBeaconBlockSubmitters(beaconBlockSubmitters),
+				multinode.WithAttestationsSubmitters(attestationsSubmitters),
+				multinode.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
+				multinode.WithAggregateAttestationsSubmitters(aggregateAttestationsSubmitters),
+				multinode.WithSyncCommitteeMessagesSubmitters(syncCommitteeMessagesSubmitters),
+				multinode.WithSyncCommitteeSubscriptionsSubmitters(syncCommitteeSubscriptionsSubmitters),
+				multinode.WithSyncCommitteeContributionsSubmitters(syncCommitteeContributionsSubmitters),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := multinode.New(context.Background(), test.params...)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInterfaces(t *testing.T) {
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(2*time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+	require.Implements(t, (*submitter.BeaconBlockSubmitter)(nil), s)
+	require.Implements(t, (*submitter.AttestationsSubmitter)(nil), s)
+	require.Implements(t, (*submitter.BeaconCommitteeSubscriptionsSubmitter)(nil), s)
+	require.Implements(t, (*submitter.AggregateAttestationsSubmitter)(nil), s)
+	require.Implements(t, (*submitter.SyncCommitteeMessagesSubmitter)(nil), s)
+	require.Implements(t, (*submitter.SyncCommitteeSubscriptionsSubmitter)(nil), s)
+	require.Implements(t, (*submitter.SyncCommitteeContributionsSubmitter)(nil), s)
+}

--- a/services/submitter/multinode/submitaggregateattestations.go
+++ b/services/submitter/multinode/submitaggregateattestations.go
@@ -1,4 +1,4 @@
-// Copyright © 2020, 2021 Attestant Limited.
+// Copyright © 2020 - 2022 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package multinode
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
 	"time"
 
@@ -31,43 +30,51 @@ func (s *Service) SubmitAggregateAttestations(ctx context.Context, aggregates []
 		return errors.New("no aggregate attestations supplied")
 	}
 
+	var err error
 	sem := semaphore.NewWeighted(s.processConcurrency)
-	var wg sync.WaitGroup
+	w := sync.NewCond(&sync.Mutex{})
+	w.L.Lock()
 	for name, submitter := range s.aggregateAttestationsSubmitters {
-		wg.Add(1)
-		go func(ctx context.Context,
-			sem *semaphore.Weighted,
-			wg *sync.WaitGroup,
-			name string,
-			submitter eth2client.AggregateAttestationsSubmitter,
-		) {
-			defer wg.Done()
-			log := log.With().Str("beacon_node_address", name).Uint64("slot", uint64(aggregates[0].Message.Aggregate.Data.Slot)).Logger()
-			if err := sem.Acquire(ctx, 1); err != nil {
-				log.Error().Err(err).Msg("Failed to acquire semaphore")
-				return
-			}
-			defer sem.Release(1)
-
-			_, address := s.serviceInfo(ctx, submitter)
-			started := time.Now()
-			err := submitter.SubmitAggregateAttestations(ctx, aggregates)
-			s.clientMonitor.ClientOperation(address, "submit aggregate attestations", err == nil, time.Since(started))
-			if err != nil {
-				log.Warn().Err(err).Msg("Failed to submit aggregate attestations")
-				return
-			}
-			log.Trace().Msg("Submitted aggregate attestations")
-		}(ctx, sem, &wg, name, submitter)
+		go s.submitAggregateAttestations(ctx, sem, w, name, aggregates, submitter)
 	}
-	wg.Wait()
+	// Also set a timeout condition, in case no submitters return.
+	go func(s *Service, w *sync.Cond) {
+		time.Sleep(s.timeout)
+		err = errors.New("no successful submissions before timeout")
+		w.Signal()
+	}(s, w)
+	w.Wait()
+	w.L.Unlock()
 
-	if e := log.Trace(); e.Enabled() {
-		data, err := json.Marshal(aggregates)
-		if err == nil {
-			e.Str("aggregate_attestations", string(data)).Msg("Submitted aggregate attestations")
-		}
+	return err
+}
+
+// submitAggregateAttestations carries out the internal work of submitting aggregate attestations.
+// skipcq: RVV-B0001
+func (s *Service) submitAggregateAttestations(ctx context.Context,
+	sem *semaphore.Weighted,
+	w *sync.Cond,
+	name string,
+	aggregates []*phase0.SignedAggregateAndProof,
+	submitter eth2client.AggregateAttestationsSubmitter,
+) {
+	log := log.With().Str("beacon_node_address", name).Uint64("slot", uint64(aggregates[0].Message.Aggregate.Data.Slot)).Logger()
+	if err := sem.Acquire(ctx, 1); err != nil {
+		log.Error().Err(err).Msg("Failed to acquire semaphore")
+		return
+	}
+	defer sem.Release(1)
+
+	_, address := s.serviceInfo(ctx, submitter)
+	started := time.Now()
+	err := submitter.SubmitAggregateAttestations(ctx, aggregates)
+
+	s.clientMonitor.ClientOperation(address, "submit aggregate attestations", err == nil, time.Since(started))
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to submit aggregate attestations")
+		return
 	}
 
-	return nil
+	w.Signal()
+	log.Trace().Msg("Submitted aggregate attestations")
 }

--- a/services/submitter/multinode/submitaggregateattestations_test.go
+++ b/services/submitter/multinode/submitaggregateattestations_test.go
@@ -1,0 +1,283 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/attestantio/vouch/testutil"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitAggregateAttestationsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(2*time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAggregateAttestations(ctx, []*phase0.SignedAggregateAndProof{})
+	require.EqualError(t, err, "no aggregate attestations supplied")
+}
+
+func TestSubmitAggregateAttestations(t *testing.T) {
+	ctx := context.Background()
+
+	capture := logger.NewLogCapture()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAggregateAttestations(ctx, []*phase0.SignedAggregateAndProof{
+		{
+			Message: &phase0.AggregateAndProof{
+				Aggregate: &phase0.Attestation{
+					Data: &phase0.AttestationData{
+						BeaconBlockRoot: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+						Source: &phase0.Checkpoint{
+							Epoch: 5,
+							Root:  testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+						},
+						Target: &phase0.Checkpoint{
+							Epoch: 6,
+							Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+						},
+					},
+				},
+			},
+			Signature: testutil.HexToSignature("0x040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"),
+		},
+	})
+	require.NoError(t, err)
+	capture.AssertHasEntry(t, "Submitted aggregate attestations")
+}
+
+func TestSubmitAggregateAttestationsErroring(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewErroringAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAggregateAttestations(ctx, []*phase0.SignedAggregateAndProof{
+		{
+			Message: &phase0.AggregateAndProof{
+				Aggregate: &phase0.Attestation{
+					Data: &phase0.AttestationData{
+						BeaconBlockRoot: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+						Source: &phase0.Checkpoint{
+							Epoch: 5,
+							Root:  testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+						},
+						Target: &phase0.Checkpoint{
+							Epoch: 6,
+							Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+						},
+					},
+				},
+			},
+			Signature: testutil.HexToSignature("0x040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"),
+		},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitAggregateAttestationsSleepy(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewSleepyAggregateAttestationsSubmitter(200*time.Millisecond, mock.NewAggregateAttestationsSubmitter()),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAggregateAttestations(ctx, []*phase0.SignedAggregateAndProof{
+		{
+			Message: &phase0.AggregateAndProof{
+				Aggregate: &phase0.Attestation{
+					Data: &phase0.AttestationData{
+						BeaconBlockRoot: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+						Source: &phase0.Checkpoint{
+							Epoch: 5,
+							Root:  testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+						},
+						Target: &phase0.Checkpoint{
+							Epoch: 6,
+							Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+						},
+					},
+				},
+			},
+			Signature: testutil.HexToSignature("0x040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"),
+		},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitAggregateAttestationsSleepySuccess(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(200*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewSleepyAggregateAttestationsSubmitter(100*time.Millisecond, mock.NewAggregateAttestationsSubmitter()),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAggregateAttestations(ctx, []*phase0.SignedAggregateAndProof{
+		{
+			Message: &phase0.AggregateAndProof{
+				Aggregate: &phase0.Attestation{
+					Data: &phase0.AttestationData{
+						BeaconBlockRoot: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+						Source: &phase0.Checkpoint{
+							Epoch: 5,
+							Root:  testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+						},
+						Target: &phase0.Checkpoint{
+							Epoch: 6,
+							Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+						},
+					},
+				},
+			},
+			Signature: testutil.HexToSignature("0x040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"),
+		},
+	})
+	require.NoError(t, err)
+}

--- a/services/submitter/multinode/submitattestations.go
+++ b/services/submitter/multinode/submitattestations.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2022 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package multinode
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"sync"
 	"time"
@@ -33,27 +32,34 @@ func (s *Service) SubmitAttestations(ctx context.Context, attestations []*phase0
 		return errors.New("no attestations supplied")
 	}
 
+	var err error
 	sem := semaphore.NewWeighted(s.processConcurrency)
-	var wg sync.WaitGroup
+	w := sync.NewCond(&sync.Mutex{})
+	w.L.Lock()
 	for name, submitter := range s.attestationsSubmitters {
-		wg.Add(1)
-		go s.submitAttestations(ctx, sem, &wg, name, attestations, submitter)
+		go s.submitAttestations(ctx, sem, w, name, attestations, submitter)
 	}
-	wg.Wait()
+	// Also set a timeout condition, in case no submitters return.
+	go func(s *Service, w *sync.Cond) {
+		time.Sleep(s.timeout)
+		err = errors.New("no successful submissions before timeout")
+		w.Signal()
+	}(s, w)
+	w.Wait()
+	w.L.Unlock()
 
-	return nil
+	return err
 }
 
 // submitAttestations carries out the internal work of submitting attestations.
 // skipcq: RVV-B0001
 func (s *Service) submitAttestations(ctx context.Context,
 	sem *semaphore.Weighted,
-	wg *sync.WaitGroup,
+	w *sync.Cond,
 	name string,
 	attestations []*phase0.Attestation,
 	submitter eth2client.AttestationsSubmitter,
 ) {
-	defer wg.Done()
 	log := log.With().Str("beacon_node_address", name).Uint64("slot", uint64(attestations[0].Data.Slot)).Logger()
 	if err := sem.Acquire(ctx, 1); err != nil {
 		log.Error().Err(err).Msg("Failed to acquire semaphore")
@@ -61,45 +67,45 @@ func (s *Service) submitAttestations(ctx context.Context,
 	}
 	defer sem.Release(1)
 
-	serverType, address := s.serviceInfo(ctx, submitter)
+	_, address := s.serviceInfo(ctx, submitter)
 	started := time.Now()
-
 	_, err := util.Scatter(len(attestations), int(s.processConcurrency), func(offset int, entries int, _ *sync.RWMutex) (interface{}, error) {
 		return nil, submitter.SubmitAttestations(ctx, attestations[offset:offset+entries])
 	})
-
 	if err != nil {
-		switch {
-		case serverType == "lighthouse" && strings.Contains(err.Error(), "PriorAttestationKnown"):
-			// Lighthouse rejects duplicate attestations.  It is possible that an attestation we sent
-			// to another node already propagated to this node, so ignore the error.
-			log.Trace().Msg("Node already knows about attestation; ignored")
-			// Not an error as far as we are concerned, so clear it.
-			err = nil
-		case serverType == "lighthouse" && strings.Contains(err.Error(), "UnknownHeadBlock"):
-			// Lighthouse rejects an attestation for a block  that is not its current head.  It is possible
-			// that the node is just behind, and we can't do anything about it anyway at this point having
-			// already signed an attestation for this slot, so ignore the error.
-			log.Debug().Err(err).Msg("Node does not know head block; rejected")
-			// Not an error as far as we are concerned, so clear it.
-			err = nil
-		case serverType == "lighthouse" && strings.Contains(err.Error(), "InvalidSignature"):
-			data, err2 := json.Marshal(attestations)
-			if err2 != nil {
-				log.Error().Err(err).Msg("Failed to marshal JSON")
-			} else {
-				log.Warn().Err(err).Str("data", string(data)).Msg("Invalid signature!")
-			}
-		default:
-			log.Warn().Err(err).Msg("Failed to submit attestation")
-		}
-	} else {
-		data, err := json.Marshal(attestations)
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to marshal JSON")
-		} else {
-			log.Trace().Str("data", string(data)).Msg("Submitted attestations")
-		}
+		err = s.handleAttestationsError(ctx, submitter, err)
 	}
+
 	s.clientMonitor.ClientOperation(address, "submit attestations", err == nil, time.Since(started))
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to submit attestations")
+		return
+	}
+
+	w.Signal()
+	log.Trace().Msg("Submitted attestations")
+}
+
+func (s *Service) handleAttestationsError(ctx context.Context,
+	submitter eth2client.AttestationsSubmitter,
+	err error,
+) error {
+	serverType, _ := s.serviceInfo(ctx, submitter)
+	switch {
+	case serverType == "lighthouse" && strings.Contains(err.Error(), "PriorAttestationKnown"):
+		// Lighthouse rejects duplicate attestations.  It is possible that an attestation we sent
+		// to another node already propagated to this node, so ignore the error.
+		log.Trace().Msg("Node already knows about attestation; ignored")
+		// Not an error as far as we are concerned, so clear it.
+		err = nil
+	case serverType == "lighthouse" && strings.Contains(err.Error(), "UnknownHeadBlock"):
+		// Lighthouse rejects an attestation for a block  that is not its current head.  It is possible
+		// that the node is just behind, and we can't do anything about it anyway at this point having
+		// already signed an attestation for this slot, so ignore the error.
+		log.Debug().Err(err).Msg("Node does not know head block; rejected")
+		// Not an error as far as we are concerned, so clear it.
+		err = nil
+	}
+
+	return err
 }

--- a/services/submitter/multinode/submitattestations_test.go
+++ b/services/submitter/multinode/submitattestations_test.go
@@ -1,0 +1,267 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/attestantio/vouch/testutil"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitAttestationsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(2*time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAttestations(ctx, []*phase0.Attestation{})
+	require.EqualError(t, err, "no attestations supplied")
+}
+
+func TestSubmitAttestations(t *testing.T) {
+	ctx := context.Background()
+
+	capture := logger.NewLogCapture()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAttestations(ctx, []*phase0.Attestation{
+		{
+			Data: &phase0.AttestationData{
+				BeaconBlockRoot: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+				Source: &phase0.Checkpoint{
+					Epoch: 5,
+					Root:  testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+				},
+				Target: &phase0.Checkpoint{
+					Epoch: 6,
+					Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+				},
+			},
+			Signature: testutil.HexToSignature("0x040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"),
+		},
+	})
+	require.NoError(t, err)
+	capture.AssertHasEntry(t, "Submitted attestations")
+}
+
+func TestSubmitAttestationsErroring(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewErroringAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAttestations(ctx, []*phase0.Attestation{
+		{
+			Data: &phase0.AttestationData{
+				BeaconBlockRoot: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+				Source: &phase0.Checkpoint{
+					Epoch: 5,
+					Root:  testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+				},
+				Target: &phase0.Checkpoint{
+					Epoch: 6,
+					Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+				},
+			},
+			Signature: testutil.HexToSignature("0x040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"),
+		},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitAttestationsSleepy(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewSleepyAttestationsSubmitter(200*time.Millisecond, mock.NewAttestationsSubmitter()),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAttestations(ctx, []*phase0.Attestation{
+		{
+			Data: &phase0.AttestationData{
+				BeaconBlockRoot: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+				Source: &phase0.Checkpoint{
+					Epoch: 5,
+					Root:  testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+				},
+				Target: &phase0.Checkpoint{
+					Epoch: 6,
+					Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+				},
+			},
+			Signature: testutil.HexToSignature("0x040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"),
+		},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitAttestationsSleepySuccess(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(200*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewSleepyAttestationsSubmitter(100*time.Millisecond, mock.NewAttestationsSubmitter()),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitAttestations(ctx, []*phase0.Attestation{
+		{
+			Data: &phase0.AttestationData{
+				BeaconBlockRoot: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+				Source: &phase0.Checkpoint{
+					Epoch: 5,
+					Root:  testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+				},
+				Target: &phase0.Checkpoint{
+					Epoch: 6,
+					Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+				},
+			},
+			Signature: testutil.HexToSignature("0x040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404"),
+		},
+	})
+	require.NoError(t, err)
+}

--- a/services/submitter/multinode/submitbeaconblock_test.go
+++ b/services/submitter/multinode/submitbeaconblock_test.go
@@ -1,0 +1,235 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitBeaconBlockEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(2*time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconBlock(ctx, nil)
+	require.EqualError(t, err, "no beacon block supplied")
+}
+
+func TestSubmitBeaconBlock(t *testing.T) {
+	ctx := context.Background()
+
+	capture := logger.NewLogCapture()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconBlock(ctx, &spec.VersionedSignedBeaconBlock{
+		Version: spec.DataVersionAltair,
+		Altair: &altair.SignedBeaconBlock{
+			Message: &altair.BeaconBlock{
+				Slot: 1,
+			},
+		},
+	})
+	require.NoError(t, err)
+	capture.AssertHasEntry(t, "Submitted beacon block")
+}
+
+func TestSubmitBeaconBlockErroring(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewErroringBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconBlock(ctx, &spec.VersionedSignedBeaconBlock{
+		Version: spec.DataVersionAltair,
+		Altair: &altair.SignedBeaconBlock{
+			Message: &altair.BeaconBlock{
+				Slot: 1,
+			},
+		},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitBeaconBlockSleepy(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewSleepyBeaconBlockSubmitter(200*time.Millisecond, mock.NewBeaconBlockSubmitter()),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconBlock(ctx, &spec.VersionedSignedBeaconBlock{
+		Version: spec.DataVersionAltair,
+		Altair: &altair.SignedBeaconBlock{
+			Message: &altair.BeaconBlock{
+				Slot: 1,
+			},
+		},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitBeaconBlockSleepySuccess(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(200*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewSleepyBeaconBlockSubmitter(100*time.Millisecond, mock.NewBeaconBlockSubmitter()),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconBlock(ctx, &spec.VersionedSignedBeaconBlock{
+		Version: spec.DataVersionAltair,
+		Altair: &altair.SignedBeaconBlock{
+			Message: &altair.BeaconBlock{
+				Slot: 1,
+			},
+		},
+	})
+	require.NoError(t, err)
+}

--- a/services/submitter/multinode/submitbeaconcommitteesubscriptions_test.go
+++ b/services/submitter/multinode/submitbeaconcommitteesubscriptions_test.go
@@ -1,0 +1,214 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitBeaconCommitteeSubscriptionsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(2*time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconCommitteeSubscriptions(ctx, []*api.BeaconCommitteeSubscription{})
+	require.NoError(t, err)
+}
+
+func TestSubmitBeaconCommitteeSubscriptions(t *testing.T) {
+	ctx := context.Background()
+
+	capture := logger.NewLogCapture()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconCommitteeSubscriptions(ctx, []*api.BeaconCommitteeSubscription{
+		{},
+	})
+	require.NoError(t, err)
+	capture.AssertHasEntry(t, "Submitted beacon committee subscriptions")
+}
+
+func TestSubmitBeaconCommitteeSubscriptionsErroring(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewErroringBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconCommitteeSubscriptions(ctx, []*api.BeaconCommitteeSubscription{
+		{},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitBeaconCommitteeSubscriptionsSleepy(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSleepyBeaconCommitteeSubscriptionsSubmitter(200*time.Millisecond, mock.NewBeaconCommitteeSubscriptionsSubmitter()),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconCommitteeSubscriptions(ctx, []*api.BeaconCommitteeSubscription{
+		{},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitBeaconCommitteeSubscriptionsSleepySuccess(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(200*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSleepyBeaconCommitteeSubscriptionsSubmitter(100*time.Millisecond, mock.NewBeaconCommitteeSubscriptionsSubmitter()),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitBeaconCommitteeSubscriptions(ctx, []*api.BeaconCommitteeSubscription{
+		{},
+	})
+	require.NoError(t, err)
+}

--- a/services/submitter/multinode/submitsynccommitteecontributions_test.go
+++ b/services/submitter/multinode/submitsynccommitteecontributions_test.go
@@ -1,0 +1,238 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitSyncCommitteeContributionsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(2*time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeContributions(ctx, []*altair.SignedContributionAndProof{})
+	require.EqualError(t, err, "no sync committee contribution and proofs supplied")
+}
+
+func TestSubmitSyncCommitteeContributions(t *testing.T) {
+	ctx := context.Background()
+
+	capture := logger.NewLogCapture()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeContributions(ctx, []*altair.SignedContributionAndProof{
+		{
+			Message: &altair.ContributionAndProof{
+				Contribution: &altair.SyncCommitteeContribution{
+					Slot: 5,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	capture.AssertHasEntry(t, "Submitted sync committee contribution and proofs")
+}
+
+func TestSubmitSyncCommitteeContributionsErroring(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewErroringSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeContributions(ctx, []*altair.SignedContributionAndProof{
+		{
+			Message: &altair.ContributionAndProof{
+				Contribution: &altair.SyncCommitteeContribution{
+					Slot: 5,
+				},
+			},
+		},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitSyncCommitteeContributionsSleepy(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSleepySyncCommitteeContributionsSubmitter(200*time.Millisecond, mock.NewSyncCommitteeContributionsSubmitter()),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeContributions(ctx, []*altair.SignedContributionAndProof{
+		{
+			Message: &altair.ContributionAndProof{
+				Contribution: &altair.SyncCommitteeContribution{
+					Slot: 5,
+				},
+			},
+		},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitSyncCommitteeContributionsSleepySuccess(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(200*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSleepySyncCommitteeContributionsSubmitter(100*time.Millisecond, mock.NewSyncCommitteeContributionsSubmitter()),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeContributions(ctx, []*altair.SignedContributionAndProof{
+		{
+			Message: &altair.ContributionAndProof{
+				Contribution: &altair.SyncCommitteeContribution{
+					Slot: 5,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+}

--- a/services/submitter/multinode/submitsynccommitteemessages_test.go
+++ b/services/submitter/multinode/submitsynccommitteemessages_test.go
@@ -1,0 +1,214 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitSyncCommitteeMessagesEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(2*time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeMessages(ctx, []*altair.SyncCommitteeMessage{})
+	require.EqualError(t, err, "no sync committee messages supplied")
+}
+
+func TestSubmitSyncCommitteeMessages(t *testing.T) {
+	ctx := context.Background()
+
+	capture := logger.NewLogCapture()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeMessages(ctx, []*altair.SyncCommitteeMessage{
+		{},
+	})
+	require.NoError(t, err)
+	capture.AssertHasEntry(t, "Submitted sync committee messages")
+}
+
+func TestSubmitSyncCommitteeMessagesErroring(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewErroringSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeMessages(ctx, []*altair.SyncCommitteeMessage{
+		{},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitSyncCommitteeMessagesSleepy(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSleepySyncCommitteeMessagesSubmitter(200*time.Millisecond, mock.NewSyncCommitteeMessagesSubmitter()),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeMessages(ctx, []*altair.SyncCommitteeMessage{
+		{},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitSyncCommitteeMessagesSleepySuccess(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(200*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSleepySyncCommitteeMessagesSubmitter(100*time.Millisecond, mock.NewSyncCommitteeMessagesSubmitter()),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeMessages(ctx, []*altair.SyncCommitteeMessage{
+		{},
+	})
+	require.NoError(t, err)
+}

--- a/services/submitter/multinode/submitsynccommitteesubscriptions_test.go
+++ b/services/submitter/multinode/submitsynccommitteesubscriptions_test.go
@@ -1,0 +1,214 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitSyncCommitteeSubscriptionsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(2*time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeSubscriptions(ctx, []*api.SyncCommitteeSubscription{})
+	require.EqualError(t, err, "no sync committee subscriptions supplied")
+}
+
+func TestSubmitSyncCommitteeSubscriptions(t *testing.T) {
+	ctx := context.Background()
+
+	capture := logger.NewLogCapture()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeSubscriptions(ctx, []*api.SyncCommitteeSubscription{
+		{},
+	})
+	require.NoError(t, err)
+	capture.AssertHasEntry(t, "Submitted sync committee subscriptions")
+}
+
+func TestSubmitSyncCommitteeSubscriptionsErroring(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewErroringSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeSubscriptions(ctx, []*api.SyncCommitteeSubscription{
+		{},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitSyncCommitteeSubscriptionsSleepy(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(100*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSleepySyncCommitteeSubscriptionsSubmitter(200*time.Millisecond, mock.NewSyncCommitteeSubscriptionsSubmitter()),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeSubscriptions(ctx, []*api.SyncCommitteeSubscription{
+		{},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+}
+
+func TestSubmitSyncCommitteeSubscriptionsSleepySuccess(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := multinode.New(context.Background(),
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(200*time.Millisecond),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"1": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconBlockSubmitters(map[string]eth2client.BeaconBlockSubmitter{
+			"1": mock.NewBeaconBlockSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"1": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"1": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"1": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"1": mock.NewSleepySyncCommitteeSubscriptionsSubmitter(100*time.Millisecond, mock.NewSyncCommitteeSubscriptionsSubmitter()),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"1": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = s.SubmitSyncCommitteeSubscriptions(ctx, []*api.SyncCommitteeSubscription{
+		{},
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
The multinode submitter waited for all nodes to respond to it before returning, resulting in artifically high response times.  This now returns after the first successful result, which provides a more accurate metric for tracking the successful submission of the relevant data to the network.