### PR TITLE
Provide better errors from strategies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - update dirk module to reduce number of concurrent connections
   - provide timeout option for remote dirk interactions
   - unblind blocks from all relays that hold the desired payload
+  - provide more error information when beacon nodes fail to return expected information
 
 1.6.3:
   - fix crash attempting to store metrics when prometheus not enabled


### PR DESCRIPTION
Erros from strategies were somewhat opaque.  This patch includes the provider with error messages to understand better their source.