### PR TITLE
Fix sync committee duplicate-pubkey rejection in signRootsMulti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ dev:
   - update go-eth2-client to v0.28.0
   - update go version to 1.25
   - cancel open http requests when strategies.builderbid.best.timeout is reached
+  - fix sync committee signing when a validator occupies multiple positions
 
 1.12.0:
   - import fulu container specs from go-eth2-client

--- a/services/signer/standard/helpers.go
+++ b/services/signer/standard/helpers.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -109,14 +109,78 @@ func (*Service) signRootsMulti(ctx context.Context,
 
 	uniqueSigs := make([]phase0.BLSSignature, len(uniqueAccounts))
 
+	// All accounts are homogeneous (same signer type) — enforced upstream by signRootsByAccountType.
 	if multiSigner, isMultiSigner := uniqueAccounts[0].(e2wtypes.AccountProtectingMultiSigner); isMultiSigner {
-		signatures, err := multiSigner.SignGenericMulti(ctx, uniqueAccounts, uniqueData, domain[:])
-		if err != nil {
-			return []phase0.BLSSignature{}, err
+		// Split into batches where each batch contains at most one entry per account.
+		// Dirk rejects Multisign batches with duplicate pubkeys, even with different signing roots.
+		// Single pass: count occurrences per account and determine number of batches needed.
+		accountOccurrences := make(map[uuid.UUID]int, len(uniqueAccounts))
+		numBatches := 0
+		for _, acct := range uniqueAccounts {
+			id := acct.ID()
+			next := accountOccurrences[id]
+			accountOccurrences[id] = next + 1
+			if next+1 > numBatches {
+				numBatches = next + 1
+			}
 		}
-		for i := range signatures {
-			if signatures[i] != nil {
-				copy(uniqueSigs[i][:], signatures[i].Marshal())
+
+		if numBatches == 1 {
+			// Fast path: all accounts are unique, single batch.
+			signatures, err := multiSigner.SignGenericMulti(ctx, uniqueAccounts, uniqueData, domain[:])
+			if err != nil {
+				return []phase0.BLSSignature{}, err
+			}
+			for i := range signatures {
+				if signatures[i] != nil {
+					copy(uniqueSigs[i][:], signatures[i].Marshal())
+				}
+			}
+		} else {
+			// Slow path: split entries into numBatches batches.
+			type batchEntry struct {
+				uniqueIdx int
+				account   e2wtypes.Account
+				data      []byte
+			}
+			batchSizes := make([]int, numBatches)
+			for _, count := range accountOccurrences {
+				for b := range count {
+					batchSizes[b]++
+				}
+			}
+			batches := make([][]batchEntry, numBatches)
+			for i := range batches {
+				batches[i] = make([]batchEntry, 0, batchSizes[i])
+			}
+			batchAssignment := make(map[uuid.UUID]int, len(uniqueAccounts))
+			for i, acct := range uniqueAccounts {
+				id := acct.ID()
+				batchIdx := batchAssignment[id]
+				batchAssignment[id] = batchIdx + 1
+				batches[batchIdx] = append(batches[batchIdx], batchEntry{
+					uniqueIdx: i,
+					account:   acct,
+					data:      uniqueData[i],
+				})
+			}
+
+			for _, batch := range batches {
+				batchAccounts := make([]e2wtypes.Account, len(batch))
+				batchData := make([][]byte, len(batch))
+				for j, entry := range batch {
+					batchAccounts[j] = entry.account
+					batchData[j] = entry.data
+				}
+				signatures, err := multiSigner.SignGenericMulti(ctx, batchAccounts, batchData, domain[:])
+				if err != nil {
+					return []phase0.BLSSignature{}, err
+				}
+				for j, entry := range batch {
+					if signatures[j] != nil {
+						copy(uniqueSigs[entry.uniqueIdx][:], signatures[j].Marshal())
+					}
+				}
 			}
 		}
 	} else {

--- a/services/signer/standard/helpers.go
+++ b/services/signer/standard/helpers.go
@@ -105,12 +105,25 @@ func signMulti(ctx context.Context,
 		return sigs, nil
 	}
 
-	// Slow path: split entries into per-account-unique batches.
-	type batchEntry struct {
-		idx     int
-		account e2wtypes.Account
-		data    []byte
-	}
+	return signMultiBatched(ctx, multiSigner, accounts, data, domain, numBatches, accountOccurrences)
+}
+
+type batchEntry struct {
+	idx     int
+	account e2wtypes.Account
+	data    []byte
+}
+
+func signMultiBatched(ctx context.Context,
+	multiSigner e2wtypes.AccountProtectingMultiSigner,
+	accounts []e2wtypes.Account,
+	data [][]byte,
+	domain []byte,
+	numBatches int,
+	accountOccurrences map[uuid.UUID]int,
+) ([]phase0.BLSSignature, error) {
+	sigs := make([]phase0.BLSSignature, len(accounts))
+
 	batchSizes := make([]int, numBatches)
 	for _, count := range accountOccurrences {
 		for b := range count {

--- a/services/signer/standard/helpers.go
+++ b/services/signer/standard/helpers.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	e2types "github.com/wealdtech/go-eth2-types/v2"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
@@ -61,7 +62,14 @@ func (*Service) sign(ctx context.Context,
 	return signature, nil
 }
 
+// dedupKey identifies a unique (account, root) pair for deduplication.
+type dedupKey struct {
+	accountID uuid.UUID
+	root      phase0.Root
+}
+
 // signRootsMulti signs multiple roots for multiple accounts, using protected methods if possible.
+// Duplicate (account, root) pairs are deduplicated so that signing is only performed once per unique pair.
 func (*Service) signRootsMulti(ctx context.Context,
 	accounts []e2wtypes.Account,
 	roots []phase0.Root,
@@ -73,34 +81,55 @@ func (*Service) signRootsMulti(ctx context.Context,
 	if len(accounts) == 0 {
 		return []phase0.BLSSignature{}, errors.New("no accounts; cannot sign")
 	}
-	sigs := make([]phase0.BLSSignature, len(accounts))
-	data := make([][]byte, len(roots))
-	for i := range roots {
-		data[i] = roots[i][:]
+	if len(accounts) != len(roots) {
+		return []phase0.BLSSignature{}, errors.New("number of accounts and roots do not match")
 	}
 
-	if multiSigner, isMultiSigner := accounts[0].(e2wtypes.AccountProtectingMultiSigner); isMultiSigner {
-		var err error
-		signatures, err := multiSigner.SignGenericMulti(ctx, accounts, data, domain[:])
+	// Deduplicate (account, root) pairs.
+	uniqueMap := make(map[dedupKey]int, len(accounts))
+	indexMapping := make([]int, len(accounts))
+	uniqueAccounts := make([]e2wtypes.Account, 0, len(accounts))
+	uniqueRoots := make([]phase0.Root, 0, len(accounts))
+	for i, acct := range accounts {
+		key := dedupKey{accountID: acct.ID(), root: roots[i]}
+		if idx, exists := uniqueMap[key]; exists {
+			indexMapping[i] = idx
+		} else {
+			uniqueMap[key] = len(uniqueAccounts)
+			indexMapping[i] = len(uniqueAccounts)
+			uniqueAccounts = append(uniqueAccounts, acct)
+			uniqueRoots = append(uniqueRoots, roots[i])
+		}
+	}
+
+	uniqueData := make([][]byte, len(uniqueRoots))
+	for i := range uniqueRoots {
+		uniqueData[i] = uniqueRoots[i][:]
+	}
+
+	uniqueSigs := make([]phase0.BLSSignature, len(uniqueAccounts))
+
+	if multiSigner, isMultiSigner := uniqueAccounts[0].(e2wtypes.AccountProtectingMultiSigner); isMultiSigner {
+		signatures, err := multiSigner.SignGenericMulti(ctx, uniqueAccounts, uniqueData, domain[:])
 		if err != nil {
 			return []phase0.BLSSignature{}, err
 		}
 		for i := range signatures {
 			if signatures[i] != nil {
-				copy(sigs[i][:], signatures[i].Marshal())
+				copy(uniqueSigs[i][:], signatures[i].Marshal())
 			}
 		}
 	} else {
-		for i := range accounts {
+		for i := range uniqueAccounts {
 			container := phase0.SigningData{
-				ObjectRoot: roots[i],
+				ObjectRoot: uniqueRoots[i],
 				Domain:     domain,
 			}
 			hashTreeRoot, err := container.HashTreeRoot()
 			if err != nil {
 				return []phase0.BLSSignature{}, errors.Wrap(err, "failed to generate hash tree root")
 			}
-			signer, isAccountSigner := accounts[i].(e2wtypes.AccountSigner)
+			signer, isAccountSigner := uniqueAccounts[i].(e2wtypes.AccountSigner)
 			if !isAccountSigner {
 				return []phase0.BLSSignature{}, errors.New("unknown signer type; cannot sign")
 			}
@@ -108,9 +137,16 @@ func (*Service) signRootsMulti(ctx context.Context,
 			if err != nil {
 				return []phase0.BLSSignature{}, err
 			}
-			copy(sigs[i][:], sig.Marshal())
+			copy(uniqueSigs[i][:], sig.Marshal())
 		}
 	}
+
+	// Map unique signatures back to all original positions.
+	sigs := make([]phase0.BLSSignature, len(accounts))
+	for i := range accounts {
+		sigs[i] = uniqueSigs[indexMapping[i]]
+	}
+
 	return sigs, nil
 }
 

--- a/services/signer/standard/helpers.go
+++ b/services/signer/standard/helpers.go
@@ -68,6 +68,92 @@ type dedupKey struct {
 	root      phase0.Root
 }
 
+// signMulti signs multiple roots for multiple accounts using a multi-signer, splitting entries into
+// per-account-unique batches. Dirk rejects batches with duplicate pubkeys, even with different signing roots.
+func signMulti(ctx context.Context,
+	multiSigner e2wtypes.AccountProtectingMultiSigner,
+	accounts []e2wtypes.Account,
+	data [][]byte,
+	domain []byte,
+) ([]phase0.BLSSignature, error) {
+	sigs := make([]phase0.BLSSignature, len(accounts))
+
+	// Count occurrences per account to determine number of batches needed.
+	accountOccurrences := make(map[uuid.UUID]int, len(accounts))
+	numBatches := 0
+	for _, acct := range accounts {
+		id := acct.ID()
+		next := accountOccurrences[id]
+		accountOccurrences[id] = next + 1
+		if next+1 > numBatches {
+			numBatches = next + 1
+		}
+	}
+
+	if numBatches == 1 {
+		// Fast path: all accounts are unique, single batch.
+		signatures, err := multiSigner.SignGenericMulti(ctx, accounts, data, domain)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to sign generic multi")
+		}
+		for i := range signatures {
+			if signatures[i] != nil {
+				copy(sigs[i][:], signatures[i].Marshal())
+			}
+		}
+
+		return sigs, nil
+	}
+
+	// Slow path: split entries into per-account-unique batches.
+	type batchEntry struct {
+		idx     int
+		account e2wtypes.Account
+		data    []byte
+	}
+	batchSizes := make([]int, numBatches)
+	for _, count := range accountOccurrences {
+		for b := range count {
+			batchSizes[b]++
+		}
+	}
+	batches := make([][]batchEntry, numBatches)
+	for i := range batches {
+		batches[i] = make([]batchEntry, 0, batchSizes[i])
+	}
+	batchAssignment := make(map[uuid.UUID]int, len(accounts))
+	for i, acct := range accounts {
+		id := acct.ID()
+		batchIdx := batchAssignment[id]
+		batchAssignment[id] = batchIdx + 1
+		batches[batchIdx] = append(batches[batchIdx], batchEntry{
+			idx:     i,
+			account: acct,
+			data:    data[i],
+		})
+	}
+
+	for _, batch := range batches {
+		batchAccounts := make([]e2wtypes.Account, len(batch))
+		batchData := make([][]byte, len(batch))
+		for j, entry := range batch {
+			batchAccounts[j] = entry.account
+			batchData[j] = entry.data
+		}
+		signatures, err := multiSigner.SignGenericMulti(ctx, batchAccounts, batchData, domain)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to sign generic multi")
+		}
+		for j, entry := range batch {
+			if signatures[j] != nil {
+				copy(sigs[entry.idx][:], signatures[j].Marshal())
+			}
+		}
+	}
+
+	return sigs, nil
+}
+
 // signRootsMulti signs multiple roots for multiple accounts, using protected methods if possible.
 // Duplicate (account, root) pairs are deduplicated so that signing is only performed once per unique pair.
 func (*Service) signRootsMulti(ctx context.Context,
@@ -88,112 +174,46 @@ func (*Service) signRootsMulti(ctx context.Context,
 	// Deduplicate (account, root) pairs.
 	uniqueMap := make(map[dedupKey]int, len(accounts))
 	indexMapping := make([]int, len(accounts))
-	uniqueAccounts := make([]e2wtypes.Account, 0, len(accounts))
-	uniqueRoots := make([]phase0.Root, 0, len(accounts))
+	uniquePairAccounts := make([]e2wtypes.Account, 0, len(accounts))
+	uniquePairRoots := make([]phase0.Root, 0, len(accounts))
 	for i, acct := range accounts {
 		key := dedupKey{accountID: acct.ID(), root: roots[i]}
 		if idx, exists := uniqueMap[key]; exists {
 			indexMapping[i] = idx
 		} else {
-			uniqueMap[key] = len(uniqueAccounts)
-			indexMapping[i] = len(uniqueAccounts)
-			uniqueAccounts = append(uniqueAccounts, acct)
-			uniqueRoots = append(uniqueRoots, roots[i])
+			uniqueMap[key] = len(uniquePairAccounts)
+			indexMapping[i] = len(uniquePairAccounts)
+			uniquePairAccounts = append(uniquePairAccounts, acct)
+			uniquePairRoots = append(uniquePairRoots, roots[i])
 		}
 	}
 
-	uniqueData := make([][]byte, len(uniqueRoots))
-	for i := range uniqueRoots {
-		uniqueData[i] = uniqueRoots[i][:]
+	uniquePairData := make([][]byte, len(uniquePairRoots))
+	for i := range uniquePairRoots {
+		uniquePairData[i] = uniquePairRoots[i][:]
 	}
 
-	uniqueSigs := make([]phase0.BLSSignature, len(uniqueAccounts))
+	var uniquePairSigs []phase0.BLSSignature
 
 	// All accounts are homogeneous (same signer type) — enforced upstream by signRootsByAccountType.
-	if multiSigner, isMultiSigner := uniqueAccounts[0].(e2wtypes.AccountProtectingMultiSigner); isMultiSigner {
-		// Split into batches where each batch contains at most one entry per account.
-		// Dirk rejects Multisign batches with duplicate pubkeys, even with different signing roots.
-		// Single pass: count occurrences per account and determine number of batches needed.
-		accountOccurrences := make(map[uuid.UUID]int, len(uniqueAccounts))
-		numBatches := 0
-		for _, acct := range uniqueAccounts {
-			id := acct.ID()
-			next := accountOccurrences[id]
-			accountOccurrences[id] = next + 1
-			if next+1 > numBatches {
-				numBatches = next + 1
-			}
-		}
-
-		if numBatches == 1 {
-			// Fast path: all accounts are unique, single batch.
-			signatures, err := multiSigner.SignGenericMulti(ctx, uniqueAccounts, uniqueData, domain[:])
-			if err != nil {
-				return []phase0.BLSSignature{}, err
-			}
-			for i := range signatures {
-				if signatures[i] != nil {
-					copy(uniqueSigs[i][:], signatures[i].Marshal())
-				}
-			}
-		} else {
-			// Slow path: split entries into numBatches batches.
-			type batchEntry struct {
-				uniqueIdx int
-				account   e2wtypes.Account
-				data      []byte
-			}
-			batchSizes := make([]int, numBatches)
-			for _, count := range accountOccurrences {
-				for b := range count {
-					batchSizes[b]++
-				}
-			}
-			batches := make([][]batchEntry, numBatches)
-			for i := range batches {
-				batches[i] = make([]batchEntry, 0, batchSizes[i])
-			}
-			batchAssignment := make(map[uuid.UUID]int, len(uniqueAccounts))
-			for i, acct := range uniqueAccounts {
-				id := acct.ID()
-				batchIdx := batchAssignment[id]
-				batchAssignment[id] = batchIdx + 1
-				batches[batchIdx] = append(batches[batchIdx], batchEntry{
-					uniqueIdx: i,
-					account:   acct,
-					data:      uniqueData[i],
-				})
-			}
-
-			for _, batch := range batches {
-				batchAccounts := make([]e2wtypes.Account, len(batch))
-				batchData := make([][]byte, len(batch))
-				for j, entry := range batch {
-					batchAccounts[j] = entry.account
-					batchData[j] = entry.data
-				}
-				signatures, err := multiSigner.SignGenericMulti(ctx, batchAccounts, batchData, domain[:])
-				if err != nil {
-					return []phase0.BLSSignature{}, err
-				}
-				for j, entry := range batch {
-					if signatures[j] != nil {
-						copy(uniqueSigs[entry.uniqueIdx][:], signatures[j].Marshal())
-					}
-				}
-			}
+	if multiSigner, isMultiSigner := uniquePairAccounts[0].(e2wtypes.AccountProtectingMultiSigner); isMultiSigner {
+		var err error
+		uniquePairSigs, err = signMulti(ctx, multiSigner, uniquePairAccounts, uniquePairData, domain[:])
+		if err != nil {
+			return []phase0.BLSSignature{}, err
 		}
 	} else {
-		for i := range uniqueAccounts {
+		uniquePairSigs = make([]phase0.BLSSignature, len(uniquePairAccounts))
+		for i := range uniquePairAccounts {
 			container := phase0.SigningData{
-				ObjectRoot: uniqueRoots[i],
+				ObjectRoot: uniquePairRoots[i],
 				Domain:     domain,
 			}
 			hashTreeRoot, err := container.HashTreeRoot()
 			if err != nil {
 				return []phase0.BLSSignature{}, errors.Wrap(err, "failed to generate hash tree root")
 			}
-			signer, isAccountSigner := uniqueAccounts[i].(e2wtypes.AccountSigner)
+			signer, isAccountSigner := uniquePairAccounts[i].(e2wtypes.AccountSigner)
 			if !isAccountSigner {
 				return []phase0.BLSSignature{}, errors.New("unknown signer type; cannot sign")
 			}
@@ -201,14 +221,14 @@ func (*Service) signRootsMulti(ctx context.Context,
 			if err != nil {
 				return []phase0.BLSSignature{}, err
 			}
-			copy(uniqueSigs[i][:], sig.Marshal())
+			copy(uniquePairSigs[i][:], sig.Marshal())
 		}
 	}
 
 	// Map unique signatures back to all original positions.
 	sigs := make([]phase0.BLSSignature, len(accounts))
 	for i := range accounts {
-		sigs[i] = uniqueSigs[indexMapping[i]]
+		sigs[i] = uniquePairSigs[indexMapping[i]]
 	}
 
 	return sigs, nil

--- a/services/signer/standard/helpers_internal_test.go
+++ b/services/signer/standard/helpers_internal_test.go
@@ -193,6 +193,16 @@ func TestSignRootsMultiBatchSplitting(t *testing.T) {
 			expectedBatches: 1,
 		},
 		{
+			name: "AllDuplicates_FastPath",
+			accounts: func() []*mockMultiSignerAccount {
+				batches := &[]batchRecord{}
+				a := newMockMultiSignerAccount("acct-1", batches)
+				return []*mockMultiSignerAccount{a, a, a}
+			}(),
+			roots:           []phase0.Root{rootA, rootA, rootA},
+			expectedBatches: 1,
+		},
+		{
 			name: "SameAccountDifferentRoots_TwoBatches",
 			accounts: func() []*mockMultiSignerAccount {
 				batches := &[]batchRecord{}

--- a/services/signer/standard/helpers_internal_test.go
+++ b/services/signer/standard/helpers_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020-2026 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	e2types "github.com/wealdtech/go-eth2-types/v2"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
@@ -69,11 +70,216 @@ var (
 	_ e2wtypes.AccountSigner = (*mockSignerAccount)(nil)
 )
 
+// batchRecord records one SignGenericMulti call for verification.
+type batchRecord struct {
+	accountIDs []uuid.UUID
+	data       [][]byte
+}
+
+// mockMultiSignerAccount implements Account and AccountProtectingMultiSigner.
+// All instances sharing the same *batches pointer record calls to SignGenericMulti.
+type mockMultiSignerAccount struct {
+	id      uuid.UUID
+	name    string
+	pubKey  *mockPublicKey
+	batches *[]batchRecord
+}
+
+func (a *mockMultiSignerAccount) ID() uuid.UUID               { return a.id }
+func (a *mockMultiSignerAccount) Name() string                 { return a.name }
+func (a *mockMultiSignerAccount) PublicKey() e2types.PublicKey  { return a.pubKey }
+
+func (a *mockMultiSignerAccount) SignBeaconAttestations(_ context.Context,
+	_ uint64,
+	_ []e2wtypes.Account,
+	_ []uint64,
+	_ []byte,
+	_ uint64,
+	_ []byte,
+	_ uint64,
+	_ []byte,
+	_ []byte,
+) ([]e2types.Signature, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *mockMultiSignerAccount) SignGenericMulti(_ context.Context,
+	accounts []e2wtypes.Account,
+	data [][]byte,
+	_ []byte,
+) ([]e2types.Signature, error) {
+	ids := make([]uuid.UUID, len(accounts))
+	for i, acct := range accounts {
+		ids[i] = acct.ID()
+	}
+	dataCopy := make([][]byte, len(data))
+	for i, d := range data {
+		dataCopy[i] = make([]byte, len(d))
+		copy(dataCopy[i], d)
+	}
+	*a.batches = append(*a.batches, batchRecord{accountIDs: ids, data: dataCopy})
+
+	sigs := make([]e2types.Signature, len(accounts))
+	for i, acct := range accounts {
+		sigData := make([]byte, 96)
+		copy(sigData, append([]byte(acct.Name()+":"), data[i][:8]...))
+		sigs[i] = &mockSignature{data: sigData}
+	}
+
+	return sigs, nil
+}
+
+// Compile-time interface checks for multi-signer mock.
+var (
+	_ e2wtypes.Account                       = (*mockMultiSignerAccount)(nil)
+	_ e2wtypes.AccountProtectingMultiSigner  = (*mockMultiSignerAccount)(nil)
+)
+
+func newMockMultiSignerAccount(name string, batches *[]batchRecord) *mockMultiSignerAccount {
+	return &mockMultiSignerAccount{
+		id:      uuid.New(),
+		name:    name,
+		pubKey:  &mockPublicKey{data: []byte(name)},
+		batches: batches,
+	}
+}
+
 func newMockAccount(name string) *mockSignerAccount {
 	return &mockSignerAccount{
 		id:     uuid.New(),
 		name:   name,
 		pubKey: &mockPublicKey{data: []byte(name)},
+	}
+}
+
+func TestSignRootsMultiBatchSplitting(t *testing.T) {
+	rootA := phase0.Root{0x01}
+	rootB := phase0.Root{0x02}
+	rootC := phase0.Root{0x03}
+	domain := phase0.Domain{0xAA}
+
+	tests := []struct {
+		name            string
+		accounts        []*mockMultiSignerAccount
+		roots           []phase0.Root
+		expectedBatches int // number of SignGenericMulti calls
+	}{
+		{
+			name: "SingleAccount_NoBatchSplit",
+			accounts: func() []*mockMultiSignerAccount {
+				batches := &[]batchRecord{}
+				return []*mockMultiSignerAccount{newMockMultiSignerAccount("acct-1", batches)}
+			}(),
+			roots:           []phase0.Root{rootA},
+			expectedBatches: 1,
+		},
+		{
+			name: "AllUnique_NoBatchSplit",
+			accounts: func() []*mockMultiSignerAccount {
+				batches := &[]batchRecord{}
+				return []*mockMultiSignerAccount{
+					newMockMultiSignerAccount("acct-1", batches),
+					newMockMultiSignerAccount("acct-2", batches),
+					newMockMultiSignerAccount("acct-3", batches),
+				}
+			}(),
+			roots:           []phase0.Root{rootA, rootB, rootC},
+			expectedBatches: 1,
+		},
+		{
+			name: "SameAccountDifferentRoots_TwoBatches",
+			accounts: func() []*mockMultiSignerAccount {
+				batches := &[]batchRecord{}
+				a := newMockMultiSignerAccount("acct-1", batches)
+				return []*mockMultiSignerAccount{a, a}
+			}(),
+			roots:           []phase0.Root{rootA, rootB},
+			expectedBatches: 2,
+		},
+		{
+			name: "SameAccountThreeRoots_ThreeBatches",
+			accounts: func() []*mockMultiSignerAccount {
+				batches := &[]batchRecord{}
+				a := newMockMultiSignerAccount("acct-1", batches)
+				return []*mockMultiSignerAccount{a, a, a}
+			}(),
+			roots:           []phase0.Root{rootA, rootB, rootC},
+			expectedBatches: 3,
+		},
+		{
+			name: "MixedDuplicateAndUnique",
+			accounts: func() []*mockMultiSignerAccount {
+				batches := &[]batchRecord{}
+				a := newMockMultiSignerAccount("acct-1", batches)
+				b := newMockMultiSignerAccount("acct-2", batches)
+				// a signs rootA and rootB (2 subnets), b signs rootA (1 subnet).
+				return []*mockMultiSignerAccount{a, b, a}
+			}(),
+			roots:           []phase0.Root{rootA, rootA, rootB},
+			expectedBatches: 2,
+		},
+		{
+			name: "DedupAndSplit",
+			accounts: func() []*mockMultiSignerAccount {
+				batches := &[]batchRecord{}
+				a := newMockMultiSignerAccount("acct-1", batches)
+				// a signs rootA twice (dedup removes one), then rootB (split needed).
+				return []*mockMultiSignerAccount{a, a, a}
+			}(),
+			roots:           []phase0.Root{rootA, rootA, rootB},
+			expectedBatches: 2,
+		},
+	}
+
+	svc := &Service{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			batches := test.accounts[0].batches
+			*batches = nil // Reset between tests.
+
+			accounts := make([]e2wtypes.Account, len(test.accounts))
+			for i, a := range test.accounts {
+				accounts[i] = a
+			}
+
+			sigs, err := svc.signRootsMulti(context.Background(), accounts, test.roots, domain)
+			require.NoError(t, err)
+			require.Len(t, sigs, len(test.accounts))
+
+			// Verify the number of SignGenericMulti calls (batches).
+			require.Len(t, *batches, test.expectedBatches,
+				"expected %d SignGenericMulti calls, got %d", test.expectedBatches, len(*batches))
+
+			// Verify each batch has unique account IDs (no duplicate pubkeys).
+			for batchIdx, batch := range *batches {
+				seen := make(map[uuid.UUID]bool)
+				for _, id := range batch.accountIDs {
+					require.False(t, seen[id],
+						"batch %d contains duplicate account ID %s", batchIdx, id)
+					seen[id] = true
+				}
+			}
+
+			// Verify signature correctness: each (account, root) pair gets the right signature.
+			type key struct {
+				name string
+				root phase0.Root
+			}
+			sigByKey := make(map[key]phase0.BLSSignature)
+			for i, a := range test.accounts {
+				k := key{name: a.name, root: test.roots[i]}
+				if prev, exists := sigByKey[k]; exists {
+					require.Equal(t, prev, sigs[i],
+						"duplicate (account, root) pairs must produce identical signatures")
+				} else {
+					// Non-zero signature.
+					require.NotEqual(t, phase0.BLSSignature{}, sigs[i],
+						"signature at index %d should not be zero", i)
+					sigByKey[k] = sigs[i]
+				}
+			}
+		})
 	}
 }
 

--- a/services/signer/standard/helpers_internal_test.go
+++ b/services/signer/standard/helpers_internal_test.go
@@ -90,7 +90,7 @@ func (a *mockMultiSignerAccount) ID() uuid.UUID               { return a.id }
 func (a *mockMultiSignerAccount) Name() string                 { return a.name }
 func (a *mockMultiSignerAccount) PublicKey() e2types.PublicKey  { return a.pubKey }
 
-func (a *mockMultiSignerAccount) SignBeaconAttestations(_ context.Context,
+func (*mockMultiSignerAccount) SignBeaconAttestations(_ context.Context,
 	_ uint64,
 	_ []e2wtypes.Account,
 	_ []uint64,

--- a/services/signer/standard/helpers_internal_test.go
+++ b/services/signer/standard/helpers_internal_test.go
@@ -79,10 +79,11 @@ type batchRecord struct {
 // mockMultiSignerAccount implements Account and AccountProtectingMultiSigner.
 // All instances sharing the same *batches pointer record calls to SignGenericMulti.
 type mockMultiSignerAccount struct {
-	id      uuid.UUID
-	name    string
-	pubKey  *mockPublicKey
-	batches *[]batchRecord
+	id           uuid.UUID
+	name         string
+	pubKey       *mockPublicKey
+	batches      *[]batchRecord
+	failOnBatch  *int // if non-nil, SignGenericMulti returns error when len(*batches) == *failOnBatch
 }
 
 func (a *mockMultiSignerAccount) ID() uuid.UUID               { return a.id }
@@ -108,6 +109,10 @@ func (a *mockMultiSignerAccount) SignGenericMulti(_ context.Context,
 	data [][]byte,
 	_ []byte,
 ) ([]e2types.Signature, error) {
+	if a.failOnBatch != nil && len(*a.batches) == *a.failOnBatch {
+		return nil, errors.New("signing failed")
+	}
+
 	ids := make([]uuid.UUID, len(accounts))
 	for i, acct := range accounts {
 		ids[i] = acct.ID()
@@ -163,6 +168,7 @@ func TestSignRootsMultiBatchSplitting(t *testing.T) {
 		accounts        []*mockMultiSignerAccount
 		roots           []phase0.Root
 		expectedBatches int // number of SignGenericMulti calls
+		err             string
 	}{
 		{
 			name: "SingleAccount_NoBatchSplit",
@@ -229,6 +235,31 @@ func TestSignRootsMultiBatchSplitting(t *testing.T) {
 			roots:           []phase0.Root{rootA, rootA, rootB},
 			expectedBatches: 2,
 		},
+		{
+			name: "SingleBatchFails",
+			accounts: func() []*mockMultiSignerAccount {
+				batches := &[]batchRecord{}
+				a := newMockMultiSignerAccount("acct-1", batches)
+				failOn := 0
+				a.failOnBatch = &failOn
+				return []*mockMultiSignerAccount{a}
+			}(),
+			roots: []phase0.Root{rootA},
+			err:   "failed to sign generic multi: signing failed",
+		},
+		{
+			name: "SecondBatchFails",
+			accounts: func() []*mockMultiSignerAccount {
+				batches := &[]batchRecord{}
+				a := newMockMultiSignerAccount("acct-1", batches)
+				failOn := 1
+				a.failOnBatch = &failOn
+				// Same account, two different roots → 2 batches needed, second will fail.
+				return []*mockMultiSignerAccount{a, a}
+			}(),
+			roots: []phase0.Root{rootA, rootB},
+			err:   "failed to sign generic multi: signing failed",
+		},
 	}
 
 	svc := &Service{}
@@ -244,6 +275,11 @@ func TestSignRootsMultiBatchSplitting(t *testing.T) {
 			}
 
 			sigs, err := svc.signRootsMulti(context.Background(), accounts, test.roots, domain)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+
+				return
+			}
 			require.NoError(t, err)
 			require.Len(t, sigs, len(test.accounts))
 

--- a/services/signer/standard/helpers_internal_test.go
+++ b/services/signer/standard/helpers_internal_test.go
@@ -1,0 +1,193 @@
+// Copyright © 2020-2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	e2types "github.com/wealdtech/go-eth2-types/v2"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+// mockSignature implements e2types.Signature for testing.
+type mockSignature struct {
+	data []byte
+}
+
+func (s *mockSignature) Marshal() []byte                                       { return s.data }
+func (*mockSignature) Verify(_ []byte, _ e2types.PublicKey) bool               { return true }
+func (*mockSignature) VerifyAggregate(_ [][]byte, _ []e2types.PublicKey) bool   { return true }
+func (*mockSignature) VerifyAggregateCommon(_ []byte, _ []e2types.PublicKey) bool { return true }
+
+// mockPublicKey implements e2types.PublicKey for testing.
+type mockPublicKey struct {
+	data []byte
+}
+
+func (k *mockPublicKey) Marshal() []byte            { return k.data }
+func (k *mockPublicKey) Copy() e2types.PublicKey     { return k }
+func (*mockPublicKey) Aggregate(_ e2types.PublicKey) {}
+
+// mockSignerAccount implements e2wtypes.Account and e2wtypes.AccountSigner.
+type mockSignerAccount struct {
+	id        uuid.UUID
+	name      string
+	pubKey    *mockPublicKey
+	signCount int
+}
+
+func (a *mockSignerAccount) ID() uuid.UUID             { return a.id }
+func (a *mockSignerAccount) Name() string               { return a.name }
+func (a *mockSignerAccount) PublicKey() e2types.PublicKey { return a.pubKey }
+func (a *mockSignerAccount) Sign(_ context.Context, data []byte) (e2types.Signature, error) {
+	a.signCount++
+	// Return deterministic signature based on account name + data.
+	sigData := make([]byte, 96)
+	copy(sigData, append([]byte(a.name+":"), data[:8]...))
+
+	return &mockSignature{data: sigData}, nil
+}
+
+// Compile-time interface checks.
+var (
+	_ e2wtypes.Account       = (*mockSignerAccount)(nil)
+	_ e2wtypes.AccountSigner = (*mockSignerAccount)(nil)
+)
+
+func newMockAccount(name string) *mockSignerAccount {
+	return &mockSignerAccount{
+		id:     uuid.New(),
+		name:   name,
+		pubKey: &mockPublicKey{data: []byte(name)},
+	}
+}
+
+func TestSignRootsMulti(t *testing.T) {
+	rootA := phase0.Root{0x01}
+	rootB := phase0.Root{0x02}
+	domain := phase0.Domain{0xAA}
+
+	tests := []struct {
+		name             string
+		accounts         []*mockSignerAccount
+		roots            []phase0.Root
+		expectedSignCalls int // total Sign() calls across all accounts
+		err              string
+	}{
+		{
+			name:             "AllUnique",
+			accounts:         []*mockSignerAccount{newMockAccount("acct-1"), newMockAccount("acct-2"), newMockAccount("acct-3")},
+			roots:            []phase0.Root{rootA, rootB, rootA},
+			expectedSignCalls: 3,
+		},
+		{
+			name: "AllDuplicates",
+			accounts: func() []*mockSignerAccount {
+				a := newMockAccount("acct-1")
+				return []*mockSignerAccount{a, a, a}
+			}(),
+			roots:             []phase0.Root{rootA, rootA, rootA},
+			expectedSignCalls: 1,
+		},
+		{
+			name: "Mixed",
+			accounts: func() []*mockSignerAccount {
+				a := newMockAccount("acct-1")
+				b := newMockAccount("acct-2")
+				return []*mockSignerAccount{a, b, a, b}
+			}(),
+			roots:             []phase0.Root{rootA, rootB, rootA, rootA},
+			expectedSignCalls: 3, // (acct-1,rootA), (acct-2,rootB), (acct-2,rootA)
+		},
+		{
+			name:             "Single",
+			accounts:         []*mockSignerAccount{newMockAccount("acct-1")},
+			roots:            []phase0.Root{rootA},
+			expectedSignCalls: 1,
+		},
+		{
+			name:             "Empty",
+			accounts:         []*mockSignerAccount{},
+			roots:            []phase0.Root{},
+			expectedSignCalls: 0,
+			err:              "no accounts; cannot sign",
+		},
+		{
+			name:             "LengthMismatch",
+			accounts:         []*mockSignerAccount{newMockAccount("acct-1"), newMockAccount("acct-2")},
+			roots:            []phase0.Root{rootA},
+			expectedSignCalls: 0,
+			err:              "number of accounts and roots do not match",
+		},
+	}
+
+	svc := &Service{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Reset sign counts.
+			seen := map[string]bool{}
+			for _, a := range test.accounts {
+				if !seen[a.name] {
+					a.signCount = 0
+					seen[a.name] = true
+				}
+			}
+
+			// Convert to interface slices.
+			accounts := make([]e2wtypes.Account, len(test.accounts))
+			for i, a := range test.accounts {
+				accounts[i] = a
+			}
+
+			sigs, err := svc.signRootsMulti(context.Background(), accounts, test.roots, domain)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, sigs, len(test.accounts))
+
+			// Verify sign call count matches expected (dedup reduces calls).
+			totalSignCalls := 0
+			seen = map[string]bool{}
+			for _, a := range test.accounts {
+				if !seen[a.name] {
+					totalSignCalls += a.signCount
+					seen[a.name] = true
+				}
+			}
+			require.Equal(t, test.expectedSignCalls, totalSignCalls, "unexpected number of Sign() calls")
+
+			// Verify duplicate (account, root) pairs produce identical signatures.
+			type key struct {
+				name string
+				root phase0.Root
+			}
+			sigByKey := make(map[key]phase0.BLSSignature)
+			for i, a := range test.accounts {
+				k := key{name: a.name, root: test.roots[i]}
+				if prev, exists := sigByKey[k]; exists {
+					require.Equal(t, prev, sigs[i], "duplicate (account, root) pairs must produce identical signatures")
+				} else {
+					sigByKey[k] = sigs[i]
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sync committee validators can occupy multiple positions, producing duplicate `(account, root)` pairs or same-account entries with different roots that Dirk rejects as a batch. Deduplicate identical pairs and split remaining entries into per-account-unique batches before signing.

Depends on https://github.com/attestantio/vouch/pull/396 for passing the Trivy scan