### PR TITLE
Apply Debian security upgrades in Docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ RUN go build
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR fixes https://github.com/attestantio/vouch/actions/runs/26036524797/job/76536085457?pr=372

## Summary

- Run `apt-get upgrade` in the runtime stage so Debian security updates land on every rebuild — fixes the trivy CI job that started failing as patched packages shipped for `libc-bin`/`libc6` (CVE-2026-0861), `libcap2` (CVE-2026-4878), and `libsystemd0`/`libudev1` (CVE-2026-29111).
- Switch the runtime `RUN` from `apt` to `apt-get` for a stable scripted CLI (`apt` itself warns against use in scripts).
- Split the chain across multiple lines for readability; behavior of `update → upgrade → install ca-certificates → clean → rm` is otherwise unchanged.

## Test plan

- [ ] Trivy scan job passes on this PR (CRITICAL/HIGH count drops from 5 to 0).