### PR TITLE
Handle soft timeout in separate loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+dev:
+  - fix bug where soft timeout message could repeat rapidly
+
 1.6.0:
   - add block relay module, to handle interactions with MEV relays
 

--- a/strategies/aggregateattestation/best/aggregateattestation.go
+++ b/strategies/aggregateattestation/best/aggregateattestation.go
@@ -41,8 +41,10 @@ func (s *Service) AggregateAttestation(ctx context.Context, slot phase0.Slot, at
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	softCtx, softCancel := context.WithTimeout(ctx, s.timeout/2)
 
-	respCh := make(chan *aggregateAttestationResponse, len(s.aggregateAttestationProviders))
-	errCh := make(chan error, len(s.aggregateAttestationProviders))
+	requests := len(s.aggregateAttestationProviders)
+
+	respCh := make(chan *aggregateAttestationResponse, requests)
+	errCh := make(chan error, requests)
 	// Kick off the requests.
 	for name, provider := range s.aggregateAttestationProviders {
 		go s.aggregateAttestation(ctx, started, name, provider, respCh, errCh, slot, attestationDataRoot)
@@ -52,40 +54,61 @@ func (s *Service) AggregateAttestation(ctx context.Context, slot phase0.Slot, at
 	responded := 0
 	errored := 0
 	timedOut := 0
+	softTimedOut := 0
 	bestScore := float64(0)
 	var bestAggregateAttestation *phase0.Attestation
 	bestProvider := ""
 
-	for responded+errored+timedOut != len(s.aggregateAttestationProviders) {
+	// Loop 1: prior to soft timeout.
+	for responded+errored+timedOut+softTimedOut != requests {
 		select {
-		case <-softCtx.Done():
-			// If we have any responses at this point we consider the non-responders timed out.
-			if responded > 0 {
-				timedOut = len(s.aggregateAttestationProviders) - responded - errored
-				log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Msg("Soft timeout reached with responses")
-			} else {
-				log.Debug().Dur("elapsed", time.Since(started)).Int("errored", errored).Msg("Soft timeout reached with no responses")
-			}
-		case <-ctx.Done():
-			// Anyone not responded by now is considered errored.
-			errored = len(s.aggregateAttestationProviders) - responded
-			log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Hard timeout reached")
-		case err := <-errCh:
-			errored++
-			log.Debug().Dur("elapsed", time.Since(started)).Err(err).Msg("Responded with error")
 		case resp := <-respCh:
 			responded++
+			log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Response received")
 			if bestAggregateAttestation == nil || resp.score > bestScore {
 				bestAggregateAttestation = resp.aggregate
 				bestScore = resp.score
 				bestProvider = resp.provider
 			}
-			log.Trace().Dur("elapsed", time.Since(started)).Msg("Response")
+		case err := <-errCh:
+			errored++
+			log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Err(err).Msg("Error received")
+		case <-softCtx.Done():
+			// If we have any responses at this point we consider the non-responders timed out.
+			if responded > 0 {
+				timedOut = requests - responded - errored
+				log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Soft timeout reached with responses")
+			} else {
+				log.Debug().Dur("elapsed", time.Since(started)).Int("errored", errored).Msg("Soft timeout reached with no responses")
+			}
+			// Set the number of requests that have soft timed out.
+			softTimedOut = requests - responded - errored - timedOut
 		}
 	}
 	softCancel()
+
+	// Loop 2: after soft timeout.
+	for responded+errored+timedOut != requests {
+		select {
+		case resp := <-respCh:
+			responded++
+			log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Response received")
+			if bestAggregateAttestation == nil || resp.score > bestScore {
+				bestAggregateAttestation = resp.aggregate
+				bestScore = resp.score
+				bestProvider = resp.provider
+			}
+		case err := <-errCh:
+			errored++
+			log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Err(err).Msg("Error received")
+		case <-ctx.Done():
+			// Anyone not responded by now is considered errored.
+			timedOut = requests - responded - errored
+			log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Hard timeout reached")
+		}
+	}
 	cancel()
-	log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Responses")
+	log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Results")
 
 	if bestAggregateAttestation == nil {
 		return nil, errors.New("no aggregate attestations received")

--- a/strategies/blindedbeaconblockproposal/best/blindedbeaconblockproposal.go
+++ b/strategies/blindedbeaconblockproposal/best/blindedbeaconblockproposal.go
@@ -39,14 +39,14 @@ func (s *Service) BlindedBeaconBlockProposal(ctx context.Context, slot phase0.Sl
 	started := time.Now()
 	log := util.LogWithID(ctx, log, "strategy_id").With().Uint64("slot", uint64(slot)).Logger()
 
-	requests := len(s.blindedBeaconBlockProposalProviders)
-
 	// We have two timeouts: a soft timeout and a hard timeout.
 	// At the soft timeout, we return if we have any responses so far.
 	// At the hard timeout, we return unconditionally.
 	// The soft timeout is half the duration of the hard timeout.
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	softCtx, softCancel := context.WithTimeout(ctx, s.timeout/2)
+
+	requests := len(s.blindedBeaconBlockProposalProviders)
 
 	respCh := make(chan *beaconBlockResponse, requests)
 	errCh := make(chan error, requests)
@@ -127,7 +127,7 @@ func (s *Service) BlindedBeaconBlockProposal(ctx context.Context, slot phase0.Sl
 		}
 	}
 	cancel()
-	log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Responses")
+	log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Results")
 
 	if bestProposal == nil {
 		return nil, errors.New("no proposals received")

--- a/strategies/synccommitteecontribution/best/synccommitteecontribution.go
+++ b/strategies/synccommitteecontribution/best/synccommitteecontribution.go
@@ -42,8 +42,10 @@ func (s *Service) SyncCommitteeContribution(ctx context.Context, slot phase0.Slo
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	softCtx, softCancel := context.WithTimeout(ctx, s.timeout/2)
 
-	respCh := make(chan *syncCommitteeContributionResponse, len(s.syncCommitteeContributionProviders))
-	errCh := make(chan error, len(s.syncCommitteeContributionProviders))
+	requests := len(s.syncCommitteeContributionProviders)
+
+	respCh := make(chan *syncCommitteeContributionResponse, requests)
+	errCh := make(chan error, requests)
 	// Kick off the requests.
 	for name, provider := range s.syncCommitteeContributionProviders {
 		go s.syncCommitteeContribution(ctx, started, name, provider, respCh, errCh, slot, subcommitteeIndex, beaconBlockRoot)
@@ -53,40 +55,61 @@ func (s *Service) SyncCommitteeContribution(ctx context.Context, slot phase0.Slo
 	responded := 0
 	errored := 0
 	timedOut := 0
+	softTimedOut := 0
 	bestScore := float64(0)
 	var bestSyncCommitteeContribution *altair.SyncCommitteeContribution
 	bestProvider := ""
 
-	for responded+errored+timedOut != len(s.syncCommitteeContributionProviders) {
+	// Loop 1: prior to soft timeout.
+	for responded+errored+timedOut+softTimedOut != requests {
 		select {
-		case <-softCtx.Done():
-			// If we have any responses at this point we consider the non-responders timed out.
-			if responded > 0 {
-				timedOut = len(s.syncCommitteeContributionProviders) - responded - errored
-				log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Msg("Soft timeout reached with responses")
-			} else {
-				log.Debug().Dur("elapsed", time.Since(started)).Int("errored", errored).Msg("Soft timeout reached with no responses")
-			}
-		case <-ctx.Done():
-			// Anyone not responded by now is considered errored.
-			errored = len(s.syncCommitteeContributionProviders) - responded
-			log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Hard timeout reached")
-		case err := <-errCh:
-			errored++
-			log.Debug().Dur("elapsed", time.Since(started)).Err(err).Msg("Responded with error")
 		case resp := <-respCh:
 			responded++
+			log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Response received")
 			if bestSyncCommitteeContribution == nil || resp.score > bestScore {
 				bestSyncCommitteeContribution = resp.contribution
 				bestScore = resp.score
 				bestProvider = resp.provider
 			}
-			log.Trace().Dur("elapsed", time.Since(started)).Msg("Response")
+		case err := <-errCh:
+			errored++
+			log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Err(err).Msg("Error received")
+		case <-softCtx.Done():
+			// If we have any responses at this point we consider the non-responders timed out.
+			if responded > 0 {
+				timedOut = requests - responded - errored
+				log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Soft timeout reached with responses")
+			} else {
+				log.Debug().Dur("elapsed", time.Since(started)).Int("errored", errored).Msg("Soft timeout reached with no responses")
+			}
+			// Set the number of requests that have soft timed out.
+			softTimedOut = requests - responded - errored - timedOut
 		}
 	}
 	softCancel()
+
+	// Loop 2: after soft timeout.
+	for responded+errored+timedOut != requests {
+		select {
+		case resp := <-respCh:
+			responded++
+			log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Response received")
+			if bestSyncCommitteeContribution == nil || resp.score > bestScore {
+				bestSyncCommitteeContribution = resp.contribution
+				bestScore = resp.score
+				bestProvider = resp.provider
+			}
+		case err := <-errCh:
+			errored++
+			log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Err(err).Msg("Error received")
+		case <-ctx.Done():
+			// Anyone not responded by now is considered errored.
+			timedOut = requests - responded - errored
+			log.Debug().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Hard timeout reached")
+		}
+	}
 	cancel()
-	log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Responses")
+	log.Trace().Dur("elapsed", time.Since(started)).Int("responded", responded).Int("errored", errored).Int("timed_out", timedOut).Msg("Results")
 
 	if bestSyncCommitteeContribution == nil {
 		return nil, errors.New("no sync committee contribution received")


### PR DESCRIPTION
Move to a dual-loop system, one pre-soft timeout and one post-soft timeout, to avoid repeating notifications of the soft timeout being reached.