### PR TITLE
Ensure secondary registrations take place..

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.9.1:
+  - ensure that secondary validator registrations take place for all accounts
+
 1.9.0:
   - allow Vouch to start with some consensus nodes unavailable
   - allow Vouch to act as an MEV-boost client for non-Vouch validators

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "1.9.0"
+var ReleaseVersion = "1.9.1"
 
 func main() {
 	exitCode := main2()


### PR DESCRIPTION
In some situations the secondary registrations were not fully captured, resulting in some validators not letting their beacon nodes know they wanted to use MEV relays.  This addresses that issue.