### PR TITLE
Use combined attestation pool strategy.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.2
 require (
 	github.com/attestantio/go-block-relay v0.4.4
 	github.com/attestantio/go-builder-client v0.6.1
-	github.com/attestantio/go-eth2-client v0.24.2
+	github.com/attestantio/go-eth2-client v0.25.0
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/holiman/uint256 v1.3.2
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/attestantio/go-block-relay v0.4.4 h1:GhU8KdwOGA3squVCzFQ5H9G+63/ggmWu
 github.com/attestantio/go-block-relay v0.4.4/go.mod h1:S6OLyaLiLnxI8VRwJLJnDkTn2VdBZ/fSbePBjEfQlFM=
 github.com/attestantio/go-builder-client v0.6.1 h1:fn6PC8aDWx2YbptstR1JKP8NyakiNJJTiOE5f9N0z5Q=
 github.com/attestantio/go-builder-client v0.6.1/go.mod h1:f8wi3HzuPxfJoi2PirpJK3yZhte4SavDgKJbRrKoB1Q=
-github.com/attestantio/go-eth2-client v0.24.2 h1:fMYpPtoA8ZavCpbO0VJLA7Op9z/BSJR7xJSBECtGC8g=
-github.com/attestantio/go-eth2-client v0.24.2/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
+github.com/attestantio/go-eth2-client v0.25.0 h1:wLQxoteGCbTE/vKCMASx1ze+Zm9rcqtltRnblaLJup4=
+github.com/attestantio/go-eth2-client v0.25.0/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/aws/aws-sdk-go v1.44.81/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=

--- a/mock/eth2client.go
+++ b/mock/eth2client.go
@@ -1643,11 +1643,11 @@ func NewAttestationPoolProvider() eth2client.AttestationPoolProvider {
 func (*AttestationPoolProvider) AttestationPool(_ context.Context,
 	_ *api.AttestationPoolOpts,
 ) (
-	*api.Response[[]*phase0.Attestation],
+	*api.Response[[]*spec.VersionedAttestation],
 	error,
 ) {
-	return &api.Response[[]*phase0.Attestation]{
-		Data:     []*phase0.Attestation{},
+	return &api.Response[[]*spec.VersionedAttestation]{
+		Data:     []*spec.VersionedAttestation{},
 		Metadata: make(map[string]any),
 	}, nil
 }
@@ -1664,7 +1664,7 @@ func NewErroringAttestationPoolProvider() eth2client.AttestationPoolProvider {
 func (*ErroringAttestationPoolProvider) AttestationPool(_ context.Context,
 	_ *api.AttestationPoolOpts,
 ) (
-	*api.Response[[]*phase0.Attestation],
+	*api.Response[[]*spec.VersionedAttestation],
 	error,
 ) {
 	return nil, errors.New("mock error")
@@ -1688,7 +1688,7 @@ func NewSleepyAttestationPoolProvider(wait time.Duration, next eth2client.Attest
 func (m *SleepyAttestationPoolProvider) AttestationPool(ctx context.Context,
 	opts *api.AttestationPoolOpts,
 ) (
-	*api.Response[[]*phase0.Attestation],
+	*api.Response[[]*spec.VersionedAttestation],
 	error,
 ) {
 	time.Sleep(m.wait)

--- a/services/multiinstance/staticdelay/parameters.go
+++ b/services/multiinstance/staticdelay/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024, 2025 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import (
 type parameters struct {
 	logLevel                   zerolog.Level
 	monitor                    metrics.Service
+	specProvider               consensusclient.SpecProvider
 	attestationPoolProvider    consensusclient.AttestationPoolProvider
 	beaconBlockHeadersProvider consensusclient.BeaconBlockHeadersProvider
 	chainTime                  chaintime.Service
@@ -56,6 +57,13 @@ func WithLogLevel(logLevel zerolog.Level) Parameter {
 func WithMonitor(monitor metrics.Service) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.monitor = monitor
+	})
+}
+
+// WithSpecProvider sets the specification provider for the module.
+func WithSpecProvider(provider consensusclient.SpecProvider) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.specProvider = provider
 	})
 }
 
@@ -106,6 +114,9 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 
 	if parameters.monitor == nil {
 		return nil, errors.New("no monitor specified")
+	}
+	if parameters.specProvider == nil {
+		return nil, errors.New("no spec provider specified")
 	}
 	if parameters.attestationPoolProvider == nil {
 		return nil, errors.New("no attestation pool provider specified")

--- a/services/multiinstance/staticdelay/service.go
+++ b/services/multiinstance/staticdelay/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024, 2025 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	consensusclient "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/metrics"
 	"github.com/pkg/errors"
@@ -35,6 +36,7 @@ type Service struct {
 	attestationPoolProvider    consensusclient.AttestationPoolProvider
 	beaconBlockHeadersProvider consensusclient.BeaconBlockHeadersProvider
 	chainTime                  chaintime.Service
+	specAttestationDelay       time.Duration
 	attesterDelay              time.Duration
 	attesterActive             atomic.Bool
 	proposerDelay              time.Duration
@@ -58,12 +60,19 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		return nil, errors.New("failed to register metrics")
 	}
 
+	specAttestationDelay, err := obtainSpecAttestationDelay(ctx, parameters.specProvider)
+	if err != nil {
+		return nil, err
+	}
+	log.Trace().Dur("delay", specAttestationDelay).Msg("Obtained spec attestation delay")
+
 	s := &Service{
 		log:                        log,
 		monitor:                    parameters.monitor,
 		attestationPoolProvider:    parameters.attestationPoolProvider,
 		beaconBlockHeadersProvider: parameters.beaconBlockHeadersProvider,
 		chainTime:                  parameters.chainTime,
+		specAttestationDelay:       specAttestationDelay,
 		attesterDelay:              parameters.attesterDelay,
 		proposerDelay:              parameters.proposerDelay,
 	}
@@ -98,4 +107,40 @@ func (s *Service) disableProposer(_ context.Context) {
 func (s *Service) enableProposer(_ context.Context) {
 	s.proposerActive.Store(true)
 	monitorActive("proposer", true)
+}
+
+func obtainSpecAttestationDelay(ctx context.Context,
+	specProvider consensusclient.SpecProvider,
+) (
+	time.Duration,
+	error,
+) {
+	specResponse, err := specProvider.Spec(ctx, &api.SpecOpts{})
+	if err != nil {
+		return 0, err
+	}
+	spec := specResponse.Data
+
+	tmp, exists := spec["SECONDS_PER_SLOT"]
+	if !exists {
+		return 0, errors.New("failed to obtain SECONDS_PER_SLOT")
+	}
+	secondsPerSlot, isDuration := tmp.(time.Duration)
+	if !isDuration {
+		return 0, errors.New("seconds per slot not a duration")
+	}
+
+	tmp, exists = spec["INTERVALS_PER_SLOT"]
+	if !exists {
+		// Some nodes do not provide this value, so use the default from mainnet.
+		tmp = uint64(3)
+	}
+	intervalsPerSlot, isUint64 := tmp.(uint64)
+	if !isUint64 {
+		return 0, errors.New("intervals per slot not a uint64")
+	}
+
+	delay := secondsPerSlot / time.Duration(intervalsPerSlot)
+
+	return delay, nil
 }

--- a/services/multiinstance/staticdelay/service_test.go
+++ b/services/multiinstance/staticdelay/service_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024, 2025 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -58,6 +58,7 @@ func TestService(t *testing.T) {
 			params: []staticdelay.Parameter{
 				staticdelay.WithLogLevel(zerolog.Disabled),
 				staticdelay.WithMonitor(nil),
+				staticdelay.WithSpecProvider(specProvider),
 				staticdelay.WithAttestationPoolProvider(attestationPoolProvider),
 				staticdelay.WithBeaconBlockHeadersProvider(beaconBlockHeadersProvider),
 				staticdelay.WithChainTime(chainTime),
@@ -67,10 +68,25 @@ func TestService(t *testing.T) {
 			err: "problem with parameters: no monitor specified",
 		},
 		{
-			name: "AttestationProviderMissing",
+			name: "SpecProviderMissing",
 			params: []staticdelay.Parameter{
 				staticdelay.WithLogLevel(zerolog.Disabled),
 				staticdelay.WithMonitor(monitor),
+				staticdelay.WithSpecProvider(nil),
+				staticdelay.WithAttestationPoolProvider(attestationPoolProvider),
+				staticdelay.WithBeaconBlockHeadersProvider(beaconBlockHeadersProvider),
+				staticdelay.WithChainTime(chainTime),
+				staticdelay.WithAttesterDelay(100 * time.Millisecond),
+				staticdelay.WithProposerDelay(100 * time.Millisecond),
+			},
+			err: "problem with parameters: no spec provider specified",
+		},
+		{
+			name: "AttestationPoolProviderMissing",
+			params: []staticdelay.Parameter{
+				staticdelay.WithLogLevel(zerolog.Disabled),
+				staticdelay.WithMonitor(monitor),
+				staticdelay.WithSpecProvider(specProvider),
 				staticdelay.WithAttestationPoolProvider(nil),
 				staticdelay.WithBeaconBlockHeadersProvider(beaconBlockHeadersProvider),
 				staticdelay.WithChainTime(chainTime),
@@ -84,6 +100,7 @@ func TestService(t *testing.T) {
 			params: []staticdelay.Parameter{
 				staticdelay.WithLogLevel(zerolog.Disabled),
 				staticdelay.WithMonitor(monitor),
+				staticdelay.WithSpecProvider(specProvider),
 				staticdelay.WithAttestationPoolProvider(attestationPoolProvider),
 				staticdelay.WithBeaconBlockHeadersProvider(nil),
 				staticdelay.WithChainTime(chainTime),
@@ -97,6 +114,7 @@ func TestService(t *testing.T) {
 			params: []staticdelay.Parameter{
 				staticdelay.WithLogLevel(zerolog.Disabled),
 				staticdelay.WithMonitor(monitor),
+				staticdelay.WithSpecProvider(specProvider),
 				staticdelay.WithAttestationPoolProvider(attestationPoolProvider),
 				staticdelay.WithBeaconBlockHeadersProvider(beaconBlockHeadersProvider),
 				staticdelay.WithChainTime(nil),
@@ -110,6 +128,7 @@ func TestService(t *testing.T) {
 			params: []staticdelay.Parameter{
 				staticdelay.WithLogLevel(zerolog.Disabled),
 				staticdelay.WithMonitor(monitor),
+				staticdelay.WithSpecProvider(specProvider),
 				staticdelay.WithAttestationPoolProvider(attestationPoolProvider),
 				staticdelay.WithBeaconBlockHeadersProvider(beaconBlockHeadersProvider),
 				staticdelay.WithChainTime(chainTime),
@@ -123,6 +142,7 @@ func TestService(t *testing.T) {
 			params: []staticdelay.Parameter{
 				staticdelay.WithLogLevel(zerolog.Disabled),
 				staticdelay.WithMonitor(monitor),
+				staticdelay.WithSpecProvider(specProvider),
 				staticdelay.WithAttestationPoolProvider(attestationPoolProvider),
 				staticdelay.WithBeaconBlockHeadersProvider(beaconBlockHeadersProvider),
 				staticdelay.WithChainTime(chainTime),
@@ -136,6 +156,7 @@ func TestService(t *testing.T) {
 			params: []staticdelay.Parameter{
 				staticdelay.WithLogLevel(zerolog.Disabled),
 				staticdelay.WithMonitor(monitor),
+				staticdelay.WithSpecProvider(specProvider),
 				staticdelay.WithAttestationPoolProvider(attestationPoolProvider),
 				staticdelay.WithBeaconBlockHeadersProvider(beaconBlockHeadersProvider),
 				staticdelay.WithChainTime(chainTime),

--- a/services/multiinstance/staticdelay/shouldattest.go
+++ b/services/multiinstance/staticdelay/shouldattest.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024, 2025 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,10 +15,10 @@ package staticdelay
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/attester"
 )
 
@@ -41,15 +41,30 @@ func (s *Service) ShouldAttest(ctx context.Context, duty *attester.Duty) bool {
 	}
 
 	// Sleep to let other instances do their work.
+	// Start off by sleeping until 4 seconds into the slot.
+	time.Sleep(time.Until(s.chainTime.StartOfSlot(duty.Slot()).Add(s.specAttestationDelay)))
+	// Now sleep for the additional attester delay.
 	time.Sleep(s.attesterDelay)
+	log.Trace().Msg("Checking for attestations from an active instance")
 
 	// Look for any attestations that we are meant to generate that are already in the node's attestation pool.
 	slot := duty.Slot()
+
+	// Turn the duty information into maps for easy lookup.
+	// Map is committee index -> validator offset in committee.
+	committeesMap := make(map[phase0.CommitteeIndex]map[uint64]phase0.ValidatorIndex)
+	for i, validatorIndex := range duty.ValidatorIndices() {
+		committeeIndex := duty.CommitteeIndices()[i]
+		validatorCommitteeIndex := duty.ValidatorCommitteeIndices()[i]
+		if _, exists := committeesMap[committeeIndex]; !exists {
+			committeesMap[committeeIndex] = make(map[uint64]phase0.ValidatorIndex)
+		}
+		committeesMap[committeeIndex][validatorCommitteeIndex] = validatorIndex
+	}
+
 	// Go through the committee indices one at a time, to avoid overloading ourselves with attestations from the pool, and because
 	// we expect to find attestations in all committees if the network is behaving so don't pull data unnecessarily.
-	for _, committeeIndex := range duty.CommitteeIndices() {
-		log.Info().Uint64("slot", uint64(slot)).Uint64("committee_index", uint64(committeeIndex)).Msg("Checking committee for existing attestations")
-		validatorCommitteeIndices := duty.ValidatorCommitteeIndices()
+	for committeeIndex, dutyAttestations := range committeesMap {
 		resp, err := s.attestationPoolProvider.AttestationPool(ctx, &api.AttestationPoolOpts{
 			Slot:           &slot,
 			CommitteeIndex: &committeeIndex,
@@ -60,12 +75,25 @@ func (s *Service) ShouldAttest(ctx context.Context, duty *attester.Duty) bool {
 		}
 
 		for _, attestation := range resp.Data {
-			if slices.ContainsFunc(validatorCommitteeIndices, func(index uint64) bool { return attestation.AggregationBits.BitAt(index) }) {
-				// An attestation is already in the pool; we don't need to act.
-				log.Trace().Msg("Another instance is attesting; not activating attester")
-				s.disableAttester(ctx)
+			// We only accept single-committee attestations.
+			if _, err := attestation.CommitteeIndex(); err != nil {
+				continue
+			}
 
-				return false
+			aggregationBits, err := attestation.AggregationBits()
+			if err != nil {
+				log.Warn().Err(err).Msg("Failed to obtain aggregation bits")
+				continue
+			}
+			for validatorCommitteeIndex := range dutyAttestations {
+				if aggregationBits.BitAt(validatorCommitteeIndex) {
+					// if slices.ContainsFunc(validatorCommitteeIndices, func(index uint64) bool { return attestation.AggregationBits.BitAt(index) }) {
+					// An attestation is already in the pool; we don't need to act.
+					log.Trace().Msg("Another instance is attesting; not activating attester")
+					s.disableAttester(ctx)
+
+					return false
+				}
 			}
 		}
 	}

--- a/strategies/attestationpool/combined/attestationdata_test.go
+++ b/strategies/attestationpool/combined/attestationdata_test.go
@@ -1,0 +1,172 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package combined_test
+
+// TODO
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/cache"
+	mockcache "github.com/attestantio/vouch/services/cache/mock"
+	standardchaintime "github.com/attestantio/vouch/services/chaintime/standard"
+	"github.com/attestantio/vouch/strategies/attestationdata/best"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttestationData(t *testing.T) {
+	ctx := context.Background()
+
+	genesisTime := time.Now()
+	genesisProvider := mock.NewGenesisProvider(genesisTime)
+	specProvider := mock.NewSpecProvider()
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisProvider(genesisProvider),
+		standardchaintime.WithSpecProvider(specProvider),
+	)
+	require.NoError(t, err)
+
+	cache := mockcache.New(map[phase0.Root]phase0.Slot{}).(cache.BlockRootToSlotProvider)
+
+	tests := []struct {
+		name           string
+		params         []best.Parameter
+		slot           phase0.Slot
+		committeeIndex phase0.CommitteeIndex
+		err            string
+		logEntries     []string
+	}{
+		{
+			name: "Good",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(2 * time.Second),
+				best.WithAttestationDataProviders(map[string]eth2client.AttestationDataProvider{
+					"good": mock.NewAttestationDataProvider(),
+				}),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			slot:           12345,
+			committeeIndex: 3,
+		},
+		{
+			name: "Timeout",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(time.Second),
+				best.WithAttestationDataProviders(map[string]eth2client.AttestationDataProvider{
+					"sleepy": mock.NewSleepyAttestationDataProvider(5*time.Second, mock.NewAttestationDataProvider()),
+				}),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			slot:           12345,
+			committeeIndex: 3,
+			err:            "no attestations received",
+		},
+		{
+			name: "GoodMixed",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(2 * time.Second),
+				best.WithAttestationDataProviders(map[string]eth2client.AttestationDataProvider{
+					"error":  mock.NewErroringAttestationDataProvider(),
+					"sleepy": mock.NewSleepyAttestationDataProvider(time.Second, mock.NewAttestationDataProvider()),
+				}),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			slot:           12345,
+			committeeIndex: 3,
+		},
+		{
+			name: "SoftTimeoutWithResponses",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(3 * time.Second),
+				best.WithAttestationDataProviders(map[string]eth2client.AttestationDataProvider{
+					"good":   mock.NewAttestationDataProvider(),
+					"sleepy": mock.NewSleepyAttestationDataProvider(2*time.Second, mock.NewAttestationDataProvider()),
+				}),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			slot:           12345,
+			committeeIndex: 3,
+			logEntries:     []string{"Soft timeout reached with responses"},
+		},
+		{
+			name: "SoftTimeoutWithoutResponses",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(3 * time.Second),
+				best.WithAttestationDataProviders(map[string]eth2client.AttestationDataProvider{
+					"sleepy": mock.NewSleepyAttestationDataProvider(2*time.Second, mock.NewAttestationDataProvider()),
+				}),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			slot:           12345,
+			committeeIndex: 3,
+			logEntries:     []string{"Soft timeout reached with no responses"},
+		},
+		{
+			name: "SoftTimeoutWithError",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(3 * time.Second),
+				best.WithAttestationDataProviders(map[string]eth2client.AttestationDataProvider{
+					"error":  mock.NewErroringAttestationDataProvider(),
+					"sleepy": mock.NewSleepyAttestationDataProvider(2*time.Second, mock.NewAttestationDataProvider()),
+				}),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			slot:           12345,
+			committeeIndex: 3,
+			logEntries:     []string{"Soft timeout reached with no responses"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capture := logger.NewLogCapture()
+			s, err := best.New(context.Background(), test.params...)
+			require.NoError(t, err)
+			attestationData, err := s.AttestationData(context.Background(), &api.AttestationDataOpts{
+				Slot:           test.slot,
+				CommitteeIndex: test.committeeIndex,
+			})
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, attestationData)
+			}
+			for _, entry := range test.logEntries {
+				capture.AssertHasEntry(t, entry)
+			}
+		})
+	}
+}

--- a/strategies/attestationpool/combined/attestationpool.go
+++ b/strategies/attestationpool/combined/attestationpool.go
@@ -1,0 +1,220 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package combined
+
+import (
+	"context"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/util"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type attestationPoolResponse struct {
+	provider     string
+	attestations []*spec.VersionedAttestation
+}
+
+type attestationPoolError struct {
+	provider string
+	err      error
+}
+
+// AttestationPool provides the combined attestation pools from a number of beacon nodes.
+func (s *Service) AttestationPool(ctx context.Context,
+	opts *api.AttestationPoolOpts,
+) (
+	*api.Response[[]*spec.VersionedAttestation],
+	error,
+) {
+	ctx, span := otel.Tracer("attestantio.vouch.strategies.attestationpool.combined").Start(ctx, "AttestationPool")
+	defer span.End()
+
+	started := time.Now()
+	log := util.LogWithID(ctx, s.log, "strategy_id").With().Logger()
+	if opts.Slot != nil {
+		log = log.With().Uint64("slot", uint64(*opts.Slot)).Logger()
+	}
+
+	// We have two timeouts: a soft timeout and a hard timeout.
+	// At the soft timeout, we return if we have any responses so far.
+	// At the hard timeout, we return unconditionally.
+	// The soft timeout is half the duration of the hard timeout.
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	softCtx, softCancel := context.WithTimeout(ctx, s.timeout/2)
+
+	requests := len(s.attestationPoolProviders)
+
+	respCh := make(chan *attestationPoolResponse, requests)
+	errCh := make(chan *attestationPoolError, requests)
+	// Kick off the requests.
+	for name, provider := range s.attestationPoolProviders {
+		go s.attestationPool(ctx, started, name, provider, respCh, errCh, opts)
+	}
+
+	// Wait for all responses (or context done).
+	responded := 0
+	errored := 0
+	timedOut := 0
+	softTimedOut := 0
+
+	attestations := make(map[phase0.Root]*spec.VersionedAttestation)
+
+	// Loop 1: prior to soft timeout.
+	for responded+errored+timedOut+softTimedOut != requests {
+		select {
+		case resp := <-respCh:
+			responded++
+			log.Trace().
+				Dur("elapsed", time.Since(started)).
+				Str("provider", resp.provider).
+				Int("responded", responded).
+				Int("errored", errored).
+				Int("timed_out", timedOut).
+				Msg("Response received")
+			for _, attestation := range resp.attestations {
+				root, err := attestation.HashTreeRoot()
+				if err != nil {
+					log.Warn().Err(err).Msg("Failed to obtain hash tree root for attestation")
+					continue
+				}
+				attestations[root] = attestation
+			}
+		case err := <-errCh:
+			errored++
+			log.Debug().
+				Dur("elapsed", time.Since(started)).
+				Str("provider", err.provider).
+				Int("responded", responded).
+				Int("errored", errored).
+				Int("timed_out", timedOut).
+				Err(err.err).
+				Msg("Error received")
+		case <-softCtx.Done():
+			// If we have any responses at this point we consider the non-responders timed out.
+			if responded > 0 {
+				timedOut = requests - responded - errored
+				log.Debug().
+					Dur("elapsed", time.Since(started)).
+					Int("responded", responded).
+					Int("errored", errored).
+					Int("timed_out", timedOut).
+					Msg("Soft timeout reached with responses")
+			} else {
+				log.Debug().
+					Dur("elapsed", time.Since(started)).
+					Int("errored", errored).
+					Msg("Soft timeout reached with no responses")
+			}
+			// Set the number of requests that have soft timed out.
+			softTimedOut = requests - responded - errored - timedOut
+		}
+	}
+	softCancel()
+
+	// Loop 2: after soft timeout.
+	for responded+errored+timedOut != requests {
+		select {
+		case resp := <-respCh:
+			responded++
+			log.Trace().
+				Dur("elapsed", time.Since(started)).
+				Str("provider", resp.provider).
+				Int("responded", responded).
+				Int("errored", errored).
+				Int("timed_out", timedOut).
+				Msg("Response received")
+			for _, attestation := range resp.attestations {
+				root, err := attestation.HashTreeRoot()
+				if err != nil {
+					log.Warn().Err(err).Msg("Failed to obtain hash tree root for attestation")
+					continue
+				}
+				attestations[root] = attestation
+			}
+		case err := <-errCh:
+			errored++
+			log.Debug().
+				Dur("elapsed", time.Since(started)).
+				Str("provider", err.provider).
+				Int("responded", responded).
+				Int("errored", errored).
+				Int("timed_out", timedOut).
+				Err(err.err).
+				Msg("Error received")
+		case <-ctx.Done():
+			// Anyone not responded by now is considered errored.
+			timedOut = requests - responded - errored
+			log.Debug().
+				Dur("elapsed", time.Since(started)).
+				Int("responded", responded).
+				Int("errored", errored).
+				Int("timed_out", timedOut).
+				Msg("Hard timeout reached")
+		}
+	}
+	cancel()
+	log.Trace().
+		Dur("elapsed", time.Since(started)).
+		Int("responded", responded).
+		Int("errored", errored).
+		Int("timed_out", timedOut).
+		Msg("Results")
+
+	attestationsSlice := make([]*spec.VersionedAttestation, 0, len(attestations))
+	for _, attestation := range attestations {
+		attestationsSlice = append(attestationsSlice, attestation)
+	}
+
+	return &api.Response[[]*spec.VersionedAttestation]{
+		Data:     attestationsSlice,
+		Metadata: make(map[string]any),
+	}, nil
+}
+
+func (s *Service) attestationPool(ctx context.Context,
+	started time.Time,
+	name string,
+	provider eth2client.AttestationPoolProvider,
+	respCh chan *attestationPoolResponse,
+	errCh chan *attestationPoolError,
+	opts *api.AttestationPoolOpts,
+) {
+	ctx, span := otel.Tracer("attestantio.vouch.strategies.attestationpool.combined").Start(ctx, "attestationPool", trace.WithAttributes(
+		attribute.String("provider", name),
+	))
+	defer span.End()
+
+	response, err := provider.AttestationPool(ctx, opts)
+	s.clientMonitor.ClientOperation(name, "attestation pool", err == nil, time.Since(started))
+	if err != nil {
+		errCh <- &attestationPoolError{
+			provider: name,
+			err:      err,
+		}
+		return
+	}
+	s.log.Trace().Dur("elapsed", time.Since(started)).Msg("Obtained attestation pool")
+
+	respCh <- &attestationPoolResponse{
+		provider:     name,
+		attestations: response.Data,
+	}
+}

--- a/strategies/attestationpool/combined/parameters.go
+++ b/strategies/attestationpool/combined/parameters.go
@@ -1,0 +1,97 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package combined is a strategy that obtains attestation pools from
+// multiple nodes and combines them into a single set.
+package combined
+
+import (
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/vouch/services/metrics"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+type parameters struct {
+	logLevel                 zerolog.Level
+	clientMonitor            metrics.ClientMonitor
+	attestationPoolProviders map[string]eth2client.AttestationPoolProvider
+	timeout                  time.Duration
+}
+
+// Parameter is the interface for service parameters.
+type Parameter interface {
+	apply(p *parameters)
+}
+
+type parameterFunc func(*parameters)
+
+func (f parameterFunc) apply(p *parameters) {
+	f(p)
+}
+
+// WithLogLevel sets the log level for the module.
+func WithLogLevel(logLevel zerolog.Level) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.logLevel = logLevel
+	})
+}
+
+// WithClientMonitor sets the client monitor for the service.
+func WithClientMonitor(monitor metrics.ClientMonitor) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.clientMonitor = monitor
+	})
+}
+
+// WithAttestationPoolProviders sets the attestation pool providers.
+func WithAttestationPoolProviders(providers map[string]eth2client.AttestationPoolProvider) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.attestationPoolProviders = providers
+	})
+}
+
+// WithTimeout sets the timeout for requests.
+func WithTimeout(timeout time.Duration) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.timeout = timeout
+	})
+}
+
+// parseAndCheckParameters parses and checks parameters to ensure that mandatory parameters are present and correct.
+func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
+	parameters := parameters{
+		logLevel:      zerolog.GlobalLevel(),
+		clientMonitor: nullmetrics.New(),
+	}
+	for _, p := range params {
+		if params != nil {
+			p.apply(&parameters)
+		}
+	}
+
+	if parameters.timeout == 0 {
+		return nil, errors.New("no timeout specified")
+	}
+	if parameters.clientMonitor == nil {
+		return nil, errors.New("no client monitor specified")
+	}
+	if len(parameters.attestationPoolProviders) == 0 {
+		return nil, errors.New("no attestation pool providers specified")
+	}
+
+	return &parameters, nil
+}

--- a/strategies/attestationpool/combined/service.go
+++ b/strategies/attestationpool/combined/service.go
@@ -1,0 +1,56 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package combined
+
+import (
+	"context"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/vouch/services/metrics"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	zerologger "github.com/rs/zerolog/log"
+)
+
+// Service is the provider for attestation pools.
+type Service struct {
+	log                      zerolog.Logger
+	clientMonitor            metrics.ClientMonitor
+	attestationPoolProviders map[string]eth2client.AttestationPoolProvider
+	timeout                  time.Duration
+}
+
+// New creates a new attestation data strategy.
+func New(_ context.Context, params ...Parameter) (*Service, error) {
+	parameters, err := parseAndCheckParameters(params...)
+	if err != nil {
+		return nil, errors.Wrap(err, "problem with parameters")
+	}
+
+	// Set logging.
+	log := zerologger.With().Str("strategy", "attestationdata").Str("impl", "best").Logger()
+	if parameters.logLevel != log.GetLevel() {
+		log = log.Level(parameters.logLevel)
+	}
+
+	s := &Service{
+		log:                      log,
+		timeout:                  parameters.timeout,
+		clientMonitor:            parameters.clientMonitor,
+		attestationPoolProviders: parameters.attestationPoolProviders,
+	}
+
+	return s, nil
+}

--- a/strategies/attestationpool/combined/service_test.go
+++ b/strategies/attestationpool/combined/service_test.go
@@ -1,0 +1,185 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package combined_test
+
+// TODO
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/mock"
+	"github.com/attestantio/vouch/services/cache"
+	mockcache "github.com/attestantio/vouch/services/cache/mock"
+	standardchaintime "github.com/attestantio/vouch/services/chaintime/standard"
+	"github.com/attestantio/vouch/strategies/attestationdata/best"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService(t *testing.T) {
+	ctx := context.Background()
+
+	attestationDataProviders := map[string]eth2client.AttestationDataProvider{
+		"localhost:1": mock.NewAttestationDataProvider(),
+	}
+
+	genesisTime := time.Now()
+	genesisProvider := mock.NewGenesisProvider(genesisTime)
+	specProvider := mock.NewSpecProvider()
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisProvider(genesisProvider),
+		standardchaintime.WithSpecProvider(specProvider),
+	)
+	require.NoError(t, err)
+
+	cache := mockcache.New(map[phase0.Root]phase0.Slot{}).(cache.BlockRootToSlotProvider)
+
+	tests := []struct {
+		name   string
+		params []best.Parameter
+		err    string
+	}{
+		{
+			name: "TimeoutMissing",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithAttestationDataProviders(attestationDataProviders),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			err: "problem with parameters: no timeout specified",
+		},
+		{
+			name: "TimeoutZero",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(0),
+				best.WithAttestationDataProviders(attestationDataProviders),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			err: "problem with parameters: no timeout specified",
+		},
+		{
+			name: "ClientMonitorMissing",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(2 * time.Second),
+				best.WithClientMonitor(nil),
+				best.WithAttestationDataProviders(attestationDataProviders),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			err: "problem with parameters: no client monitor specified",
+		},
+		{
+			name: "AttestationDataProvidersNil",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(2 * time.Second),
+				best.WithAttestationDataProviders(nil),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			err: "problem with parameters: no attestation data providers specified",
+		},
+		{
+			name: "AttestationDataProvidersEmpty",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(2 * time.Second),
+				best.WithAttestationDataProviders(map[string]eth2client.AttestationDataProvider{}),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			err: "problem with parameters: no attestation data providers specified",
+		},
+		{
+			name: "ChainTimeMissing",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(2 * time.Second),
+				best.WithAttestationDataProviders(attestationDataProviders),
+				best.WithBlockRootToSlotCache(cache),
+			},
+			err: "problem with parameters: no chain time service specified",
+		},
+		{
+			name: "Good",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(2 * time.Second),
+				best.WithAttestationDataProviders(attestationDataProviders),
+				best.WithChainTime(chainTime),
+				best.WithBlockRootToSlotCache(cache),
+			},
+		},
+		{
+			name: "BlockRootToSlotCacheMissing",
+			params: []best.Parameter{
+				best.WithLogLevel(zerolog.TraceLevel),
+				best.WithTimeout(2 * time.Second),
+				best.WithAttestationDataProviders(attestationDataProviders),
+				best.WithChainTime(chainTime),
+			},
+			err: "problem with parameters: no block root to slot cache specified",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := best.New(context.Background(), test.params...)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInterfaces(t *testing.T) {
+	ctx := context.Background()
+
+	attestationDataProviders := map[string]eth2client.AttestationDataProvider{
+		"localhost:1": mock.NewAttestationDataProvider(),
+	}
+
+	genesisTime := time.Now()
+	genesisProvider := mock.NewGenesisProvider(genesisTime)
+	specProvider := mock.NewSpecProvider()
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisProvider(genesisProvider),
+		standardchaintime.WithSpecProvider(specProvider),
+	)
+	require.NoError(t, err)
+
+	cache := mockcache.New(map[phase0.Root]phase0.Slot{}).(cache.BlockRootToSlotProvider)
+
+	s, err := best.New(context.Background(),
+		best.WithLogLevel(zerolog.Disabled),
+		best.WithTimeout(2*time.Second),
+		best.WithAttestationDataProviders(attestationDataProviders),
+		best.WithChainTime(chainTime),
+		best.WithBlockRootToSlotCache(cache),
+	)
+	require.NoError(t, err)
+	require.Implements(t, (*eth2client.AttestationDataProvider)(nil), s)
+}


### PR DESCRIPTION
Provider a combined attestation pool strategy, that combines information from multiple beacon nodes.