### PR TITLE
Use correct mime type on fetch of execution config

### DIFF
--- a/services/blockrelay/standard/executionconfig.go
+++ b/services/blockrelay/standard/executionconfig.go
@@ -146,6 +146,7 @@ func (s *Service) obtainExecutionConfig(ctx context.Context,
 		}
 
 		ctx = context.WithValue(ctx, &httpconfidant.HTTPMethod{}, http.MethodPost)
+		ctx = context.WithValue(ctx, &httpconfidant.MIMEType{}, "application/json")
 		pubkeyStrs := make([]string, 0, len(pubkeys))
 		for _, pubkey := range pubkeys {
 			pubkeyStrs = append(pubkeyStrs, pubkey.String())


### PR DESCRIPTION
When vouch was configured to fetch the blockrelay/executionconfig from an http endpoint, the respective majordomo call did not properly set the `Content-Type` and `Accept` headers. Instead, `Content-Type: text/plain` was sent.

This commit adds the respective `MIMEType` value to the majordomo context [1] so that these requests are now sent with the `Content-Type` and `Accept` headers set to `application/json`.

## Contribution

I ran the tests locally and they were passing.  I also ran an integration test with an `mitmproxy` for introspection of the request:

### Without this patch:

Incorrect header is sent and our endpoint rejects the unsupported media type text/plain

```yml
[::1]:53462: POST http://localhost:8082/execution-configuration
    Host: localhost:8082
    User-Agent: Go-http-client/1.1
    Content-Length: 405
    Accept-Encoding: gzip

    ["0x867d16dabac51596831c10ee1c20fb63f2ccf427a6bc3bae0e76f75e56a34af6df83e756a0de540ba1341d6a35e46af4","0xa7a7a8e444cf8e4fac2269b3de1023fc58cb0c60cff1838f878d84eb9961ac24b5c935bd0307704fc5dd8f5855aff9d3","0xa30c710adf75e8b491021a896f0da3818e5d1f7e9c447679090ae13683d7c41a0418f2ac48327d4b339f9c423eb44375","0xa14313d0d843c117dfff8a1fa40f19640f26591c457c8a6730e2c05b79690e8f117e1436869f359bef3579e8a5782c10"]

 << 415 Unsupported Media Type 54b
    content-type: text/plain; charset=utf-8
    content-length: 54
    date: Tue, 07 Jan 2025 17:05:01 GMT

    Expected request with `Content-Type: application/json`
```

### With this patch:

Headers are correctly set to `application/json` and our endpoint responds politely ;-)

```yml
[::1]:54590: POST http://localhost:8082/execution-configuration
    Host: localhost:8082
    User-Agent: Go-http-client/1.1
    Content-Length: 405
    Accept: application/json
    Content-Type: application/json
    Accept-Encoding: gzip

    [
        "0xa7a7a8e444cf8e4fac2269b3de1023fc58cb0c60cff1838f878d84eb9961ac24b5c935bd0307704fc5dd8f5855aff9d3",
        "0xa30c710adf75e8b491021a896f0da3818e5d1f7e9c447679090ae13683d7c41a0418f2ac48327d4b339f9c423eb44375",
        "0xa14313d0d843c117dfff8a1fa40f19640f26591c457c8a6730e2c05b79690e8f117e1436869f359bef3579e8a5782c10",
        "0x867d16dabac51596831c10ee1c20fb63f2ccf427a6bc3bae0e76f75e56a34af6df83e756a0de540ba1341d6a35e46af4"
    ]

 << 200 OK 28b
    content-type: application/json
    content-length: 28
    date: Tue, 07 Jan 2025 18:54:54 GMT

    {
        "version": 2,
        "proposers": []
    }
```

## References

- [1] The reference to majordomo can be found here: https://github.com/wealdtech/go-majordomo/blob/a3d534c394016eaa23769c61791e428206e575ae/confidants/http/service.go#L184-L188