### PR TITLE
Add target scoring for block proposals.

### DIFF
--- a/strategies/beaconblockproposal/best/score.go
+++ b/strategies/beaconblockproposal/best/score.go
@@ -137,9 +137,8 @@ func (s *Service) scoreAltairBeaconBlockProposal(ctx context.Context,
 
 		priorVotes, err := s.priorVotesForAttestation(ctx, attestation, blockProposal.ParentRoot)
 		if err != nil {
-			log.Warn().Err(err).Msg("Failed to obtain prior votes for attestation; assuming no votes")
+			log.Debug().Err(err).Msg("Failed to obtain prior votes for attestation; assuming no votes")
 		}
-		log.Trace().Str("prior_votes", fmt.Sprintf("%#x", priorVotes.Bytes())).Msg("Prior votes")
 
 		votes := 0
 		for i := uint64(0); i < attestation.AggregationBits.Len(); i++ {
@@ -160,24 +159,27 @@ func (s *Service) scoreAltairBeaconBlockProposal(ctx context.Context,
 		// Now we know how many new votes are in this attestation we can score it.
 		// We can calculate if the head vote is correct, but not target so for the
 		// purposes of the calculation we assume that it is.
-		switch blockProposal.Slot - attestation.Data.Slot {
-		case 1:
-			// If the attesation was for the past slot we know that the head vote
-			// can only be correct if it matches the parent root in the block.
-			score := float64(votes)
-			if bytes.Equal(blockProposal.ParentRoot[:], attestation.Data.BeaconBlockRoot[:]) {
-				score *= float64(s.timelySourceWeight+s.timelyTargetWeight+s.timelyHeadWeight) / float64(s.weightDenominator)
-			} else {
-				score *= float64(s.timelySourceWeight+s.timelyTargetWeight) / float64(s.weightDenominator)
-			}
-			attestationScore += score
+
+		headCorrect := altairHeadCorrect(blockProposal, attestation)
+		targetCorrect := s.altairTargetCorrect(ctx, attestation)
+		inclusionDistance := blockProposal.Slot - attestation.Data.Slot
+
+		score := 0.0
+		if targetCorrect {
+			// Target is correct (and timely).
+			score += float64(s.timelyTargetWeight) / float64(s.weightDenominator)
+		}
+		if inclusionDistance <= 5 {
+			// Source is timely.
+			score += float64(s.timelySourceWeight) / float64(s.weightDenominator)
+		}
+		if headCorrect && inclusionDistance == 1 {
+			score += float64(s.timelyHeadWeight) / float64(s.weightDenominator)
+		}
+		score *= float64(votes)
+		attestationScore += score
+		if inclusionDistance == 1 {
 			immediateAttestationScore += score
-		case 2, 3, 4, 5:
-			// Head vote is no longer timely; source and target counts.
-			attestationScore += float64(votes) * float64(s.timelySourceWeight+s.timelyTargetWeight) / float64(s.weightDenominator)
-		default:
-			// Head and source votes are no longer timely; target counts.
-			attestationScore += float64(votes) * float64(s.timelyTargetWeight) / float64(s.weightDenominator)
 		}
 	}
 
@@ -270,6 +272,35 @@ func (s *Service) priorVotesForAttestation(_ context.Context,
 	}
 
 	return res, nil
+}
+
+// altairHeadCorrect calculates if the head of an Altair attestation is correct.
+func altairHeadCorrect(blockProposal *altair.BeaconBlock, attestation *phase0.Attestation) bool {
+	return bytes.Equal(blockProposal.ParentRoot[:], attestation.Data.BeaconBlockRoot[:])
+}
+
+// altairTargetCorrect calculates if the target of an Altair attestation is correct.
+func (s *Service) altairTargetCorrect(ctx context.Context,
+	attestation *phase0.Attestation,
+) bool {
+	s.priorBlocksMu.RLock()
+	defer s.priorBlocksMu.RUnlock()
+	root := attestation.Data.BeaconBlockRoot
+	maxSlot := s.chainTime.FirstSlotOfEpoch(attestation.Data.Target.Epoch)
+	for {
+		priorBlock, exists := s.priorBlocks[root]
+		if !exists {
+			// We don't have data on this block, assume the target is correct.
+			// (We could assume the target is incorrect in this situation, but that
+			// would give false incorrects whilst the prior block cache warms up.)
+			log.Trace().Uint64("attestation_slot", uint64(attestation.Data.Slot)).Uint64("max_slot", uint64(maxSlot)).Str("root", fmt.Sprintf("%#x", root)).Msg("Root does not exist, assuming true")
+			return true
+		}
+		if priorBlock.slot <= maxSlot {
+			return bytes.Equal(attestation.Data.Target.Root[:], priorBlock.root[:])
+		}
+		root = priorBlock.parent
+	}
 }
 
 // intersection returns a list of items common between the two sets.

--- a/strategies/beaconblockproposal/best/score.go
+++ b/strategies/beaconblockproposal/best/score.go
@@ -280,7 +280,7 @@ func altairHeadCorrect(blockProposal *altair.BeaconBlock, attestation *phase0.At
 }
 
 // altairTargetCorrect calculates if the target of an Altair attestation is correct.
-func (s *Service) altairTargetCorrect(ctx context.Context,
+func (s *Service) altairTargetCorrect(_ context.Context,
 	attestation *phase0.Attestation,
 ) bool {
 	s.priorBlocksMu.RLock()

--- a/strategies/beaconblockproposal/best/score_internal_test.go
+++ b/strategies/beaconblockproposal/best/score_internal_test.go
@@ -80,6 +80,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -101,6 +105,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -122,6 +130,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12343,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -143,12 +155,20 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(2, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 							{
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12341,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -170,6 +190,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(50, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -201,12 +225,20 @@ func TestScore(t *testing.T) {
 								AggregationBits: specificAggregationBits([]uint64{1, 2, 3}, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 							{
 								AggregationBits: specificAggregationBits([]uint64{2, 3, 4}, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -228,6 +260,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(50, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -283,6 +319,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(50, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -338,6 +378,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(50, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -393,6 +437,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -417,7 +465,11 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot:            12344,
-									BeaconBlockRoot: testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"),
+									BeaconBlockRoot: testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"),
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -442,6 +494,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12343,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -466,6 +522,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12340,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0404040404040404040404040404040404040404040404040404040404040404"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -490,6 +550,10 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12339,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x0707070707070707070707070707070707070707070707070707070707070707"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -514,12 +578,20 @@ func TestScore(t *testing.T) {
 								AggregationBits: bitList(1, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12343,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x4343434343434343434343434343434343434343434343434343434343434343"),
+										Epoch: 385,
+									},
 								},
 							},
 							{
 								AggregationBits: bitList(2, 128),
 								Data: &phase0.AttestationData{
 									Slot: 12343,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x4343434343434343434343434343434343434343434343434343434343434343"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -533,15 +605,56 @@ func TestScore(t *testing.T) {
 			score:      1.25,
 		},
 		{
+			name: "AltairParentMissing",
+			block: &spec.VersionedBeaconBlock{
+				Version: spec.DataVersionAltair,
+				Altair: &altair.BeaconBlock{
+					Slot:       12345,
+					ParentRoot: testutil.HexToRoot("0x1111111111111111111111111111111111111111111111111111111111111111"),
+					Body: &altair.BeaconBlockBody{
+						Attestations: []*phase0.Attestation{
+							{
+								AggregationBits: bitList(1, 128),
+								Data: &phase0.AttestationData{
+									Slot:            12344,
+									BeaconBlockRoot: testutil.HexToRoot("0x1111111111111111111111111111111111111111111111111111111111111111"),
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"),
+										Epoch: 385,
+									},
+								},
+							},
+							{
+								AggregationBits: bitList(1, 128),
+								Data: &phase0.AttestationData{
+									Slot:            12343,
+									BeaconBlockRoot: testutil.HexToRoot("0x1111111111111111111111111111111111111111111111111111111111111111"),
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x4343434343434343434343434343434343434343434343434343434343434343"),
+										Epoch: 385,
+									},
+								},
+							},
+						},
+						SyncAggregate: &altair.SyncAggregate{
+							SyncCommitteeBits: bitfield.NewBitvector512(),
+						},
+					},
+				},
+			},
+			parentSlot: 12343,
+			score:      0.84375 + 0.625,
+		},
+		{
 			name: "PriorVotes",
 			priorBlocks: map[phase0.Root]*priorBlockVotes{
 				// Chain with middle block orphaned.
-				testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"): {
-					parent: testutil.HexToRoot("0x0000000000000000000000000000000000000000000000000000000000000000"),
+				testutil.HexToRoot("0x4141414141414141414141414141414141414141414141414141414141414141"): {
+					parent: testutil.HexToRoot("0x4040404040404040404040404040404040404040404040404040404040404040"),
 					slot:   12341,
 				},
-				testutil.HexToRoot("0x0202020202020202020202020202020202020202020202020202020202020202"): {
-					parent: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+				testutil.HexToRoot("0x4242424242424242424242424242424242424242424242424242424242424242"): {
+					parent: testutil.HexToRoot("0x4141414141414141414141414141414141414141414141414141414141414141"),
 					slot:   12342,
 					votes: map[phase0.Slot]map[phase0.CommitteeIndex]bitfield.Bitlist{
 						// This block is orphaned so its votes should be ignored.
@@ -550,8 +663,8 @@ func TestScore(t *testing.T) {
 						},
 					},
 				},
-				testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"): {
-					parent: testutil.HexToRoot("0x0101010101010101010101010101010101010101010101010101010101010101"),
+				testutil.HexToRoot("0x4343434343434343434343434343434343434343434343434343434343434343"): {
+					parent: testutil.HexToRoot("0x4141414141414141414141414141414141414141414141414141414141414141"),
 					slot:   12343,
 					votes: map[phase0.Slot]map[phase0.CommitteeIndex]bitfield.Bitlist{
 						// This block is a recent ancestore so its votes should be considered.
@@ -565,14 +678,18 @@ func TestScore(t *testing.T) {
 				Version: spec.DataVersionAltair,
 				Altair: &altair.BeaconBlock{
 					Slot:       12344,
-					ParentRoot: testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+					ParentRoot: testutil.HexToRoot("0x4343434343434343434343434343434343434343434343434343434343434343"),
 					Body: &altair.BeaconBlockBody{
 						Attestations: []*phase0.Attestation{
 							{
 								AggregationBits: bitList(5, 128),
 								Data: &phase0.AttestationData{
-									BeaconBlockRoot: testutil.HexToRoot("0x0303030303030303030303030303030303030303030303030303030303030303"),
+									BeaconBlockRoot: testutil.HexToRoot("0x4242424242424242424242424242424242424242424242424242424242424242"),
 									Slot:            12342,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x4242424242424242424242424242424242424242424242424242424242424242"),
+										Epoch: 385,
+									},
 								},
 							},
 						},
@@ -584,6 +701,90 @@ func TestScore(t *testing.T) {
 			},
 			parentSlot: 12343,
 			score:      1.875,
+		},
+		{
+			name: "TargetCorrect",
+			priorBlocks: map[phase0.Root]*priorBlockVotes{
+				testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"): {
+					root:   testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"),
+					parent: testutil.HexToRoot("0x2020202020202020202020202020202020202020202020202020202020202020"),
+					slot:   12344,
+				},
+				testutil.HexToRoot("0x2020202020202020202020202020202020202020202020202020202020202020"): {
+					root:   testutil.HexToRoot("0x2020202020202020202020202020202020202020202020202020202020202020"),
+					parent: testutil.HexToRoot("0x1919191919191919191919191919191919191919191919191919191919191919"),
+					slot:   12320,
+				},
+			},
+			block: &spec.VersionedBeaconBlock{
+				Version: spec.DataVersionAltair,
+				Altair: &altair.BeaconBlock{
+					Slot:       12345,
+					ParentRoot: testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"),
+					Body: &altair.BeaconBlockBody{
+						Attestations: []*phase0.Attestation{
+							{
+								AggregationBits: bitList(1, 128),
+								Data: &phase0.AttestationData{
+									BeaconBlockRoot: testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"),
+									Slot:            12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x2020202020202020202020202020202020202020202020202020202020202020"),
+										Epoch: 385,
+									},
+								},
+							},
+						},
+						SyncAggregate: &altair.SyncAggregate{
+							SyncCommitteeBits: bitfield.NewBitvector512(),
+						},
+					},
+				},
+			},
+			parentSlot: 12343,
+			score:      0.84375,
+		},
+		{
+			name: "TargetIncorrect",
+			priorBlocks: map[phase0.Root]*priorBlockVotes{
+				testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"): {
+					root:   testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"),
+					parent: testutil.HexToRoot("0x2020202020202020202020202020202020202020202020202020202020202020"),
+					slot:   12344,
+				},
+				testutil.HexToRoot("0x2020202020202020202020202020202020202020202020202020202020202020"): {
+					root:   testutil.HexToRoot("0x2020202020202020202020202020202020202020202020202020202020202020"),
+					parent: testutil.HexToRoot("0x1919191919191919191919191919191919191919191919191919191919191919"),
+					slot:   12320,
+				},
+			},
+			block: &spec.VersionedBeaconBlock{
+				Version: spec.DataVersionAltair,
+				Altair: &altair.BeaconBlock{
+					Slot:       12345,
+					ParentRoot: testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"),
+					Body: &altair.BeaconBlockBody{
+						Attestations: []*phase0.Attestation{
+							{
+								AggregationBits: bitList(1, 128),
+								Data: &phase0.AttestationData{
+									BeaconBlockRoot: testutil.HexToRoot("0x4444444444444444444444444444444444444444444444444444444444444444"),
+									Slot:            12344,
+									Target: &phase0.Checkpoint{
+										Root:  testutil.HexToRoot("0x1515151515151515151515151515151515151515151515151515151515151515"),
+										Epoch: 385,
+									},
+								},
+							},
+						},
+						SyncAggregate: &altair.SyncAggregate{
+							SyncCommitteeBits: bitfield.NewBitvector512(),
+						},
+					},
+				},
+			},
+			parentSlot: 12343,
+			score:      0.4375,
 		},
 		{
 			name: "InvalidVersion",


### PR DESCRIPTION
Scoring target votes requires historical information for chain, however it is not feasible to fetch this at the time the block is proposed. This fetches blocks as they are added to the chain, and uses the information to score target votes accordingly.