### PR TITLE
Remove info logs from past forks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,7 +166,6 @@ linters:
     - err113
     - exhaustive
     - exhaustruct
-    - exportloopref
     - forcetypeassert
     - funlen
     - gci
@@ -182,6 +181,7 @@ linters:
     - nlreturn
     - perfsprint
     - promlinter
+    - tenv
     - varnamelen
     - wrapcheck
     - wsl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,35 +82,9 @@ run:
 
 # output configuration options
 output:
-  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  #
-  # Multiple can be specified by separating them by comma, output can be provided
-  # for each of them by separating format name and path by colon symbol.
-  # Output path can be either `stdout`, `stderr` or path to the file to write to.
-  # Example: "checkstyle:report.json,colored-line-number"
-  #
-  # Default: colored-line-number
-  # format: json
-
-  # Print lines of code with issue.
-  # Default: true
-  # print-issued-lines: false
-
-  # Print linter name in the end of issue text.
-  # Default: true
-  # print-linter-name: false
-
-  # Make issues output unique by line.
-  # Default: true
-  # uniq-by-line: false
-
-  # Add a prefix to the output file references.
-  # Default is no prefix.
-  # path-prefix: ""
-
-  # Sort results by: filepath, line and column.
-  # sort-results: true
-
+  formats:
+    - format: colored-line-number
+      path: stderr
 
 # All available settings of specific linters.
 linters-settings:

--- a/main.go
+++ b/main.go
@@ -325,7 +325,7 @@ func startServices(ctx context.Context,
 		return nil, nil, errors.Wrap(err, "failed to wait for genesis block")
 	}
 
-	altairCapable, bellatrixCapable, _, err := consensusClientCapabilities(ctx, eth2Client)
+	altairCapable, bellatrixCapable, err := consensusClientCapabilities(ctx, eth2Client)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1587,40 +1587,29 @@ func runCommands(ctx context.Context,
 	return false
 }
 
-func consensusClientCapabilities(ctx context.Context, consensusClient eth2client.Service) (bool, bool, bool, error) {
+func consensusClientCapabilities(ctx context.Context, consensusClient eth2client.Service) (bool, bool, error) {
 	// Decide if the ETH2 client is capable of Altair.
 	altairCapable := false
 	specResponse, err := consensusClient.(eth2client.SpecProvider).Spec(ctx, &api.SpecOpts{})
 	if err != nil {
-		return false, false, false, errors.Wrap(err, "failed to obtain spec")
+		return false, false, errors.Wrap(err, "failed to obtain spec")
 	}
 	spec := specResponse.Data
 	if _, exists := spec["ALTAIR_FORK_EPOCH"]; exists {
 		altairCapable = true
-		log.Info().Msg("Client is Altair-capable")
 	} else {
-		log.Info().Msg("Client is not Altair-capable")
+		log.Warn().Msg("Client is not Altair-capable")
 	}
 
-	// Decide if the ETH2 client is capabale of Bellatrix.
+	// Decide if the ETH2 client is capable of Bellatrix.
 	bellatrixCapable := false
 	if _, exists := spec["BELLATRIX_FORK_EPOCH"]; exists {
 		bellatrixCapable = true
-		log.Info().Msg("Client is Bellatrix-capable")
 	} else {
-		log.Info().Msg("Client is not Bellatrix-capable")
+		log.Warn().Msg("Client is not Bellatrix-capable")
 	}
 
-	// Decide if the ETH2 client is capabale of Capella.
-	capellaCapable := false
-	if _, exists := spec["CAPELLA_FORK_EPOCH"]; exists {
-		capellaCapable = true
-		log.Info().Msg("Client is Capella-capable")
-	} else {
-		log.Info().Msg("Client is not Capella-capable")
-	}
-
-	return altairCapable, bellatrixCapable, capellaCapable, nil
+	return altairCapable, bellatrixCapable, nil
 }
 
 func startBlockRelay(ctx context.Context,


### PR DESCRIPTION
The logs stating we are altair/bellatrix/capella capable are a bit misleading as we don't have corresponding deneb/electra log messages. 

Removing the logs saying past forks are supported. 

Some linter updates also