### PR TITLE
fix: bestScore is a pointer to a big.Int and we were changing the pointer itself instead of changing the data on the pointer

### DIFF
--- a/strategies/builderbid/best/builderbid.go
+++ b/strategies/builderbid/best/builderbid.go
@@ -271,7 +271,7 @@ func (*Service) setBuilderBid(ctx context.Context,
 	switch {
 	case resp.score.Cmp(bestScore) > 0:
 		res.Bid = resp.bid
-		bestScore = resp.score
+		bestScore.Set(resp.score)
 		res.Providers = make([]builderclient.BuilderBidProvider, 0)
 		res.Providers = append(res.Providers, resp.provider)
 		log.Trace().Str("provider", resp.provider.Address()).Stringer("score", bestScore).Msg("New winning bid")


### PR DESCRIPTION
## Bug
The best value block was not selected.

`bestScore` is a pointer to a `big.Int`, and when you do `bestScore = resp.score`, you're changing the pointer itself, not the data it points to. This change will not be visible outside the function.