### PR TITLE
Handle nil strategy responses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-dev:
+1.7.0:
   - provide full information for beacon committee subscriptions
   - verify bid signatures from relays if public key available
   - make execution configuration values hierarchical
+  - mark nil responses from beacon nodes as errors rather than dropping silently
 
 1.6.3:
   - fix crash attempting to store metrics when prometheus not enabled

--- a/strategies/aggregateattestation/best/aggregateattestation.go
+++ b/strategies/aggregateattestation/best/aggregateattestation.go
@@ -137,6 +137,7 @@ func (s *Service) aggregateAttestation(ctx context.Context,
 	}
 	log.Trace().Str("provider", name).Dur("elapsed", time.Since(started)).Msg("Obtained aggregate attestation")
 	if aggregate == nil {
+		errCh <- errors.New("aggregate attestation nil")
 		return
 	}
 

--- a/strategies/beaconblockproposal/best/beaconblockproposal.go
+++ b/strategies/beaconblockproposal/best/beaconblockproposal.go
@@ -153,8 +153,9 @@ func (s *Service) beaconBlockProposal(ctx context.Context,
 		errCh <- errors.Wrap(err, name)
 		return
 	}
-	log.Trace().Dur("elapsed", time.Since(started)).Msg("Obtained attestation data")
+	log.Trace().Dur("elapsed", time.Since(started)).Msg("Obtained beacon block proposal")
 	if proposal == nil {
+		errCh <- errors.New("beacon block proposal nil")
 		return
 	}
 

--- a/strategies/blindedbeaconblockproposal/best/blindedbeaconblockproposal.go
+++ b/strategies/blindedbeaconblockproposal/best/blindedbeaconblockproposal.go
@@ -158,7 +158,7 @@ func (s *Service) blindedBeaconBlockProposal(ctx context.Context,
 	}
 	log.Trace().Dur("elapsed", time.Since(started)).Msg("Obtained blinded beacon block proposal")
 	if proposal == nil {
-		errCh <- errors.New("empty blinded beacon block response")
+		errCh <- errors.New("blinded beacon block proposal nil")
 		return
 	}
 	feeRecipient, err := proposal.FeeRecipient()

--- a/strategies/synccommitteecontribution/best/synccommitteecontribution.go
+++ b/strategies/synccommitteecontribution/best/synccommitteecontribution.go
@@ -140,6 +140,7 @@ func (s *Service) syncCommitteeContribution(ctx context.Context,
 	}
 	log.Trace().Str("provider", name).Dur("elapsed", time.Since(started)).Msg("Obtained sync committee contribution")
 	if contribution == nil {
+		errCh <- errors.New("sync committee contribution nil")
 		return
 	}
 


### PR DESCRIPTION
Mark nil responses from beacon nodes as errors rather than dropping silently, allowing the strategy to return more quickly.