### PR TITLE
Clean up beacon committee subscriptions.

### DIFF
--- a/main.go
+++ b/main.go
@@ -408,6 +408,7 @@ func startServices(ctx context.Context, majordomo majordomo.Service) error {
 		standardbeaconcommitteesubscriber.WithLogLevel(util.LogLevel("beaconcommiteesubscriber")),
 		standardbeaconcommitteesubscriber.WithProcessConcurrency(util.ProcessConcurrency("beaconcommitteesubscriber")),
 		standardbeaconcommitteesubscriber.WithMonitor(monitor.(metrics.BeaconCommitteeSubscriptionMonitor)),
+		standardbeaconcommitteesubscriber.WithChainTimeService(chainTime),
 		standardbeaconcommitteesubscriber.WithAttesterDutiesProvider(eth2Client.(eth2client.AttesterDutiesProvider)),
 		standardbeaconcommitteesubscriber.WithAttestationAggregator(attestationAggregator),
 		standardbeaconcommitteesubscriber.WithBeaconCommitteeSubmitter(submitterStrategy.(submitter.BeaconCommitteeSubscriptionsSubmitter)),

--- a/services/beaconcommitteesubscriber/standard/parameters.go
+++ b/services/beaconcommitteesubscriber/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2022 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,6 +16,7 @@ package standard
 import (
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/vouch/services/attestationaggregator"
+	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/metrics"
 	"github.com/attestantio/vouch/services/submitter"
 	"github.com/pkg/errors"
@@ -26,6 +27,7 @@ type parameters struct {
 	logLevel                 zerolog.Level
 	processConcurrency       int64
 	monitor                  metrics.BeaconCommitteeSubscriptionMonitor
+	chainTimeService         chaintime.Service
 	attesterDutiesProvider   eth2client.AttesterDutiesProvider
 	beaconCommitteeSubmitter submitter.BeaconCommitteeSubscriptionsSubmitter
 	attestationAggregator    attestationaggregator.Service
@@ -60,6 +62,13 @@ func WithProcessConcurrency(concurrency int64) Parameter {
 func WithMonitor(monitor metrics.BeaconCommitteeSubscriptionMonitor) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.monitor = monitor
+	})
+}
+
+// WithChainTimeService sets the chaintime service.
+func WithChainTimeService(service chaintime.Service) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.chainTimeService = service
 	})
 }
 
@@ -100,6 +109,9 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	}
 	if parameters.monitor == nil {
 		return nil, errors.New("no monitor specified")
+	}
+	if parameters.chainTimeService == nil {
+		return nil, errors.New("no chain time service specified")
 	}
 	if parameters.attesterDutiesProvider == nil {
 		return nil, errors.New("no attester duties provider specified")

--- a/services/beaconcommitteesubscriber/standard/service.go
+++ b/services/beaconcommitteesubscriber/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2022 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,28 +15,21 @@ package standard
 
 import (
 	"context"
-	"sync"
-	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
-	api "github.com/attestantio/go-eth2-client/api/v1"
-	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/attestationaggregator"
-	"github.com/attestantio/vouch/services/attester"
-	"github.com/attestantio/vouch/services/beaconcommitteesubscriber"
+	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/metrics"
 	"github.com/attestantio/vouch/services/submitter"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	zerologger "github.com/rs/zerolog/log"
-	"github.com/sasha-s/go-deadlock"
-	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
-	"golang.org/x/sync/semaphore"
 )
 
 // Service is an beacon committee subscriber.
 type Service struct {
 	monitor                metrics.BeaconCommitteeSubscriptionMonitor
+	chainTimeService       chaintime.Service
 	processConcurrency     int64
 	attesterDutiesProvider eth2client.AttesterDutiesProvider
 	attestationAggregator  attestationaggregator.Service
@@ -62,6 +55,7 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 	s := &Service{
 		processConcurrency:     parameters.processConcurrency,
 		monitor:                parameters.monitor,
+		chainTimeService:       parameters.chainTimeService,
 		attesterDutiesProvider: parameters.attesterDutiesProvider,
 		attestationAggregator:  parameters.attestationAggregator,
 		submitter:              parameters.beaconCommitteeSubmitter,
@@ -69,180 +63,4 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 	log.Trace().Int64("process_concurrency", s.processConcurrency).Msg("Set process concurrency")
 
 	return s, nil
-}
-
-// Subscribe subscribes to beacon committees for a given epoch.
-// This returns data about the subnets to which we are subscribing.
-func (s *Service) Subscribe(ctx context.Context,
-	epoch phase0.Epoch,
-	accounts map[phase0.ValidatorIndex]e2wtypes.Account,
-) (map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription, error) {
-	if len(accounts) == 0 {
-		// Nothing to do.
-		return map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription{}, nil
-	}
-
-	started := time.Now()
-	log := log.With().Uint64("epoch", uint64(epoch)).Logger()
-	log.Trace().Msg("Subscribing")
-
-	validatorIndices := make([]phase0.ValidatorIndex, 0, len(accounts))
-	for index := range accounts {
-		validatorIndices = append(validatorIndices, index)
-	}
-	attesterDuties, err := s.attesterDutiesProvider.AttesterDuties(ctx, epoch, validatorIndices)
-	if err != nil {
-		s.monitor.BeaconCommitteeSubscriptionCompleted(started, "failed")
-		return nil, errors.Wrap(err, "failed to obtain attester duties")
-	}
-
-	log.Trace().Dur("elapsed", time.Since(started)).Int("accounts", len(validatorIndices)).Msg("Fetched attester duties")
-	duties, err := attester.MergeDuties(ctx, attesterDuties)
-	if err != nil {
-		s.monitor.BeaconCommitteeSubscriptionCompleted(started, "failed")
-		return nil, errors.Wrap(err, "failed to merge attester duties")
-	}
-
-	subscriptionInfo, err := s.calculateSubscriptionInfo(ctx, accounts, duties)
-	if err != nil {
-		s.monitor.BeaconCommitteeSubscriptionCompleted(started, "failed")
-		return nil, errors.Wrap(err, "failed to calculate subscription duties")
-	}
-	log.Trace().Dur("elapsed", time.Since(started)).Msg("Calculated subscription info")
-
-	// Update metrics.
-	subscriptions := 0
-	aggregators := 0
-	for _, v := range subscriptionInfo {
-		for _, v2 := range v {
-			subscriptions++
-			if v2.IsAggregator {
-				aggregators++
-			}
-		}
-	}
-	s.monitor.BeaconCommitteeSubscribers(subscriptions)
-	s.monitor.BeaconCommitteeAggregators(aggregators)
-
-	// Submit the subscription information.
-	go func() {
-		log.Trace().Msg("Submitting subscription")
-		subscriptions := make([]*api.BeaconCommitteeSubscription, 0, len(duties))
-		for slot, slotInfo := range subscriptionInfo {
-			for committeeIndex, info := range slotInfo {
-				subscriptions = append(subscriptions, &api.BeaconCommitteeSubscription{
-					ValidatorIndex:   info.Duty.ValidatorIndex,
-					Slot:             slot,
-					CommitteeIndex:   committeeIndex,
-					CommitteesAtSlot: info.Duty.CommitteesAtSlot,
-					IsAggregator:     info.IsAggregator,
-				})
-			}
-		}
-		if err := s.submitter.SubmitBeaconCommitteeSubscriptions(ctx, subscriptions); err != nil {
-			log.Error().Err(err).Msg("Failed to submit beacon committees")
-			s.monitor.BeaconCommitteeSubscriptionCompleted(started, "failed")
-			return
-		}
-		log.Trace().Dur("elapsed", time.Since(started)).Msg("Submitted subscription request")
-		s.monitor.BeaconCommitteeSubscriptionCompleted(started, "succeeded")
-	}()
-
-	// Return the subscription info so the calling function knows the subnets to which we are subscribing.
-	return subscriptionInfo, nil
-}
-
-// calculateSubscriptionInfo calculates our beacon block attesation subnet requirements given a set of duties.
-// It returns a map of slot => committee => subscription information.
-func (s *Service) calculateSubscriptionInfo(ctx context.Context,
-	accounts map[phase0.ValidatorIndex]e2wtypes.Account,
-	duties []*attester.Duty,
-) (map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription, error) {
-
-	// Map is slot => committee => info.
-	subscriptionInfo := make(map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription)
-	subscriptionInfoMutex := deadlock.RWMutex{}
-
-	//	// Map is validator ID => account.
-	//	accountMap := make(map[phase0.ValidatorIndex]accountmanager.ValidatingAccount, len(accounts))
-	//	for _, account := range accounts {
-	//		index, err := account.Index(ctx)
-	//		if err != nil {
-	//			log.Warn().Err(err).Msg("Failed to obtain account index for account map")
-	//			continue
-	//		}
-	//		accountMap[index] = account
-	//	}
-
-	// Gather aggregators info in parallel.
-	// Note that it is possible for two validators to be aggregating for the same (slot,committee index) tuple, however
-	// once we have a validator aggregating for a tuple we ignore subsequent validators with the same tuple.
-	sem := semaphore.NewWeighted(s.processConcurrency)
-	var wg sync.WaitGroup
-	for _, duty := range duties {
-		wg.Add(1)
-		go func(ctx context.Context, sem *semaphore.Weighted, wg *sync.WaitGroup, duty *attester.Duty) {
-			defer wg.Done()
-			for i := range duty.ValidatorIndices() {
-				wg.Add(1)
-				go func(ctx context.Context, sem *semaphore.Weighted, wg *sync.WaitGroup, duty *attester.Duty, i int) {
-					defer wg.Done()
-					if err := sem.Acquire(ctx, 1); err != nil {
-						log.Error().Err(err).Msg("Failed to obtain semaphore")
-						return
-					}
-					defer sem.Release(1)
-					subscriptionInfoMutex.RLock()
-					info, exists := subscriptionInfo[duty.Slot()][duty.CommitteeIndices()[i]]
-					subscriptionInfoMutex.RUnlock()
-					if exists && info.IsAggregator {
-						// Already an aggregator for this slot/committee; don't need to go further.
-						return
-					}
-					isAggregator, signature, err := s.attestationAggregator.(attestationaggregator.IsAggregatorProvider).
-						IsAggregator(ctx,
-							duty.ValidatorIndices()[i],
-							duty.Slot(),
-							duty.CommitteeSize(duty.CommitteeIndices()[i]))
-					if err != nil {
-						log.Error().
-							Uint64("slot", uint64(duty.Slot())).
-							Uint64("validator_index", uint64(duty.ValidatorIndices()[i])).
-							Err(err).
-							Msg("Failed to calculate if validator is an aggregator")
-						return
-					}
-					// Obtain composite public key if available, otherwise standard public key.
-					account := accounts[duty.ValidatorIndices()[i]]
-					var pubKey phase0.BLSPubKey
-					if provider, isProvider := account.(e2wtypes.AccountCompositePublicKeyProvider); isProvider {
-						copy(pubKey[:], provider.CompositePublicKey().Marshal())
-					} else {
-						copy(pubKey[:], account.PublicKey().Marshal())
-					}
-					subscriptionInfoMutex.Lock()
-					if _, exists := subscriptionInfo[duty.Slot()]; !exists {
-						subscriptionInfo[duty.Slot()] = make(map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription)
-					}
-					subscriptionInfo[duty.Slot()][duty.CommitteeIndices()[i]] = &beaconcommitteesubscriber.Subscription{
-						Duty: &api.AttesterDuty{
-							PubKey:                  pubKey,
-							Slot:                    duty.Slot(),
-							ValidatorIndex:          duty.ValidatorIndices()[i],
-							CommitteeIndex:          duty.CommitteeIndices()[i],
-							CommitteeLength:         duty.CommitteeSize(duty.CommitteeIndices()[i]),
-							CommitteesAtSlot:        duty.CommitteesAtSlot(),
-							ValidatorCommitteeIndex: duty.ValidatorCommitteeIndices()[i],
-						},
-						IsAggregator: isAggregator,
-						Signature:    signature,
-					}
-					subscriptionInfoMutex.Unlock()
-				}(ctx, sem, wg, duty, i)
-			}
-		}(ctx, sem, &wg, duty)
-	}
-	wg.Wait()
-
-	return subscriptionInfo, nil
 }

--- a/services/beaconcommitteesubscriber/standard/service_test.go
+++ b/services/beaconcommitteesubscriber/standard/service_test.go
@@ -1,0 +1,149 @@
+// Copyright © 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/vouch/mock"
+	mockattestationaggregator "github.com/attestantio/vouch/services/attestationaggregator/mock"
+	"github.com/attestantio/vouch/services/beaconcommitteesubscriber/standard"
+	standardchaintime "github.com/attestantio/vouch/services/chaintime/standard"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService(t *testing.T) {
+	ctx := context.Background()
+
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisTimeProvider(mock.NewGenesisTimeProvider(time.Now())),
+		standardchaintime.WithSlotDurationProvider(mock.NewSlotDurationProvider(12*time.Second)),
+		standardchaintime.WithSlotsPerEpochProvider(mock.NewSlotsPerEpochProvider(32)),
+	)
+	require.NoError(t, err)
+
+	attesterDutiesProvider := mock.NewAttesterDutiesProvider()
+	beaconCommitteesSubmitter := mock.NewBeaconCommitteeSubscriptionsSubmitter()
+	attestationAggregator := mockattestationaggregator.New()
+
+	tests := []struct {
+		name     string
+		params   []standard.Parameter
+		err      string
+		logEntry string
+	}{
+		{
+			name: "ProcessConcurrencyZero",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithProcessConcurrency(0),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithChainTimeService(chainTime),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithBeaconCommitteeSubmitter(beaconCommitteesSubmitter),
+				standard.WithAttestationAggregator(attestationAggregator),
+			},
+			err: "problem with parameters: no process concurrency specified",
+		},
+		{
+			name: "MonitorMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithProcessConcurrency(2),
+				standard.WithMonitor(nil),
+				standard.WithChainTimeService(chainTime),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithBeaconCommitteeSubmitter(beaconCommitteesSubmitter),
+				standard.WithAttestationAggregator(attestationAggregator),
+			},
+			err: "problem with parameters: no monitor specified",
+		},
+		{
+			name: "ChainTimeServiceMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithProcessConcurrency(2),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithBeaconCommitteeSubmitter(beaconCommitteesSubmitter),
+				standard.WithAttestationAggregator(attestationAggregator),
+			},
+			err: "problem with parameters: no chain time service specified",
+		},
+		{
+			name: "AttesterDutiesProviderMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithProcessConcurrency(2),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithChainTimeService(chainTime),
+				standard.WithBeaconCommitteeSubmitter(beaconCommitteesSubmitter),
+				standard.WithAttestationAggregator(attestationAggregator),
+			},
+			err: "problem with parameters: no attester duties provider specified",
+		},
+		{
+			name: "BeaconCommitteeSubmitterMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithProcessConcurrency(2),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithChainTimeService(chainTime),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithAttestationAggregator(attestationAggregator),
+			},
+			err: "problem with parameters: no beacon committee submitter specified",
+		},
+		{
+			name: "AttestationAggregatorMissing",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithProcessConcurrency(2),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithChainTimeService(chainTime),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithBeaconCommitteeSubmitter(beaconCommitteesSubmitter),
+			},
+			err: "problem with parameters: no attestation aggregator specified",
+		},
+		{
+			name: "Good",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithProcessConcurrency(2),
+				standard.WithMonitor(nullmetrics.New(ctx)),
+				standard.WithChainTimeService(chainTime),
+				standard.WithAttesterDutiesProvider(attesterDutiesProvider),
+				standard.WithBeaconCommitteeSubmitter(beaconCommitteesSubmitter),
+				standard.WithAttestationAggregator(attestationAggregator),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := standard.New(ctx, test.params...)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/services/beaconcommitteesubscriber/standard/subscribe.go
+++ b/services/beaconcommitteesubscriber/standard/subscribe.go
@@ -1,0 +1,199 @@
+// Copyright © 2020, 2022 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/attestationaggregator"
+	"github.com/attestantio/vouch/services/attester"
+	"github.com/attestantio/vouch/services/beaconcommitteesubscriber"
+	"github.com/pkg/errors"
+	"github.com/sasha-s/go-deadlock"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+	"golang.org/x/sync/semaphore"
+)
+
+// Subscribe subscribes to beacon committees for a given epoch.
+// This returns data about the subnets to which we are subscribing.
+func (s *Service) Subscribe(ctx context.Context,
+	epoch phase0.Epoch,
+	accounts map[phase0.ValidatorIndex]e2wtypes.Account,
+) (map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription, error) {
+	if len(accounts) == 0 {
+		// Nothing to do.
+		return map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription{}, nil
+	}
+
+	started := time.Now()
+	log := log.With().Uint64("epoch", uint64(epoch)).Logger()
+	log.Trace().Msg("Subscribing")
+
+	validatorIndices := make([]phase0.ValidatorIndex, 0, len(accounts))
+	for index := range accounts {
+		validatorIndices = append(validatorIndices, index)
+	}
+	attesterDuties, err := s.attesterDutiesProvider.AttesterDuties(ctx, epoch, validatorIndices)
+	if err != nil {
+		s.monitor.BeaconCommitteeSubscriptionCompleted(started, "failed")
+		return nil, errors.Wrap(err, "failed to obtain attester duties")
+	}
+
+	log.Trace().Dur("elapsed", time.Since(started)).Int("accounts", len(validatorIndices)).Msg("Fetched attester duties")
+	duties, err := attester.MergeDuties(ctx, attesterDuties)
+	if err != nil {
+		s.monitor.BeaconCommitteeSubscriptionCompleted(started, "failed")
+		return nil, errors.Wrap(err, "failed to merge attester duties")
+	}
+
+	subscriptionInfo, err := s.calculateSubscriptionInfo(ctx, accounts, duties)
+	if err != nil {
+		s.monitor.BeaconCommitteeSubscriptionCompleted(started, "failed")
+		return nil, errors.Wrap(err, "failed to calculate subscription duties")
+	}
+	log.Trace().Dur("elapsed", time.Since(started)).Msg("Calculated subscription info")
+
+	// Update metrics.
+	subscriptions := 0
+	aggregators := 0
+	for _, v := range subscriptionInfo {
+		for _, v2 := range v {
+			subscriptions++
+			if v2.IsAggregator {
+				aggregators++
+			}
+		}
+	}
+	s.monitor.BeaconCommitteeSubscribers(subscriptions)
+	s.monitor.BeaconCommitteeAggregators(aggregators)
+
+	// Submit the subscription information.
+	go func(currentSlot phase0.Slot) {
+		log.Trace().Msg("Submitting subscription")
+		subscriptions := make([]*api.BeaconCommitteeSubscription, 0, len(duties))
+		for slot, slotInfo := range subscriptionInfo {
+			if slot <= currentSlot {
+				log.Trace().Uint64("current_slot", uint64(currentSlot)).Uint64("duty_slot", uint64(slot)).Msg("Subscription not for a future slot; ignoring")
+				return
+			}
+			for committeeIndex, info := range slotInfo {
+				subscriptions = append(subscriptions, &api.BeaconCommitteeSubscription{
+					ValidatorIndex:   info.Duty.ValidatorIndex,
+					Slot:             slot,
+					CommitteeIndex:   committeeIndex,
+					CommitteesAtSlot: info.Duty.CommitteesAtSlot,
+					IsAggregator:     info.IsAggregator,
+				})
+			}
+		}
+		if err := s.submitter.SubmitBeaconCommitteeSubscriptions(ctx, subscriptions); err != nil {
+			log.Error().Err(err).Msg("Failed to submit beacon committees")
+			s.monitor.BeaconCommitteeSubscriptionCompleted(started, "failed")
+			return
+		}
+		log.Trace().Dur("elapsed", time.Since(started)).Msg("Submitted subscription request")
+		s.monitor.BeaconCommitteeSubscriptionCompleted(started, "succeeded")
+	}(s.chainTimeService.CurrentSlot())
+
+	// Return the subscription info so the calling function knows the subnets to which we are subscribing.
+	return subscriptionInfo, nil
+}
+
+// calculateSubscriptionInfo calculates our beacon block attesation subnet requirements given a set of duties.
+// It returns a map of slot => committee => subscription information.
+func (s *Service) calculateSubscriptionInfo(ctx context.Context,
+	accounts map[phase0.ValidatorIndex]e2wtypes.Account,
+	duties []*attester.Duty,
+) (map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription, error) {
+
+	// Map is slot => committee => info.
+	subscriptionInfo := make(map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription)
+	subscriptionInfoMutex := deadlock.RWMutex{}
+
+	// Gather aggregators info in parallel.
+	// Note that it is possible for two validators to be aggregating for the same (slot,committee index) tuple, however
+	// once we have a validator aggregating for a tuple we ignore subsequent validators with the same tuple.
+	sem := semaphore.NewWeighted(s.processConcurrency)
+	var wg sync.WaitGroup
+	for _, duty := range duties {
+		wg.Add(1)
+		go func(ctx context.Context, sem *semaphore.Weighted, wg *sync.WaitGroup, duty *attester.Duty) {
+			defer wg.Done()
+			for i := range duty.ValidatorIndices() {
+				wg.Add(1)
+				go func(ctx context.Context, sem *semaphore.Weighted, wg *sync.WaitGroup, duty *attester.Duty, i int) {
+					defer wg.Done()
+					if err := sem.Acquire(ctx, 1); err != nil {
+						log.Error().Err(err).Msg("Failed to obtain semaphore")
+						return
+					}
+					defer sem.Release(1)
+					subscriptionInfoMutex.RLock()
+					info, exists := subscriptionInfo[duty.Slot()][duty.CommitteeIndices()[i]]
+					subscriptionInfoMutex.RUnlock()
+					if exists && info.IsAggregator {
+						// Already an aggregator for this slot/committee; don't need to go further.
+						return
+					}
+					isAggregator, signature, err := s.attestationAggregator.(attestationaggregator.IsAggregatorProvider).
+						IsAggregator(ctx,
+							duty.ValidatorIndices()[i],
+							duty.Slot(),
+							duty.CommitteeSize(duty.CommitteeIndices()[i]))
+					if err != nil {
+						log.Error().
+							Uint64("slot", uint64(duty.Slot())).
+							Uint64("validator_index", uint64(duty.ValidatorIndices()[i])).
+							Err(err).
+							Msg("Failed to calculate if validator is an aggregator")
+						return
+					}
+					// Obtain composite public key if available, otherwise standard public key.
+					account := accounts[duty.ValidatorIndices()[i]]
+					var pubKey phase0.BLSPubKey
+					if provider, isProvider := account.(e2wtypes.AccountCompositePublicKeyProvider); isProvider {
+						copy(pubKey[:], provider.CompositePublicKey().Marshal())
+					} else {
+						copy(pubKey[:], account.PublicKey().Marshal())
+					}
+					subscriptionInfoMutex.Lock()
+					if _, exists := subscriptionInfo[duty.Slot()]; !exists {
+						subscriptionInfo[duty.Slot()] = make(map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription)
+					}
+					subscriptionInfo[duty.Slot()][duty.CommitteeIndices()[i]] = &beaconcommitteesubscriber.Subscription{
+						Duty: &api.AttesterDuty{
+							PubKey:                  pubKey,
+							Slot:                    duty.Slot(),
+							ValidatorIndex:          duty.ValidatorIndices()[i],
+							CommitteeIndex:          duty.CommitteeIndices()[i],
+							CommitteeLength:         duty.CommitteeSize(duty.CommitteeIndices()[i]),
+							CommitteesAtSlot:        duty.CommitteesAtSlot(),
+							ValidatorCommitteeIndex: duty.ValidatorCommitteeIndices()[i],
+						},
+						IsAggregator: isAggregator,
+						Signature:    signature,
+					}
+					subscriptionInfoMutex.Unlock()
+				}(ctx, sem, wg, duty, i)
+			}
+		}(ctx, sem, &wg, duty)
+	}
+	wg.Wait()
+
+	return subscriptionInfo, nil
+}


### PR DESCRIPTION
Beacon committee subscriptions were sending requests for all slots, including slots that occurred in the past during startup.  This cleans up the subscription request, only sending future slots at the time of sending.