### PR TITLE
feat: changing builder configs factor to be a percentage

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,19 +221,19 @@ blockrelay:
   log-results: true
   # builder-configs contain specific configurations for different builders, with each builder defined by its public key.
   # The base score for each bid is the value to the proposer, in wei.  The final score is calculated by adding
-  # the 'offset' value for the specific builder, and then multiplying it by the 'factor' value.  For example,
-  # if the base value is 1000, the offset is 10 and the factor is 2 then the final score is (1000+10)*2 = 2020.  If the
-  # offset is not configured it defaults to 0; if the factor is not configured it defaults to 1.  The category is used
+  # the 'offset' value for the specific builder, and then multiplying by the percentage of 'boost' value. For example,
+  # if the base value is 1000, the offset is 10 and the boost is 110 then the final score is (1000+10)*(110/100) = 1111.  If the
+  # offset is not configured it defaults to 0; if the boost is not configured it defaults to 100.  The category is used
   # for differentiation of bids in metrics.
   builder-configs:
     '0xaaaa...':
       category: 'privileged'
-      # With a factor of 1000000000 bids from this builder are pretty much guaranteed to be included above bids from other builders.
-      factor: 1000000000
+      # With boost of 1000000000 bids from this builder are pretty much guaranteed to be included above bids from other builders.
+      boost: 1000000000
     '0xbbbb...':
       category: 'excluded'
       # With a factor of 0 bids from this builder will be ignored.
-      factor: 0
+      boost: 0
 
 # tracing sends OTLP trace data to the supplied endpoint.
 tracing:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,19 +221,19 @@ blockrelay:
   log-results: true
   # builder-configs contain specific configurations for different builders, with each builder defined by its public key.
   # The base score for each bid is the value to the proposer, in wei.  The final score is calculated by adding
-  # the 'offset' value for the specific builder, and then multiplying by the percentage of 'boost' value. For example,
-  # if the base value is 1000, the offset is 10 and the boost is 110 then the final score is (1000+10)*(110/100) = 1111.  If the
-  # offset is not configured it defaults to 0; if the boost is not configured it defaults to 100.  The category is used
+  # the 'offset' value for the specific builder, and then multiplying by the percentage of 'factor' value. For example,
+  # if the base value is 1000, the offset is 10 and the factor is 110 then the final score is (1000+10)*(110/100) = 1111.  If the
+  # offset is not configured it defaults to 0; if the factor is not configured it defaults to 100.  The category is used
   # for differentiation of bids in metrics.
   builder-configs:
     '0xaaaa...':
       category: 'privileged'
-      # With boost of 1000000000 bids from this builder are pretty much guaranteed to be included above bids from other builders.
-      boost: 1000000000
+      # With factor of 1000000000 bids from this builder are pretty much guaranteed to be included above bids from other builders.
+      factor: 1000000000
     '0xbbbb...':
       category: 'excluded'
       # With a factor of 0 bids from this builder will be ignored.
-      boost: 0
+      factor: 0
 
 # tracing sends OTLP trace data to the supplied endpoint.
 tracing:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,7 +222,7 @@ blockrelay:
   # builder-configs contain specific configurations for different builders, with each builder defined by its public key.
   # The base score for each bid is the value to the proposer, in wei.  The final score is calculated by adding
   # the 'offset' value for the specific builder, and then multiplying by the percentage of 'factor' value. For example,
-  # if the base value is 1000, the offset is 10 and the factor is 110 then the final score is ((1000+10)/100)*110 = 1100.  If the
+  # if the base value is 1000, the offset is 10 and the factor is 110 then the final score is ((1000+10)/110)*100 = 1100.  If the
   # offset is not configured it defaults to 0; if the factor is not configured it defaults to 100.  The category is used
   # for differentiation of bids in metrics.
   builder-configs:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,7 +222,7 @@ blockrelay:
   # builder-configs contain specific configurations for different builders, with each builder defined by its public key.
   # The base score for each bid is the value to the proposer, in wei.  The final score is calculated by adding
   # the 'offset' value for the specific builder, and then multiplying by the percentage of 'factor' value. For example,
-  # if the base value is 1000, the offset is 10 and the factor is 110 then the final score is (1000+10)*(110/100) = 1111.  If the
+  # if the base value is 1000, the offset is 10 and the factor is 110 then the final score is ((1000+10)/100)*110 = 1100.  If the
   # offset is not configured it defaults to 0; if the factor is not configured it defaults to 100.  The category is used
   # for differentiation of bids in metrics.
   builder-configs:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,7 +222,7 @@ blockrelay:
   # builder-configs contain specific configurations for different builders, with each builder defined by its public key.
   # The base score for each bid is the value to the proposer, in wei.  The final score is calculated by adding
   # the 'offset' value for the specific builder, and then multiplying by the percentage of 'factor' value. For example,
-  # if the base value is 1000, the offset is 10 and the factor is 110 then the final score is ((1000+10)/110)*100 = 1111.  If the
+  # if the base value is 1000, the offset is 10 and the factor is 110 then the final score is (1000+10)*110/100 = 1111.  If the
   # offset is not configured it defaults to 0; if the factor is not configured it defaults to 100.  The category is used
   # for differentiation of bids in metrics.
   builder-configs:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,7 +222,7 @@ blockrelay:
   # builder-configs contain specific configurations for different builders, with each builder defined by its public key.
   # The base score for each bid is the value to the proposer, in wei.  The final score is calculated by adding
   # the 'offset' value for the specific builder, and then multiplying by the percentage of 'factor' value. For example,
-  # if the base value is 1000, the offset is 10 and the factor is 110 then the final score is ((1000+10)/110)*100 = 1100.  If the
+  # if the base value is 1000, the offset is 10 and the factor is 110 then the final score is ((1000+10)/110)*100 = 1111.  If the
   # offset is not configured it defaults to 0; if the factor is not configured it defaults to 100.  The category is used
   # for differentiation of bids in metrics.
   builder-configs:

--- a/main.go
+++ b/main.go
@@ -1773,7 +1773,7 @@ func obtainBuilderConfigs(ctx context.Context) (map[phase0.BLSPubKey]*blockrelay
 		copy(publicKey[:], tmp)
 
 		category := blockrelay.StandardBuilderCategory
-		var boost *big.Int
+		var factor *big.Int
 		var offset *big.Int
 
 		var success bool
@@ -1781,8 +1781,8 @@ func obtainBuilderConfigs(ctx context.Context) (map[phase0.BLSPubKey]*blockrelay
 			switch {
 			case strings.EqualFold(k, "category"):
 				category = v
-			case strings.EqualFold(k, "boost"):
-				boost, success = new(big.Int).SetString(v, 10)
+			case strings.EqualFold(k, "factor"):
+				factor, success = new(big.Int).SetString(v, 10)
 				if !success {
 					return nil, fmt.Errorf("failed to decode factor %s for builder %s", v, addr)
 				}
@@ -1799,7 +1799,7 @@ func obtainBuilderConfigs(ctx context.Context) (map[phase0.BLSPubKey]*blockrelay
 
 		res[publicKey] = &blockrelay.BuilderConfig{
 			Category: category,
-			Boost:    boost,
+			Factor:   factor,
 			Offset:   offset,
 		}
 	}
@@ -1826,7 +1826,7 @@ func obtainBuilderConfigsForExcludedBuilders(_ context.Context,
 
 		res[publicKey] = &blockrelay.BuilderConfig{
 			Category: "excluded",
-			Boost:    big.NewInt(0),
+			Factor:   big.NewInt(0),
 		}
 	}
 
@@ -1852,7 +1852,7 @@ func obtainBuilderConfigsForPrivilegedBuilders(_ context.Context,
 
 		res[publicKey] = &blockrelay.BuilderConfig{
 			Category: "privileged",
-			Boost:    big.NewInt(1000000000000000000),
+			Factor:   big.NewInt(1000000000000000000),
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -1773,7 +1773,7 @@ func obtainBuilderConfigs(ctx context.Context) (map[phase0.BLSPubKey]*blockrelay
 		copy(publicKey[:], tmp)
 
 		category := blockrelay.StandardBuilderCategory
-		var factor *big.Int
+		var boost *big.Int
 		var offset *big.Int
 
 		var success bool
@@ -1781,8 +1781,8 @@ func obtainBuilderConfigs(ctx context.Context) (map[phase0.BLSPubKey]*blockrelay
 			switch {
 			case strings.EqualFold(k, "category"):
 				category = v
-			case strings.EqualFold(k, "factor"):
-				factor, success = new(big.Int).SetString(v, 10)
+			case strings.EqualFold(k, "boost"):
+				boost, success = new(big.Int).SetString(v, 10)
 				if !success {
 					return nil, fmt.Errorf("failed to decode factor %s for builder %s", v, addr)
 				}
@@ -1799,7 +1799,7 @@ func obtainBuilderConfigs(ctx context.Context) (map[phase0.BLSPubKey]*blockrelay
 
 		res[publicKey] = &blockrelay.BuilderConfig{
 			Category: category,
-			Factor:   factor,
+			Boost:    boost,
 			Offset:   offset,
 		}
 	}
@@ -1826,7 +1826,7 @@ func obtainBuilderConfigsForExcludedBuilders(_ context.Context,
 
 		res[publicKey] = &blockrelay.BuilderConfig{
 			Category: "excluded",
-			Factor:   big.NewInt(0),
+			Boost:    big.NewInt(0),
 		}
 	}
 
@@ -1852,7 +1852,7 @@ func obtainBuilderConfigsForPrivilegedBuilders(_ context.Context,
 
 		res[publicKey] = &blockrelay.BuilderConfig{
 			Category: "privileged",
-			Factor:   big.NewInt(1000000000000000000),
+			Boost:    big.NewInt(1000000000000000000),
 		}
 	}
 

--- a/services/blockrelay/builderconfig.go
+++ b/services/blockrelay/builderconfig.go
@@ -22,8 +22,8 @@ const StandardBuilderCategory = "standard"
 type BuilderConfig struct {
 	// Category is the category applied to the builder.
 	Category string
-	// Factor is a multiple applied to the proposal score from the builder.
-	Factor *big.Int
+	// Boost is a percentage multiplier applied to the proposal score from the builder.
+	Boost *big.Int
 	// Offset is an offset applied to the proposal score from the builder.
 	Offset *big.Int
 }

--- a/services/blockrelay/builderconfig.go
+++ b/services/blockrelay/builderconfig.go
@@ -22,8 +22,8 @@ const StandardBuilderCategory = "standard"
 type BuilderConfig struct {
 	// Category is the category applied to the builder.
 	Category string
-	// Boost is a percentage multiplier applied to the proposal score from the builder.
-	Boost *big.Int
+	// Factor is a percentage multiplier applied to the proposal score from the builder.
+	Factor *big.Int
 	// Offset is an offset applied to the proposal score from the builder.
 	Offset *big.Int
 }

--- a/strategies/builderbid/best/builderbid.go
+++ b/strategies/builderbid/best/builderbid.go
@@ -243,11 +243,12 @@ func (*Service) setBuilderBid(ctx context.Context,
 		score = new(big.Int).Add(score, builderConfig.Offset)
 	}
 	if builderConfig.Factor != nil {
-		factor := new(big.Rat).SetInt64(0)
 		if builderConfig.Factor.Cmp(big.NewInt(0)) > 0 {
-			factor = new(big.Rat).Quo(new(big.Rat).SetInt(builderConfig.Factor), new(big.Rat).SetInt64(100))
+			score = new(big.Int).Div(score, new(big.Int).SetUint64(100))
+			score = new(big.Int).Mul(score, builderConfig.Factor)
+		} else {
+			score = new(big.Int).Mul(score, new(big.Int).SetUint64(0))
 		}
-		score = new(big.Int).SetInt64(new(big.Rat).Mul(new(big.Rat).SetInt(score), factor).Num().Int64())
 	}
 
 	participation := &blockauctioneer.Participation{

--- a/strategies/builderbid/best/builderbid.go
+++ b/strategies/builderbid/best/builderbid.go
@@ -243,12 +243,7 @@ func (*Service) setBuilderBid(ctx context.Context,
 		score = new(big.Int).Add(score, builderConfig.Offset)
 	}
 	if builderConfig.Factor != nil {
-		if builderConfig.Factor.Cmp(big.NewInt(0)) > 0 {
-			score = new(big.Int).Div(score, new(big.Int).SetUint64(100))
-			score = new(big.Int).Mul(score, builderConfig.Factor)
-		} else {
-			score = new(big.Int).Mul(score, new(big.Int).SetUint64(0))
-		}
+		score = new(big.Int).Div(new(big.Int).Mul(score, builderConfig.Factor), big.NewInt(100))
 	}
 
 	participation := &blockauctioneer.Participation{

--- a/strategies/builderbid/best/builderbid.go
+++ b/strategies/builderbid/best/builderbid.go
@@ -242,8 +242,12 @@ func (*Service) setBuilderBid(ctx context.Context,
 	if builderConfig.Offset != nil {
 		score = new(big.Int).Add(score, builderConfig.Offset)
 	}
-	if builderConfig.Factor != nil {
-		score = new(big.Int).Mul(score, builderConfig.Factor)
+	if builderConfig.Boost != nil {
+		boost := new(big.Rat).SetInt64(0)
+		if builderConfig.Boost.Cmp(big.NewInt(0)) > 0 {
+			boost = new(big.Rat).Quo(new(big.Rat).SetInt(builderConfig.Boost), new(big.Rat).SetInt64(100))
+		}
+		score = new(big.Int).SetInt64(new(big.Rat).Mul(new(big.Rat).SetInt(score), boost).Num().Int64())
 	}
 
 	participation := &blockauctioneer.Participation{

--- a/strategies/builderbid/best/builderbid.go
+++ b/strategies/builderbid/best/builderbid.go
@@ -242,12 +242,12 @@ func (*Service) setBuilderBid(ctx context.Context,
 	if builderConfig.Offset != nil {
 		score = new(big.Int).Add(score, builderConfig.Offset)
 	}
-	if builderConfig.Boost != nil {
-		boost := new(big.Rat).SetInt64(0)
-		if builderConfig.Boost.Cmp(big.NewInt(0)) > 0 {
-			boost = new(big.Rat).Quo(new(big.Rat).SetInt(builderConfig.Boost), new(big.Rat).SetInt64(100))
+	if builderConfig.Factor != nil {
+		factor := new(big.Rat).SetInt64(0)
+		if builderConfig.Factor.Cmp(big.NewInt(0)) > 0 {
+			factor = new(big.Rat).Quo(new(big.Rat).SetInt(builderConfig.Factor), new(big.Rat).SetInt64(100))
 		}
-		score = new(big.Int).SetInt64(new(big.Rat).Mul(new(big.Rat).SetInt(score), boost).Num().Int64())
+		score = new(big.Int).SetInt64(new(big.Rat).Mul(new(big.Rat).SetInt(score), factor).Num().Int64())
 	}
 
 	participation := &blockauctioneer.Participation{

--- a/strategies/builderbid/deadline/builderbid.go
+++ b/strategies/builderbid/deadline/builderbid.go
@@ -308,12 +308,7 @@ func (*Service) setBuilderBid(ctx context.Context,
 		score = new(big.Int).Add(score, builderConfig.Offset)
 	}
 	if builderConfig.Factor != nil {
-		if builderConfig.Factor.Cmp(big.NewInt(0)) > 0 {
-			score = new(big.Int).Div(score, new(big.Int).SetUint64(100))
-			score = new(big.Int).Mul(score, builderConfig.Factor)
-		} else {
-			score = new(big.Int).Mul(score, new(big.Int).SetUint64(0))
-		}
+		score = new(big.Int).Div(new(big.Int).Mul(score, builderConfig.Factor), big.NewInt(100))
 	}
 
 	participation := &blockauctioneer.Participation{

--- a/strategies/builderbid/deadline/builderbid.go
+++ b/strategies/builderbid/deadline/builderbid.go
@@ -307,12 +307,12 @@ func (*Service) setBuilderBid(ctx context.Context,
 	if builderConfig.Offset != nil {
 		score = new(big.Int).Add(score, builderConfig.Offset)
 	}
-	if builderConfig.Boost != nil {
-		boost := new(big.Rat).SetInt64(0)
-		if builderConfig.Boost.Cmp(big.NewInt(0)) > 0 {
-			boost = new(big.Rat).Quo(new(big.Rat).SetInt(builderConfig.Boost), new(big.Rat).SetInt64(100))
+	if builderConfig.Factor != nil {
+		factor := new(big.Rat).SetInt64(0)
+		if builderConfig.Factor.Cmp(big.NewInt(0)) > 0 {
+			factor = new(big.Rat).Quo(new(big.Rat).SetInt(builderConfig.Factor), new(big.Rat).SetInt64(100))
 		}
-		score = new(big.Int).SetInt64(new(big.Rat).Mul(new(big.Rat).SetInt(score), boost).Num().Int64())
+		score = new(big.Int).SetInt64(new(big.Rat).Mul(new(big.Rat).SetInt(score), factor).Num().Int64())
 	}
 
 	participation := &blockauctioneer.Participation{

--- a/strategies/builderbid/deadline/builderbid.go
+++ b/strategies/builderbid/deadline/builderbid.go
@@ -307,8 +307,12 @@ func (*Service) setBuilderBid(ctx context.Context,
 	if builderConfig.Offset != nil {
 		score = new(big.Int).Add(score, builderConfig.Offset)
 	}
-	if builderConfig.Factor != nil {
-		score = new(big.Int).Mul(score, builderConfig.Factor)
+	if builderConfig.Boost != nil {
+		boost := new(big.Rat).SetInt64(0)
+		if builderConfig.Boost.Cmp(big.NewInt(0)) > 0 {
+			boost = new(big.Rat).Quo(new(big.Rat).SetInt(builderConfig.Boost), new(big.Rat).SetInt64(100))
+		}
+		score = new(big.Int).SetInt64(new(big.Rat).Mul(new(big.Rat).SetInt(score), boost).Num().Int64())
 	}
 
 	participation := &blockauctioneer.Participation{

--- a/strategies/builderbid/deadline/builderbid.go
+++ b/strategies/builderbid/deadline/builderbid.go
@@ -308,11 +308,12 @@ func (*Service) setBuilderBid(ctx context.Context,
 		score = new(big.Int).Add(score, builderConfig.Offset)
 	}
 	if builderConfig.Factor != nil {
-		factor := new(big.Rat).SetInt64(0)
 		if builderConfig.Factor.Cmp(big.NewInt(0)) > 0 {
-			factor = new(big.Rat).Quo(new(big.Rat).SetInt(builderConfig.Factor), new(big.Rat).SetInt64(100))
+			score = new(big.Int).Div(score, new(big.Int).SetUint64(100))
+			score = new(big.Int).Mul(score, builderConfig.Factor)
+		} else {
+			score = new(big.Int).Mul(score, new(big.Int).SetUint64(0))
 		}
-		score = new(big.Int).SetInt64(new(big.Rat).Mul(new(big.Rat).SetInt(score), factor).Num().Int64())
 	}
 
 	participation := &blockauctioneer.Participation{


### PR DESCRIPTION
Boost is a percentage multiplier and should accommodate for the same requirements as factor but also gives the validator more precise control on how much they are willing to increase privileged relays score.

One additional feature of this is that validators could also create a new group and reduce the score of a specific relay. At the moment we don't see this as an issue, but would love to get your opinion on this.