### PR TITLE
Handle missing remote endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
   - wait until any attestations for the current slot have completed before shutting down
   - send errors to stderr before logging is ready
   - support Bellatrix
-  - add 'fee recipient' servie to obtain fee recipients from local or remote source
+  - add 'fee recipient' service to obtain fee recipients from local or remote source
   - ensure that attestations are created for slot 0
   - poll more frequently for accounts if current set is empty
 

--- a/docs/feerecipient.md
+++ b/docs/feerecipient.md
@@ -39,10 +39,17 @@ feerecipient:
 With the above configuration, Vouch will connect to the URL 'http://provider.example.com/feerecipients' on startup and periodically after that, and obtain a list of fee recipients for each index for which it is validating.  Specifically, it sends a POST request to the aforementioned URL with a body as follows:
 
 ``JSON
-{"indices":[11,16,29]}
+{
+  "indices":
+  [
+    11,
+    16,
+    29
+  ]
+}
 ``
 
-where in this case `11,16,29` are the indices of the validators for which Vouch is validating.  The response from the endpoint should be of the form:
+where in this case `11,16,29` are the consensus indices of the validators for which Vouch is validating.  The response from the endpoint should be of the form:
 
 ```JSON
 {


### PR DESCRIPTION
If the remote endpoint is uncontactable it resulted in an error rather than falling back to cache or default.  This continues to log an error in this situation, however does falls back to cache or default as available.