### PR TITLE
scheduleSyncCommitteeMessages with epoch zero causes underflow

### DIFF
--- a/services/controller/standard/synccommitteemessenger.go
+++ b/services/controller/standard/synccommitteemessenger.go
@@ -47,7 +47,10 @@ func (s *Service) scheduleSyncCommitteeMessages(ctx context.Context,
 	}
 	// If we are in the sync committee that starts at slot x we need to generate a message during slot x-1
 	// for it to be included in slot x, hence -1.
-	firstSlot := s.chainTimeService.FirstSlotOfEpoch(firstEpoch) - 1
+	firstSlot := s.chainTimeService.FirstSlotOfEpoch(firstEpoch)
+	if firstSlot != 0 {
+		firstSlot -= 1
+	}
 	if firstSlot < s.chainTimeService.CurrentSlot() {
 		firstSlot = s.chainTimeService.CurrentSlot()
 	}


### PR DESCRIPTION
While running Vouch in Kurtosis I noticed this log soon after starting:
```
{"level":"trace","service":"controller","impl":"standard","first_slot":18446744073709551615,"last_slot":8190,"time":"2025-05-12T14:43:15.164Z","message":"Setting sync committee duties for period"}
```
which I believe is caused by calling `scheduleSyncCommitteeMessages` with epoch zero causing `firstSlot` to underflow to `2^64-1` due to this [code](https://github.com/attestantio/vouch/blob/9574bc748b55dafac0bce78f0fd4993cf7759b89/services/controller/standard/synccommitteemessenger.go#L50):
```
firstSlot := s.chainTimeService.FirstSlotOfEpoch(firstEpoch) - 1
if firstSlot < s.chainTimeService.CurrentSlot() {
	firstSlot = s.chainTimeService.CurrentSlot()
}
```
This resulted in no sync messages being scheduled.
Is this intended behavior ?

This PR simply adds a check before subtracting and seems to fix my issue locally.