### PR TITLE
Tidy up accountmanager startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+dev:
+  - do not start account managers unnecessarily
+  - fail if multiple account managers are defined
+
 1.7.2:
   - update dependencies
   - provide more detail in logs on block proposal mismatches


### PR DESCRIPTION
Accountmanager was starting Dirk on an incorrect basis, and multiple accountmangers could be defined and fail to start silently.  Address both of these issues.