### PR TITLE
Controlled shutdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+Development:
+  - wait until any attestations for the current slot have completed before shutting down
+
 1.4.0:
   - increase accuracy of beacon block proposal scorer by incorporating attestation history
   - multinode submitter returns after first successful submission rather than waiting for all to complete


### PR DESCRIPTION
This changes Vouch's behaviour on a shutdown request, to wait for any outstanding attestation process for the current slot before starting the shutdown procedure.

Note that if there is an outstanding block proposal it should complete prior to the attestation starting, so is covered by the same process. If there is an outstanding sync committee duty we expect it to complete prior to the attestation, but even if not the impact of its loss will be relatively small compared to that of the attestations.