### PR TITLE
fix 'FromAsCasing' warning on docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm as builder
+FROM golang:1.22-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes warning when running `docker --debug build -t attestant/vouch .` with `Docker version 27.2.0, build 3ab4256`

Output:

```
 1 warning found:
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
The 'as' keyword should match the case of the 'from' keyword
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
Dockerfile:1
--------------------
   1 | >>> FROM golang:1.22-bookworm as builder
   2 |
   3 |     WORKDIR /app
--------------------

```