### PR TITLE
Ignore zero-value bids.

### DIFF
--- a/services/blockrelay/standard/auctionblock.go
+++ b/services/blockrelay/standard/auctionblock.go
@@ -187,7 +187,7 @@ func (s *Service) bestBuilderBid(ctx context.Context,
 				res.Bid = resp.bid
 				bestScore = resp.score
 				res.Providers = []builderclient.BuilderBidProvider{resp.provider}
-			case resp.score.Cmp(bestScore) == 0 && bidsEqual(res.Bid, resp.bid):
+			case res.Bid != nil && resp.score.Cmp(bestScore) == 0 && bidsEqual(res.Bid, resp.bid):
 				log.Trace().Str("provider", resp.provider.Address()).Msg("Matching bid from different relay")
 				res.Providers = append(res.Providers, resp.provider)
 			default:
@@ -227,7 +227,7 @@ func (s *Service) bestBuilderBid(ctx context.Context,
 				res.Bid = resp.bid
 				bestScore = resp.score
 				res.Providers = []builderclient.BuilderBidProvider{resp.provider}
-			case resp.score.Cmp(bestScore) == 0 && bidsEqual(res.Bid, resp.bid):
+			case res.Bid != nil && resp.score.Cmp(bestScore) == 0 && bidsEqual(res.Bid, resp.bid):
 				log.Trace().Str("provider", resp.provider.Address()).Msg("Matching bid from different relay")
 				res.Providers = append(res.Providers, resp.provider)
 			default:

--- a/services/blockrelay/standard/auctionblock.go
+++ b/services/blockrelay/standard/auctionblock.go
@@ -169,7 +169,7 @@ func (s *Service) bestBuilderBid(ctx context.Context,
 	errored := 0
 	timedOut := 0
 	softTimedOut := 0
-	bestScore := new(big.Int)
+	bestScore := big.NewInt(0)
 
 	// Loop 1: prior to soft timeout.
 	for responded+errored+timedOut+softTimedOut != requests {
@@ -182,7 +182,7 @@ func (s *Service) bestBuilderBid(ctx context.Context,
 				continue
 			}
 			switch {
-			case res.Bid == nil || resp.score.Cmp(bestScore) > 0:
+			case resp.score.Cmp(bestScore) > 0:
 				log.Trace().Str("provider", resp.provider.Address()).Stringer("score", resp.score).Msg("New winning bid")
 				res.Bid = resp.bid
 				bestScore = resp.score
@@ -222,7 +222,7 @@ func (s *Service) bestBuilderBid(ctx context.Context,
 				continue
 			}
 			switch {
-			case res.Bid == nil || resp.score.Cmp(bestScore) > 0:
+			case resp.score.Cmp(bestScore) > 0:
 				log.Trace().Str("provider", resp.provider.Address()).Stringer("score", resp.score).Msg("New winning bid")
 				res.Bid = resp.bid
 				bestScore = resp.score

--- a/services/blockrelay/standard/executionconfig.go
+++ b/services/blockrelay/standard/executionconfig.go
@@ -156,7 +156,7 @@ func (s *Service) obtainExecutionConfig(ctx context.Context,
 		for _, pubkey := range pubkeys {
 			pubkeyStrs = append(pubkeyStrs, fmt.Sprintf("%#x", pubkey))
 		}
-		ctx = context.WithValue(ctx, &httpconfidant.Body{}, []byte(fmt.Sprintf(`["%s"]`, strings.Join(pubkeyStrs, `","`))))
+		ctx = context.WithValue(ctx, &httpconfidant.Body{}, []byte(fmt.Sprintf(`[%q]`, strings.Join(pubkeyStrs, `","`))))
 
 		res, err = s.majordomo.Fetch(ctx, s.configURL)
 	}

--- a/services/blockrelay/standard/executionconfig.go
+++ b/services/blockrelay/standard/executionconfig.go
@@ -164,7 +164,7 @@ func (s *Service) obtainExecutionConfig(ctx context.Context,
 		return nil, errors.Wrap(err, "failed to obtain execution configuration")
 	}
 
-	log.Trace().Str("res", string(res)).Msg("Received response")
+	log.Trace().RawJSON("res", res).Msg("Received response")
 
 	executionConfig, err := blockrelay.UnmarshalJSON(res)
 	if err != nil {


### PR DESCRIPTION
A zero-value bid could be selected if it was the first bid returned from relays.  This change ensures that zero value bids are never selected as candidates for block selection.