### PR TITLE
Add service-specific timeout configuration for builderclient interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ dev:
   - add 'attester.grace' grace period to attester service
   - de-duplicate signing roots if we have duplicate values to sign
   - import latest go-eth2-client for complex Spec types
+  - add service-specific timeout configs for builderclient interactions
 
 1.10.3:
 - import latest go-builder-client for copying execution requests on unblinding

--- a/services/blockrelay/standard/submitvalidatorregistrations.go
+++ b/services/blockrelay/standard/submitvalidatorregistrations.go
@@ -225,7 +225,7 @@ func (s *Service) submitRelayRegistrations(ctx context.Context,
 			))
 			defer span.End()
 
-			client, err := util.FetchBuilderClient(ctx, builder, monitor, s.releaseVersion)
+			client, err := util.FetchBuilderClient(ctx, "submitvalidatorregistrations", builder, monitor, s.releaseVersion)
 			if err != nil {
 				s.log.Error().Err(err).Str("builder", builder).Msg("Failed to fetch builder client")
 				return

--- a/services/blockrelay/standard/unblindblock.go
+++ b/services/blockrelay/standard/unblindblock.go
@@ -111,7 +111,7 @@ func (s *Service) unblindersForProposal(ctx context.Context,
 
 	providers := make([]builderclient.UnblindedProposalProvider, 0, len(proposerConfig.Relays))
 	for _, relay := range proposerConfig.Relays {
-		builderClient, err := util.FetchBuilderClient(ctx, relay.Address, s.monitor, s.releaseVersion)
+		builderClient, err := util.FetchBuilderClient(ctx, "blockrelay", relay.Address, s.monitor, s.releaseVersion)
 		if err != nil {
 			// Error but continue.
 			s.log.Error().Err(err).Msg("Failed to obtain builder client for unblinding")

--- a/strategies/builderbid/best/builderbid.go
+++ b/strategies/builderbid/best/builderbid.go
@@ -292,7 +292,7 @@ func (s *Service) issueBuilderBidRequests(ctx context.Context,
 	errCh := make(chan *builderBidError, requests)
 	// Kick off the requests.  Continue on errors to issue as many requests as we are able.
 	for _, relay := range proposerConfig.Relays {
-		builderClient, err := util.FetchBuilderClient(ctx, relay.Address, s.monitor, s.releaseVersion)
+		builderClient, err := util.FetchBuilderClient(ctx, "strategies.builderbid", relay.Address, s.monitor, s.releaseVersion)
 		if err != nil {
 			log.Error().Str("address", builderClient.Address()).Err(err).Msg("Failed to obtain builder client for block auction")
 			continue

--- a/strategies/builderbid/deadline/builderbid.go
+++ b/strategies/builderbid/deadline/builderbid.go
@@ -94,7 +94,7 @@ func (s *Service) BuilderBid(ctx context.Context,
 	// Kick off the requests.
 
 	for _, relay := range proposerConfig.Relays {
-		builderClient, err := util.FetchBuilderClient(ctx, relay.Address, s.monitor, s.releaseVersion)
+		builderClient, err := util.FetchBuilderClient(ctx, "strategies.builderbid", relay.Address, s.monitor, s.releaseVersion)
 		if err != nil {
 			// Error but continue.
 			log.Error().Err(err).Msg("Failed to obtain builder client for block auction")

--- a/util/builders.go
+++ b/util/builders.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-// setServiceDefaults sets default timeouts for builderclient services only if not already configured
-func setServiceDefaults() {
+// SetServiceDefaults sets default timeouts for builderclient services only if not already configured.
+func SetServiceDefaults() {
 	if viper.GetDuration("builderclient.blockrelay.timeout") == 0 && !viper.IsSet("builderclient.blockrelay.timeout") {
 		viper.SetDefault("builderclient.blockrelay.timeout", "10s")
 	}
@@ -50,8 +50,8 @@ func FetchBuilderClient(ctx context.Context, service string, address string, mon
 		return nil, errors.New("no address supplied")
 	}
 
-	// Set service defaults only if not already configured
-	setServiceDefaults()
+	// Set service defaults only if not already configured.
+	SetServiceDefaults()
 
 	buildersMu.Lock()
 	defer buildersMu.Unlock()
@@ -59,7 +59,7 @@ func FetchBuilderClient(ctx context.Context, service string, address string, mon
 		builders = make(map[string]builder.Service)
 	}
 
-	// Create a unique cache key that includes the service to allow different configurations per service
+	// Create a unique cache key that includes the service to allow different configurations per service.
 	cacheKey := fmt.Sprintf("%s:%s", service, address)
 
 	extraHeaders, err := builderClientHeaders(address, releaseVersion)
@@ -69,7 +69,7 @@ func FetchBuilderClient(ctx context.Context, service string, address string, mon
 
 	client, exists := builders[cacheKey]
 	if !exists {
-		// Build timeout path: builderclient.service.address
+		// Build timeout path: builderclient.service.address.
 		var timeoutPath string
 		if service != "" {
 			timeoutPath = fmt.Sprintf("builderclient.%s.%s", service, address)
@@ -77,7 +77,7 @@ func FetchBuilderClient(ctx context.Context, service string, address string, mon
 			timeoutPath = fmt.Sprintf("builderclient.%s", address)
 		}
 
-		// Build log level path: builderclient.service.address
+		// Build log level path: builderclient.service.address.
 		var logLevelPath string
 		if service != "" {
 			logLevelPath = fmt.Sprintf("builderclient.%s.%s", service, address)

--- a/util/builders.go
+++ b/util/builders.go
@@ -69,26 +69,18 @@ func FetchBuilderClient(ctx context.Context, service string, address string, mon
 
 	client, exists := builders[cacheKey]
 	if !exists {
-		// Build timeout path: builderclient.service.address.
-		var timeoutPath string
+		// Build configuration path: builderclient.service.address.
+		var configPath string
 		if service != "" {
-			timeoutPath = fmt.Sprintf("builderclient.%s.%s", service, address)
+			configPath = fmt.Sprintf("builderclient.%s.%s", service, address)
 		} else {
-			timeoutPath = fmt.Sprintf("builderclient.%s", address)
-		}
-
-		// Build log level path: builderclient.service.address.
-		var logLevelPath string
-		if service != "" {
-			logLevelPath = fmt.Sprintf("builderclient.%s.%s", service, address)
-		} else {
-			logLevelPath = fmt.Sprintf("builderclient.%s", address)
+			configPath = fmt.Sprintf("builderclient.%s", address)
 		}
 
 		client, err = httpclient.New(ctx,
 			httpclient.WithMonitor(monitor),
-			httpclient.WithLogLevel(LogLevel(logLevelPath)),
-			httpclient.WithTimeout(Timeout(timeoutPath)),
+			httpclient.WithLogLevel(LogLevel(configPath)),
+			httpclient.WithTimeout(Timeout(configPath)),
 			httpclient.WithAddress(address),
 			httpclient.WithExtraHeaders(extraHeaders),
 		)

--- a/util/builders_test.go
+++ b/util/builders_test.go
@@ -1,0 +1,242 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/attestantio/vouch/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// mockMonitor is a mock implementation of metrics.Service for testing.
+type mockMonitor struct{}
+
+func (m *mockMonitor) Presenter() string                    { return "mock" }
+func (m *mockMonitor) Gauge(string) func(float64)           { return func(float64) {} }
+func (m *mockMonitor) Counter(string) func(uint64)          { return func(uint64) {} }
+func (m *mockMonitor) Histogram(string) func(time.Duration) { return func(time.Duration) {} }
+
+// setupViperDefaults sets up common viper defaults for tests.
+func setupViperDefaults() {
+	viper.Reset()
+	viper.SetDefault("timeout", "2s")
+	util.SetServiceDefaults()
+}
+
+// createMockServer creates a simple HTTP test server.
+func createMockServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func TestTimeoutHierarchy(t *testing.T) {
+	tests := []struct {
+		name     string
+		vars     map[string]string
+		address  string
+		expected time.Duration
+	}{
+		{
+			name:     "EmptyAddress",
+			address:  "",
+			expected: 2 * time.Second,
+		},
+		{
+			name: "GlobalBuilderClientTimeout",
+			vars: map[string]string{
+				"timeout":               "2s",
+				"builderclient.timeout": "5s",
+			},
+			address:  "relay.example.com",
+			expected: 5 * time.Second,
+		},
+		{
+			name: "SpecificRelayTimeout",
+			vars: map[string]string{
+				"timeout":               "2s",
+				"builderclient.timeout": "5s",
+				"builderclient.relay.example.com.timeout": "3s",
+			},
+			address:  "relay.example.com",
+			expected: 3 * time.Second,
+		},
+		{
+			name: "FallbackToServiceGlobal",
+			vars: map[string]string{
+				"timeout":               "2s",
+				"builderclient.timeout": "5s",
+				"builderclient.submitvalidatorregistrations.timeout": "30s",
+			},
+			address:  "relay.example.com",
+			expected: 5 * time.Second,
+		},
+		{
+			name: "FallbackToGlobalDefault",
+			vars: map[string]string{
+				"timeout": "10s",
+			},
+			address:  "relay.example.com",
+			expected: 10 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupViperDefaults()
+
+			for k, v := range test.vars {
+				viper.Set(k, v)
+			}
+
+			timeoutPath := fmt.Sprintf("builderclient.%s", test.address)
+			timeout := util.Timeout(timeoutPath)
+			require.Equal(t, test.expected, timeout)
+		})
+	}
+}
+
+func TestTimeoutWithServices(t *testing.T) {
+	tests := []struct {
+		name     string
+		vars     map[string]string
+		service  string
+		address  string
+		expected time.Duration
+	}{
+		{
+			name: "SubmitValidatorRegistrations",
+			vars: map[string]string{
+				"timeout":               "2s",
+				"builderclient.timeout": "5s",
+				"builderclient.submitvalidatorregistrations.timeout":                   "30s",
+				"builderclient.submitvalidatorregistrations.relay.example.com.timeout": "20s",
+			},
+			service:  "submitvalidatorregistrations",
+			address:  "relay.example.com",
+			expected: 20 * time.Second,
+		},
+		{
+			name: "SubmitValidatorRegistrationsWithoutAddress",
+			vars: map[string]string{
+				"timeout":               "2s",
+				"builderclient.timeout": "5s",
+				"builderclient.submitvalidatorregistrations.timeout":                   "30s",
+				"builderclient.submitvalidatorregistrations.relay.example.com.timeout": "20s",
+			},
+			service:  "submitvalidatorregistrations",
+			address:  "",
+			expected: 30 * time.Second,
+		},
+		{
+			name: "BuilderBidStrategy",
+			vars: map[string]string{
+				"timeout":               "2s",
+				"builderclient.timeout": "5s",
+				"builderclient.strategies.builderbid.timeout": "1s",
+			},
+			service:  "strategies.builderbid",
+			address:  "",
+			expected: 1 * time.Second,
+		},
+		{
+			name: "BlockRelay",
+			vars: map[string]string{
+				"timeout":                          "2s",
+				"builderclient.timeout":            "5s",
+				"builderclient.blockrelay.timeout": "4s",
+			},
+			service:  "blockrelay",
+			address:  "",
+			expected: 4 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupViperDefaults()
+
+			for k, v := range test.vars {
+				viper.Set(k, v)
+			}
+
+			ctx := context.Background()
+			monitor := &mockMonitor{}
+			server := createMockServer()
+			defer server.Close()
+
+			_, err := util.FetchBuilderClient(ctx, test.service, server.URL, monitor, "test-version")
+			require.NoError(t, err)
+
+			timeoutPath := fmt.Sprintf("builderclient.%s.%s", test.service, test.address)
+			timeout := util.Timeout(timeoutPath)
+			require.Equal(t, test.expected, timeout)
+		})
+	}
+}
+
+func TestServiceDefaultTimeouts(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  string
+		expected time.Duration
+	}{
+		{
+			name:     "BlockRelayDefault",
+			service:  "blockrelay",
+			expected: 10 * time.Second,
+		},
+		{
+			name:     "SubmitValidatorRegistrationsDefault",
+			service:  "submitvalidatorregistrations",
+			expected: 5 * time.Second,
+		},
+		{
+			name:     "StrategiesBuilderbidDefault",
+			service:  "strategies.builderbid",
+			expected: 5 * time.Second,
+		},
+		{
+			name:     "UnknownServiceNoDefault",
+			service:  "unknownservice",
+			expected: 2 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupViperDefaults()
+
+			ctx := context.Background()
+			monitor := &mockMonitor{}
+			server := createMockServer()
+			defer server.Close()
+
+			client, err := util.FetchBuilderClient(ctx, test.service, server.URL, monitor, "test-version")
+			require.NoError(t, err)
+			require.NotNil(t, client)
+
+			timeoutPath := fmt.Sprintf("builderclient.%s.%s", test.service, server.URL)
+			timeout := util.Timeout(timeoutPath)
+			require.Equal(t, test.expected, timeout, "Service: %s", test.service)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR implements service-specific timeout configuration for builderclient interactions with MEV-boost relays. The current implementation uses a single global timeout for all builderclient operations, but different services (validator registration, bid fetching, block unblinding) have different performance characteristics and would benefit from tailored timeout values.

The solution adds hierarchical timeout configuration following the pattern `builderclient.{service}.{address}.timeout` with service-specific defaults: 10s for blockrelay operations, 5s for validator registrations and builder bid strategies.

## Changes

- Add service-specific timeout configuration pattern `builderclient.{service}.{address}.timeout`
- Implement default timeouts: 10s for blockrelay, 5s for submitvalidatorregistrations and strategies.builderbid
- Add hierarchical timeout resolution with fallback chain: service+address → service → builderclient → global
- Update builderclient caching to use service-specific cache keys
- Add comprehensive test coverage for timeout resolution and edge cases
- Update configuration documentation with builderclient timeout examples
- Optimize test suite by consolidating helper functions and removing code duplication
- Consolidate duplicate path construction logic in FetchBuilderClient