### PR TITLE
Add 'failed' dimension for root to slot lookup metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ dev:
   - provide fallback location for dynamic graffiti
   - relax proposal checks to enable DVT proposals
   - add individual "controller.fast-track" flags for attestations and sync committees
+  - add 'failed' dimension for root to slot lookup metrics
 
 1.9.0-alpha.3
   - add proposal value and blinded status to trace

--- a/services/cache/standard/blockroottoslot.go
+++ b/services/cache/standard/blockroottoslot.go
@@ -38,6 +38,7 @@ func (s *Service) BlockRootToSlot(ctx context.Context, root phase0.Root) (phase0
 			Block: root.String(),
 		})
 		if err != nil {
+			monitorBlockRootToSlot("failed")
 			return 0, errors.Wrap(err, "failed to obtain block header")
 		}
 		block := blockResponse.Data
@@ -55,11 +56,13 @@ func (s *Service) BlockRootToSlot(ctx context.Context, root phase0.Root) (phase0
 			Block: root.String(),
 		})
 		if err != nil {
+			monitorBlockRootToSlot("failed")
 			return 0, errors.Wrap(err, "failed to obtain block")
 		}
 		block := blockResponse.Data
 		slot, err = block.Slot()
 		if err != nil {
+			monitorBlockRootToSlot("failed")
 			return 0, errors.Wrap(err, "failed to obtain block slot")
 		}
 

--- a/services/cache/standard/metrics.go
+++ b/services/cache/standard/metrics.go
@@ -79,11 +79,11 @@ func monitorBlockRootToSlotEntriesUpdated(entries int) {
 	blockRootToSlotEntries.Set(float64(entries))
 }
 
-func monitorBlockRootToSlot(source string) {
+func monitorBlockRootToSlot(result string) {
 	if blockRootToSlotProcessed == nil {
 		return
 	}
-	blockRootToSlotProcessed.WithLabelValues(source).Inc()
+	blockRootToSlotProcessed.WithLabelValues(result).Inc()
 }
 
 func monitorExecutionChainHeadUpdated(height uint64) {


### PR DESCRIPTION
Allow tracking of failures to resolve root to slot lookups.