### PR TITLE
Ensure first attestations are scheduled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 dev:
   - reduce time spent verifying account names
+  - ensure that attestations complete on Vouch's first ever epoch
 
 1.8.0:
   - support Deneb

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -355,11 +355,10 @@ func (s *Service) epochTicker(ctx context.Context, data interface{}) {
 		return
 	}
 
-	// Expect at least one validator.
+	// Expect at least one validator, but keep going even if we don't have any
+	// as there may be some in the next epoch.
 	if len(validatorIndices) == 0 {
 		log.Warn().Msg("No active validators; not validating")
-		cancel()
-		return
 	}
 
 	// Done the preparation work available to us; wait for the end of the timer.


### PR DESCRIPTION
Attestations were not scheduled if there are no active validators, but in the case where this is Vouch's first validator ever we need to attempt to schedule regardless to avoid missing the first attestation.