### PR TITLE
Disable sync committee fast-track by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ controller:
     # If sync-committees is true then Vouch will generate sync committee messages as soon as it receives notification that
     # the head block has been updated for the duties' slot.  Otherwise it will wait until 4 seconds into the slot before
     # generating sync committee messages.
-    sync-committees: true
+    sync-committees: false
     # grace is the delay between receiving the notification of the head block and starting the fast track process.  This allows
     # the rest of the network to settle if we saw the head block early.
     grace: '200ms'

--- a/main.go
+++ b/main.go
@@ -240,7 +240,7 @@ func fetchConfig() error {
 	viper.SetDefault("controller.sync-committee-aggregation-delay", 8*time.Second)
 	viper.SetDefault("controller.verify-sync-committee-inclusion", false)
 	viper.SetDefault("controller.fast-track.attestations", true)
-	viper.SetDefault("controller.fast-track.sync-committees", true)
+	viper.SetDefault("controller.fast-track.sync-committees", false)
 	viper.SetDefault("controller.fast-track.grace", 200*time.Millisecond)
 	viper.SetDefault("blockrelay.timeout", 1*time.Second)
 	viper.SetDefault("blockrelay.listen-address", "0.0.0.0:18550")


### PR DESCRIPTION
Hi @mcdee I wanted to get your thoughts on this change. I feel if we leave fast-track on by default it could significantly change the behaviour of sync committee participation when upgrading from 1.8.2 to 1.9.0 without being obvious to the users why. 

I'd lean towards this being more of an explicit "opt-in" change rather than enabled by default, hence the change. 