### PR TITLE
Handle exited validator in sync committee.

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "1.7.5"
+var ReleaseVersion = "1.7.6"
 
 func main() {
 	exitCode := main2()

--- a/services/signer/standard/helpers.go
+++ b/services/signer/standard/helpers.go
@@ -31,6 +31,9 @@ func (*Service) sign(ctx context.Context,
 	phase0.BLSSignature,
 	error,
 ) {
+	if account == nil {
+		return phase0.BLSSignature{}, errors.New("account is nil; cannot sign")
+	}
 	var sig e2types.Signature
 	if protectingSigner, isProtectingSigner := account.(e2wtypes.AccountProtectingSigner); isProtectingSigner {
 		var err error

--- a/services/synccommitteeaggregator/standard/service.go
+++ b/services/synccommitteeaggregator/standard/service.go
@@ -190,7 +190,13 @@ func (s *Service) Aggregate(ctx context.Context, data interface{}) {
 				Contribution:    contribution,
 				SelectionProof:  duty.SelectionProofs[validatorIndex][subcommitteeIndex],
 			}
-			sig, err := s.contributionAndProofSigner.SignContributionAndProof(ctx, duty.Accounts[validatorIndex], contributionAndProof)
+			account, exists := duty.Accounts[validatorIndex]
+			if !exists {
+				log.Debug().Msg("Account nil; likely exited validator still in sync committee")
+				s.monitor.SyncCommitteeAggregationsCompleted(started, duty.Slot, len(duty.ValidatorIndices), "exited")
+				return
+			}
+			sig, err := s.contributionAndProofSigner.SignContributionAndProof(ctx, account, contributionAndProof)
 			if err != nil {
 				log.Warn().Err(err).Msg("Failed to obtain signature of contribution and proof")
 				s.monitor.SyncCommitteeAggregationsCompleted(started, duty.Slot, len(duty.ValidatorIndices), "failed")


### PR DESCRIPTION
It is possible for a validator to exit whilst part of a sync committee. In this situation Vouch will no longer contain account information but will still try to contribute, so catch this situation and log appropriately.