### PR TITLE
Consider fee recipient addresess of 0 to be invalid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - wait until any attestations for the current slot have completed before shutting down
   - send errors to stderr before logging is ready
   - support Bellatrix
+  - add 'fee recipient' servie to obtain fee recipients from local or remote source
   - ensure that attestations are created for slot 0
   - poll more frequently for accounts if current set is empty
 

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "1.5.0-rc6"
+var ReleaseVersion = "1.5.0-rc7"
 
 func main() {
 	os.Exit(main2())

--- a/services/feerecipientprovider/remote/feerecipients_internal_test.go
+++ b/services/feerecipientprovider/remote/feerecipients_internal_test.go
@@ -21,7 +21,9 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/testing/logger"
 	"github.com/rs/zerolog"
+	zerologger "github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,4 +70,71 @@ func TestFeeRecipientsFromRemote(t *testing.T) {
 
 	_, err = s.fetchFeeRecipientsFromRemote(ctx, []phase0.ValidatorIndex{1, 2, 3})
 	require.NoError(t, err)
+}
+
+func TestParseFeeRecipients(t *testing.T) {
+	tests := []struct {
+		name                  string
+		feeRecipients         map[phase0.ValidatorIndex]bellatrix.ExecutionAddress
+		entries               []*feeRecipientResponseJSON
+		expectedFeeRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress
+		logEntries            []string
+	}{
+		{
+			name:                  "Empty",
+			feeRecipients:         map[phase0.ValidatorIndex]bellatrix.ExecutionAddress{},
+			entries:               []*feeRecipientResponseJSON{},
+			expectedFeeRecipients: map[phase0.ValidatorIndex]bellatrix.ExecutionAddress{},
+		},
+		{
+			name:          "ZeroAddress",
+			feeRecipients: map[phase0.ValidatorIndex]bellatrix.ExecutionAddress{},
+			entries: []*feeRecipientResponseJSON{
+				{
+					Index:        1,
+					FeeRecipient: "0x0000000000000000000000000000000000000000",
+				},
+			},
+			expectedFeeRecipients: map[phase0.ValidatorIndex]bellatrix.ExecutionAddress{},
+			logEntries:            []string{"Received 0 fee recipient address; ignoring"},
+		},
+		{
+			name:          "InvalidAddress",
+			feeRecipients: map[phase0.ValidatorIndex]bellatrix.ExecutionAddress{},
+			entries: []*feeRecipientResponseJSON{
+				{
+					Index:        1,
+					FeeRecipient: "invalid",
+				},
+			},
+			expectedFeeRecipients: map[phase0.ValidatorIndex]bellatrix.ExecutionAddress{},
+			logEntries:            []string{"Failed to parse fee recipient address"},
+		},
+		{
+			name:          "Valid",
+			feeRecipients: map[phase0.ValidatorIndex]bellatrix.ExecutionAddress{},
+			entries: []*feeRecipientResponseJSON{
+				{
+					Index:        1,
+					FeeRecipient: "0x1111111111111111111111111111111111111111",
+				},
+			},
+			expectedFeeRecipients: map[phase0.ValidatorIndex]bellatrix.ExecutionAddress{
+				1: {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capture := logger.NewLogCapture()
+			log = zerologger.With().Bool("test", true).Logger()
+
+			parseFeeRecipients(test.feeRecipients, test.entries)
+			require.Equal(t, test.expectedFeeRecipients, test.feeRecipients)
+			for _, entry := range test.logEntries {
+				capture.AssertHasEntry(t, entry)
+			}
+		})
+	}
 }

--- a/services/feerecipientprovider/remote/metrics.go
+++ b/services/feerecipientprovider/remote/metrics.go
@@ -109,6 +109,10 @@ func registerPrometheusMetrics(_ context.Context) error {
 }
 
 func feeRecipientObtained(source string) {
+	if latestTimestamp == nil {
+		return
+	}
+
 	switch source {
 	case "remote":
 		remoteUse.Inc()


### PR DESCRIPTION
It was possible for zero-value fee recipient addresses to be accepted by Vouch as valid.  This carries out an explicit check for such an address, and rejects it if found.