### PR TITLE
Fix default gas limit on execution config

### DIFF
--- a/services/blockrelay/v2/executionconfig.go
+++ b/services/blockrelay/v2/executionconfig.go
@@ -192,7 +192,11 @@ func (e *ExecutionConfig) setInitialRelayOptions(_ context.Context,
 		} else {
 			configRelay.MinValue = *e.MinValue
 		}
-		setRelayConfig(configRelay, baseRelayConfig, config.FeeRecipient, fallbackGasLimit)
+		if e.GasLimit == nil {
+			setRelayConfig(configRelay, baseRelayConfig, config.FeeRecipient, fallbackGasLimit)
+		} else {
+			setRelayConfig(configRelay, baseRelayConfig, config.FeeRecipient, *e.GasLimit)
+		}
 		config.Relays = append(config.Relays, configRelay)
 	}
 }

--- a/services/blockrelay/v2/executionconfig_test.go
+++ b/services/blockrelay/v2/executionconfig_test.go
@@ -673,6 +673,62 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "ExecutionConfigDefaultGasLimit",
+			executionConfig: &v2.ExecutionConfig{
+				GasLimit:     &gasLimit4,
+				Proposers:    []*v2.ProposerConfig{},
+				FeeRecipient: &feeRecipient3,
+				Relays: map[string]*v2.BaseRelayConfig{
+					"https://relay1.com/": {},
+				},
+			},
+			account:              account1,
+			pubkey:               pubkey1,
+			fallbackFeeRecipient: feeRecipient1,
+			fallbackGasLimit:     gasLimit1,
+			expected: &beaconblockproposer.ProposerConfig{
+				FeeRecipient: feeRecipient3,
+				Relays: []*beaconblockproposer.RelayConfig{
+					{
+						Address:      "https://relay1.com/",
+						FeeRecipient: feeRecipient3,
+						GasLimit:     gasLimit4,
+						Grace:        grace0,
+						MinValue:     minValue0,
+					},
+				},
+			},
+		},
+		{
+			name: "ExecutionConfigDefaultAndRelayGasLimit",
+			executionConfig: &v2.ExecutionConfig{
+				GasLimit:     &gasLimit4,
+				Proposers:    []*v2.ProposerConfig{},
+				FeeRecipient: &feeRecipient3,
+				Relays: map[string]*v2.BaseRelayConfig{
+					"https://relay1.com/": {
+						GasLimit: &gasLimit3,
+					},
+				},
+			},
+			account:              account1,
+			pubkey:               pubkey1,
+			fallbackFeeRecipient: feeRecipient1,
+			fallbackGasLimit:     gasLimit1,
+			expected: &beaconblockproposer.ProposerConfig{
+				FeeRecipient: feeRecipient3,
+				Relays: []*beaconblockproposer.RelayConfig{
+					{
+						Address:      "https://relay1.com/",
+						FeeRecipient: feeRecipient3,
+						GasLimit:     gasLimit3,
+						Grace:        grace0,
+						MinValue:     minValue0,
+					},
+				},
+			},
+		},
+		{
 			name: "InvalidProposerConfig",
 			executionConfig: &v2.ExecutionConfig{
 				Relays: map[string]*v2.BaseRelayConfig{


### PR DESCRIPTION
Fix default gas limit on execution config

Example not working gas limit on execution config - instead of 40000000, relay would use default 3000000.

```
{
  "version": 2,
  "fee_recipient": "...redacted...",
  "relays": {
    "https://holesky.titanrelay.xyz": {
      "public_key": "0xaa58208899c6105603b74396734a6263cc7d947f444f396a90f7b7d3e65d102aec7e5e5291b27e08d02c50a050825c2f"
    }
  },
  "proposers": [],
  "gas_limit": "40000000"
}
```