### PR TITLE
Ensure that registration gas limit is not 0.

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "1.7.2"
+var ReleaseVersion = "1.7.3"
 
 func main() {
 	exitCode := main2()

--- a/services/blockrelay/v1/executionconfig.go
+++ b/services/blockrelay/v1/executionconfig.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Attestant Limited.
+// Copyright © 2022, 2023 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -108,6 +108,16 @@ func (e *ExecutionConfig) ProposerConfig(_ context.Context,
 				Enabled: false,
 			},
 		}
+	}
+
+	// At this point we definitely have a proposer config, however
+	// if it was the default config it is possible that some elements
+	// are missing.  Fill them in here.
+	if proposerConfig.GasLimit == 0 {
+		proposerConfig.GasLimit = fallbackGasLimit
+	}
+	if proposerConfig.Builder == nil {
+		proposerConfig.Builder = &BuilderConfig{}
 	}
 
 	relays := make([]*beaconblockproposer.RelayConfig, 0)

--- a/services/blockrelay/v1/executionconfig_test.go
+++ b/services/blockrelay/v1/executionconfig_test.go
@@ -14,10 +14,17 @@
 package v1_test
 
 import (
+	"context"
+	"encoding/hex"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/beaconblockproposer"
 	v1 "github.com/attestantio/vouch/services/blockrelay/v1"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 )
@@ -94,6 +101,136 @@ func TestExecutionConfig(t *testing.T) {
 				require.NoError(t, err)
 				rt := res.String()
 				assert.Equal(t, string(test.input), rt)
+			}
+		})
+	}
+}
+
+func executionAddress(input string) bellatrix.ExecutionAddress {
+	data, err := hex.DecodeString(strings.TrimPrefix(input, "0x"))
+	if err != nil {
+		panic(err)
+	}
+	if len(data) != bellatrix.ExecutionAddressLength {
+		panic("execution address incorrect length")
+	}
+	var ex bellatrix.ExecutionAddress
+	copy(ex[:], data)
+	return ex
+}
+
+func pubkey(input string) phase0.BLSPubKey {
+	data, err := hex.DecodeString(strings.TrimPrefix(input, "0x"))
+	if err != nil {
+		panic(err)
+	}
+	if len(data) != phase0.PublicKeyLength {
+		panic("bls public key incorrect length")
+	}
+	var pk phase0.BLSPubKey
+	copy(pk[:], data)
+	return pk
+}
+
+func TestECProposerConfig(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name                 string
+		fallbackFeeRecipient bellatrix.ExecutionAddress
+		fallbackGasLimit     uint64
+		input                []byte
+		pubkey               phase0.BLSPubKey
+		pc                   *beaconblockproposer.ProposerConfig
+		err                  string
+	}{
+		{
+			name:                 "DefaultNoRelays",
+			fallbackFeeRecipient: executionAddress("0x0101010101010101010101010101010101010101"),
+			fallbackGasLimit:     12345,
+			input:                []byte(`{"default_config":{"fee_recipient":"0x000102030405060708090a0b0c0d0e0f10111213"}}`),
+			pc: &beaconblockproposer.ProposerConfig{
+				FeeRecipient: executionAddress("0x000102030405060708090a0b0c0d0e0f10111213"),
+				Relays:       []*beaconblockproposer.RelayConfig{},
+			},
+		},
+		{
+			name:                 "Default",
+			fallbackFeeRecipient: executionAddress("0x0101010101010101010101010101010101010101"),
+			fallbackGasLimit:     12345,
+			input:                []byte(`{"default_config":{"fee_recipient":"0x000102030405060708090a0b0c0d0e0f10111213","builder":{"enabled":true,"relays": ["https://relay1.com/"]}}}`),
+			pc: &beaconblockproposer.ProposerConfig{
+				FeeRecipient: executionAddress("0x000102030405060708090a0b0c0d0e0f10111213"),
+				Relays: []*beaconblockproposer.RelayConfig{
+					{
+						Address:      "https://relay1.com/",
+						FeeRecipient: executionAddress("0x000102030405060708090a0b0c0d0e0f10111213"),
+						GasLimit:     12345,
+						MinValue:     decimal.Zero,
+					},
+				},
+			},
+		},
+		{
+			name:                 "OverrideGasLimit",
+			fallbackFeeRecipient: executionAddress("0x0101010101010101010101010101010101010101"),
+			fallbackGasLimit:     12345,
+			input:                []byte(`{"default_config":{"fee_recipient":"0x000102030405060708090a0b0c0d0e0f10111213","gas_limit":"23456","builder":{"enabled":true,"relays": ["https://relay1.com/"]}}}`),
+			pc: &beaconblockproposer.ProposerConfig{
+				FeeRecipient: executionAddress("0x000102030405060708090a0b0c0d0e0f10111213"),
+				Relays: []*beaconblockproposer.RelayConfig{
+					{
+						Address:      "https://relay1.com/",
+						FeeRecipient: executionAddress("0x000102030405060708090a0b0c0d0e0f10111213"),
+						GasLimit:     23456,
+						MinValue:     decimal.Zero,
+					},
+				},
+			},
+		},
+		{
+			name:                 "NilProposerConfig",
+			fallbackFeeRecipient: executionAddress("0x0101010101010101010101010101010101010101"),
+			fallbackGasLimit:     12345,
+			input:                []byte(`{"default_config":{"fee_recipient":"0x000102030405060708090a0b0c0d0e0f10111213","gas_limit":"23456","builder":{"enabled":true,"relays": ["https://relay1.com/"]}},"proposer_configs":{"0x111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111": null}}`),
+			pubkey:               pubkey("0x111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"),
+			pc: &beaconblockproposer.ProposerConfig{
+				FeeRecipient: executionAddress("0x000102030405060708090a0b0c0d0e0f10111213"),
+				Relays: []*beaconblockproposer.RelayConfig{
+					{
+						Address:      "https://relay1.com/",
+						FeeRecipient: executionAddress("0x000102030405060708090a0b0c0d0e0f10111213"),
+						GasLimit:     23456,
+						MinValue:     decimal.Zero,
+					},
+				},
+			},
+		},
+		{
+			name:                 "ProposerConfig",
+			fallbackFeeRecipient: executionAddress("0x0101010101010101010101010101010101010101"),
+			fallbackGasLimit:     12345,
+			input:                []byte(`{"default_config":{"fee_recipient":"0x000102030405060708090a0b0c0d0e0f10111213","gas_limit":"23456","builder":{"enabled":true,"relays": ["https://relay1.com/"]}},"proposer_config":{"0x111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111": {"fee_recipient":"0x0102030405060708090a0b0c0d0e0f1011121314","gas_limit":"34567"}}}`),
+			pubkey:               pubkey("0x111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"),
+			pc: &beaconblockproposer.ProposerConfig{
+				FeeRecipient: executionAddress("0x0102030405060708090a0b0c0d0e0f1011121314"),
+				Relays:       []*beaconblockproposer.RelayConfig{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var ec v1.ExecutionConfig
+			err := json.Unmarshal(test.input, &ec)
+			require.NoError(t, err)
+
+			pc, err := ec.ProposerConfig(ctx, nil, test.pubkey, test.fallbackFeeRecipient, test.fallbackGasLimit)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.pc, pc)
 			}
 		})
 	}


### PR DESCRIPTION
It was possible for a registration's gas limit to be 0 if not present if the default configuration of a V1 proposer configuration did not provide a gas limit and it was called upon to be used in lieu of a specific proposer configuration.  Ensure that the fallback gas limit is used in this situation.