### PR TITLE
Satisfy the attgo struct field order and comment capitalisation rules

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// log.
+// Log.
 var log zerolog.Logger
 
 // initLogging initialises logging.

--- a/main.go
+++ b/main.go
@@ -2034,7 +2034,7 @@ func obtainBuilderConfigsForPrivilegedBuilders(_ context.Context,
 	return nil
 }
 
-// select the signed beacon block provider based on user input.
+// Select the signed beacon block provider based on user input.
 func selectSignedBeaconBlockProvider(ctx context.Context,
 	monitor metrics.Service,
 ) (
@@ -2082,7 +2082,7 @@ func selectSignedBeaconBlockProvider(ctx context.Context,
 	return provider, nil
 }
 
-// select the beacon header provider based on user input.
+// Select the beacon header provider based on user input.
 func selectBeaconHeaderProvider(ctx context.Context,
 	monitor metrics.Service,
 ) (

--- a/services/accountmanager/dirk/parameters.go
+++ b/services/accountmanager/dirk/parameters.go
@@ -27,8 +27,11 @@ import (
 )
 
 type parameters struct {
-	logLevel               zerolog.Level
 	monitor                metrics.Service
+	domainProvider         eth2client.DomainProvider
+	farFutureEpochProvider eth2client.FarFutureEpochProvider
+	currentEpochProvider   chaintime.Service
+	logLevel               zerolog.Level
 	timeout                time.Duration
 	clientMonitor          metrics.ClientMonitor
 	processConcurrency     int64
@@ -38,10 +41,7 @@ type parameters struct {
 	clientCertURI          string
 	clientKeyURI           string
 	caCertURI              string
-	domainProvider         eth2client.DomainProvider
 	validatorsManager      validatorsmanager.Service
-	farFutureEpochProvider eth2client.FarFutureEpochProvider
-	currentEpochProvider   chaintime.Service
 }
 
 // Parameter is the interface for service parameters.

--- a/services/accountmanager/dirk/service.go
+++ b/services/accountmanager/dirk/service.go
@@ -46,8 +46,9 @@ import (
 // Service is the manager for dirk accounts.
 type Service struct {
 	log                  zerolog.Logger
-	mutex                sync.RWMutex
 	monitor              metrics.Service
+	domainProvider       eth2client.DomainProvider
+	currentEpochProvider chaintime.Service
 	clientMonitor        metrics.ClientMonitor
 	timeout              time.Duration
 	processConcurrency   int64
@@ -57,10 +58,9 @@ type Service struct {
 	accounts             map[phase0.BLSPubKey]e2wtypes.Account
 	pubKeys              []phase0.BLSPubKey
 	validatorsManager    validatorsmanager.Service
-	domainProvider       eth2client.DomainProvider
 	farFutureEpoch       phase0.Epoch
-	currentEpochProvider chaintime.Service
 	wallets              map[string]e2wtypes.Wallet
+	mutex                sync.RWMutex
 	walletsMutex         sync.RWMutex
 }
 

--- a/services/accountmanager/wallet/parameters.go
+++ b/services/accountmanager/wallet/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,17 +23,17 @@ import (
 )
 
 type parameters struct {
-	logLevel               zerolog.Level
 	monitor                metrics.Service
+	specProvider           eth2client.SpecProvider
+	domainProvider         eth2client.DomainProvider
+	farFutureEpochProvider eth2client.FarFutureEpochProvider
+	currentEpochProvider   chaintime.Service
+	logLevel               zerolog.Level
 	processConcurrency     int64
 	locations              []string
 	accountPaths           []string
 	passphrases            [][]byte
 	validatorsManager      validatorsmanager.Service
-	specProvider           eth2client.SpecProvider
-	domainProvider         eth2client.DomainProvider
-	farFutureEpochProvider eth2client.FarFutureEpochProvider
-	currentEpochProvider   chaintime.Service
 }
 
 // Parameter is the interface for service parameters.

--- a/services/accountmanager/wallet/service.go
+++ b/services/accountmanager/wallet/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2025 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -44,8 +44,9 @@ import (
 // Service is the manager for wallet accounts.
 type Service struct {
 	log                  zerolog.Logger
-	mutex                sync.RWMutex
 	monitor              metrics.Service
+	domainProvider       eth2client.DomainProvider
+	currentEpochProvider chaintime.Service
 	processConcurrency   int64
 	stores               []e2wtypes.Store
 	accountPaths         []string
@@ -53,9 +54,8 @@ type Service struct {
 	accounts             map[phase0.BLSPubKey]e2wtypes.Account
 	validatorsManager    validatorsmanager.Service
 	slotsPerEpoch        phase0.Slot
-	domainProvider       eth2client.DomainProvider
 	farFutureEpoch       phase0.Epoch
-	currentEpochProvider chaintime.Service
+	mutex                sync.RWMutex
 }
 
 // New creates a new wallet account manager.

--- a/services/attestationaggregator/standard/parameters.go
+++ b/services/attestationaggregator/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -25,11 +25,11 @@ import (
 )
 
 type parameters struct {
-	logLevel                       zerolog.Level
 	monitor                        metrics.Service
 	specProvider                   eth2client.SpecProvider
 	validatingAccountsProvider     accountmanager.ValidatingAccountsProvider
 	aggregateAttestationProvider   eth2client.AggregateAttestationProvider
+	logLevel                       zerolog.Level
 	aggregateAttestationsSubmitter submitter.AggregateAttestationsSubmitter
 	slotSelectionSigner            signer.SlotSelectionSigner
 	aggregateAndProofSigner        signer.AggregateAndProofSigner

--- a/services/attestationaggregator/standard/service.go
+++ b/services/attestationaggregator/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -42,10 +42,10 @@ import (
 type Service struct {
 	log                            zerolog.Logger
 	monitor                        metrics.Service
-	targetAggregatorsPerCommittee  uint64
-	slotsPerEpoch                  uint64
 	validatingAccountsProvider     accountmanager.ValidatingAccountsProvider
 	aggregateAttestationProvider   eth2client.AggregateAttestationProvider
+	targetAggregatorsPerCommittee  uint64
+	slotsPerEpoch                  uint64
 	aggregateAttestationsSubmitter submitter.AggregateAttestationsSubmitter
 	slotSelectionSigner            signer.SlotSelectionSigner
 	aggregateAndProofSigner        signer.AggregateAndProofSigner

--- a/services/attester/standard/parameters.go
+++ b/services/attester/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020, 2025 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -27,15 +27,15 @@ import (
 )
 
 type parameters struct {
-	logLevel                   zerolog.Level
-	processConcurrency         int64
 	monitor                    metrics.Service
-	grace                      time.Duration
-	chainTime                  chaintime.Service
 	specProvider               eth2client.SpecProvider
 	attestationDataProvider    eth2client.AttestationDataProvider
-	attestationsSubmitter      submitter.AttestationsSubmitter
 	validatingAccountsProvider accountmanager.ValidatingAccountsProvider
+	logLevel                   zerolog.Level
+	processConcurrency         int64
+	grace                      time.Duration
+	chainTime                  chaintime.Service
+	attestationsSubmitter      submitter.AttestationsSubmitter
 	beaconAttestationsSigner   signer.BeaconAttestationsSigner
 }
 

--- a/services/attester/standard/service.go
+++ b/services/attester/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2025 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -35,18 +35,18 @@ import (
 type Service struct {
 	log                        zerolog.Logger
 	monitor                    metrics.Service
+	validatingAccountsProvider accountmanager.ValidatingAccountsProvider
+	attestationDataProvider    eth2client.AttestationDataProvider
 	processConcurrency         int64
 	slotsPerEpoch              uint64
 	grace                      time.Duration
 	chainTime                  chaintime.Service
-	validatingAccountsProvider accountmanager.ValidatingAccountsProvider
-	attestationDataProvider    eth2client.AttestationDataProvider
 	attestationsSubmitter      submitter.AttestationsSubmitter
 	beaconAttestationsSigner   signer.BeaconAttestationsSigner
 	attested                   map[phase0.Epoch]map[phase0.ValidatorIndex]struct{}
-	attestedMu                 sync.Mutex
 	electraForkEpoch           phase0.Epoch
 	fuluForkEpoch              phase0.Epoch
+	attestedMu                 sync.Mutex
 }
 
 // New creates a new beacon block attester.

--- a/services/beaconcommitteesubscriber/standard/parameters.go
+++ b/services/beaconcommitteesubscriber/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020, 2022 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,11 +24,11 @@ import (
 )
 
 type parameters struct {
-	logLevel                 zerolog.Level
-	processConcurrency       int64
 	monitor                  metrics.Service
 	chainTimeService         chaintime.Service
 	attesterDutiesProvider   eth2client.AttesterDutiesProvider
+	logLevel                 zerolog.Level
+	processConcurrency       int64
 	beaconCommitteeSubmitter submitter.BeaconCommitteeSubscriptionsSubmitter
 	attestationAggregator    attestationaggregator.Service
 }

--- a/services/beaconcommitteesubscriber/standard/service.go
+++ b/services/beaconcommitteesubscriber/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -31,8 +31,8 @@ type Service struct {
 	log                    zerolog.Logger
 	monitor                metrics.Service
 	chainTimeService       chaintime.Service
-	processConcurrency     int64
 	attesterDutiesProvider eth2client.AttesterDutiesProvider
+	processConcurrency     int64
 	attestationAggregator  attestationaggregator.Service
 	submitter              submitter.BeaconCommitteeSubscriptionsSubmitter
 }

--- a/services/blockrelay/standard/parameters.go
+++ b/services/blockrelay/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2023 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -33,8 +33,12 @@ import (
 )
 
 type parameters struct {
-	logLevel                                  zerolog.Level
 	monitor                                   metrics.Service
+	accountsProvider                          accountmanager.AccountsProvider
+	validatorsProvider                        consensusclient.ValidatorsProvider
+	validatingAccountsProvider                accountmanager.ValidatingAccountsProvider
+	builderBidProvider                        builderbid.Provider
+	logLevel                                  zerolog.Level
 	majordomo                                 majordomo.Service
 	scheduler                                 scheduler.Service
 	listenAddress                             string
@@ -45,14 +49,10 @@ type parameters struct {
 	clientCertURL                             string
 	clientKeyURL                              string
 	caCertURL                                 string
-	accountsProvider                          accountmanager.AccountsProvider
-	validatorsProvider                        consensusclient.ValidatorsProvider
-	validatingAccountsProvider                accountmanager.ValidatingAccountsProvider
 	validatorRegistrationSigner               signer.ValidatorRegistrationSigner
 	secondaryValidatorRegistrationsSubmitters []consensusclient.ValidatorRegistrationsSubmitter
 	logResults                                bool
 	releaseVersion                            string
-	builderBidProvider                        builderbid.Provider
 	builderConfigs                            map[phase0.BLSPubKey]*blockrelay.BuilderConfig
 }
 
@@ -263,7 +263,7 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	if _, _, err := net.SplitHostPort(parameters.listenAddress); err != nil {
 		return nil, errors.New("listen address malformed")
 	}
-	// config URL can be empty.
+	// Config URL can be empty.
 	if parameters.releaseVersion == "" {
 		return nil, errors.New("no release version specified")
 	}

--- a/services/blockrelay/standard/parameters.go
+++ b/services/blockrelay/standard/parameters.go
@@ -227,52 +227,51 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 		p.apply(&parameters)
 	}
 
-	if parameters.monitor == nil {
-		return nil, errors.New("no monitor specified")
-	}
-	if parameters.majordomo == nil {
-		return nil, errors.New("no majordomo specified")
-	}
-	if parameters.scheduler == nil {
-		return nil, errors.New("no scheduler specified")
-	}
-	if parameters.chainTime == nil {
-		return nil, errors.New("no chaintime specified")
-	}
-	if bytes.Equal(parameters.fallbackFeeRecipient[:], zeroExecutionAddress[:]) {
-		return nil, errors.New("no fallback fee recipient specified")
-	}
-	if parameters.fallbackGasLimit == 0 {
-		return nil, errors.New("no fallback gas limit specified")
-	}
-	if parameters.accountsProvider == nil {
-		return nil, errors.New("no accounts provider specified")
-	}
-	if parameters.validatorsProvider == nil {
-		return nil, errors.New("no validators provider specified")
-	}
-	if parameters.validatingAccountsProvider == nil {
-		return nil, errors.New("no validating accounts provider specified")
-	}
-	if parameters.validatorRegistrationSigner == nil {
-		return nil, errors.New("no validator registration signer specified")
-	}
-	if parameters.listenAddress == "" {
-		return nil, errors.New("no listen address specified")
-	}
-	if _, _, err := net.SplitHostPort(parameters.listenAddress); err != nil {
-		return nil, errors.New("listen address malformed")
-	}
-	// Config URL can be empty.
-	if parameters.releaseVersion == "" {
-		return nil, errors.New("no release version specified")
-	}
-	if parameters.builderBidProvider == nil {
-		return nil, errors.New("no builder bid provider specified")
-	}
-	if parameters.builderConfigs == nil {
-		return nil, errors.New("no builder configs specified")
+	if err := parameters.validate(); err != nil {
+		return nil, err
 	}
 
 	return &parameters, nil
+}
+
+func (p *parameters) validate() error {
+	checks := []struct {
+		valid bool
+		err   string
+	}{
+		{p.monitor != nil, "no monitor specified"},
+		{p.majordomo != nil, "no majordomo specified"},
+		{p.scheduler != nil, "no scheduler specified"},
+		{p.chainTime != nil, "no chaintime specified"},
+		{!bytes.Equal(p.fallbackFeeRecipient[:], zeroExecutionAddress[:]), "no fallback fee recipient specified"},
+		{p.fallbackGasLimit != 0, "no fallback gas limit specified"},
+		{p.accountsProvider != nil, "no accounts provider specified"},
+		{p.validatorsProvider != nil, "no validators provider specified"},
+		{p.validatingAccountsProvider != nil, "no validating accounts provider specified"},
+		{p.validatorRegistrationSigner != nil, "no validator registration signer specified"},
+		{p.listenAddress != "", "no listen address specified"},
+	}
+	for _, check := range checks {
+		if !check.valid {
+			return errors.New(check.err)
+		}
+	}
+	if _, _, err := net.SplitHostPort(p.listenAddress); err != nil {
+		return errors.New("listen address malformed")
+	}
+	checks = []struct {
+		valid bool
+		err   string
+	}{
+		{p.releaseVersion != "", "no release version specified"},
+		{p.builderBidProvider != nil, "no builder bid provider specified"},
+		{p.builderConfigs != nil, "no builder configs specified"},
+	}
+	for _, check := range checks {
+		if !check.valid {
+			return errors.New(check.err)
+		}
+	}
+
+	return nil
 }

--- a/services/blockrelay/standard/service.go
+++ b/services/blockrelay/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 - 2024 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -41,6 +41,10 @@ import (
 type Service struct {
 	log                                       zerolog.Logger
 	monitor                                   metrics.Service
+	accountsProvider                          accountmanager.AccountsProvider
+	validatorsProvider                        consensusclient.ValidatorsProvider
+	validatingAccountsProvider                accountmanager.ValidatingAccountsProvider
+	builderBidProvider                        builderbid.Provider
 	majordomo                                 majordomo.Service
 	chainTime                                 chaintime.Service
 	configURL                                 string
@@ -49,40 +53,31 @@ type Service struct {
 	clientCertURL                             string
 	clientKeyURL                              string
 	caCertURL                                 string
-	accountsProvider                          accountmanager.AccountsProvider
-	validatorsProvider                        consensusclient.ValidatorsProvider
-	validatingAccountsProvider                accountmanager.ValidatingAccountsProvider
 	validatorRegistrationSigner               signer.ValidatorRegistrationSigner
 	builderBidsCache                          map[string]map[string]*builderspec.VersionedSignedBuilderBid
-	builderBidsCacheMu                        sync.RWMutex
 	latestValidatorRegistrations              map[phase0.BLSPubKey]phase0.Root
-	latestValidatorRegistrationsMu            sync.RWMutex
 	signedValidatorRegistrations              map[phase0.Root]*apiv1.SignedValidatorRegistration
-	signedValidatorRegistrationsMu            sync.RWMutex
 	secondaryValidatorRegistrationsSubmitters []consensusclient.ValidatorRegistrationsSubmitter
 	logResults                                bool
 	releaseVersion                            string
-	builderBidProvider                        builderbid.Provider
 	builderConfigs                            map[phase0.BLSPubKey]*blockrelay.BuilderConfig
-
-	// builderBidMu ensures that only one builder bid operation is actively talking to
-	// relays at a time.
-	builderBidMu sync.Mutex
-
-	executionConfig   blockrelay.ExecutionConfigurator
-	executionConfigMu sync.RWMutex
-
+	executionConfig                           blockrelay.ExecutionConfigurator
 	// controlledValidators is a map of validators that are controlled
 	// by Vouch.  Used when receiving registrations from beacon nodes to know
 	// which registrations to forward, and which to drop because we have already
 	// submitted them.
-	controlledValidators   map[phase0.BLSPubKey]struct{}
-	controlledValidatorsMu sync.RWMutex
-
-	activitySem *semaphore.Weighted
-
+	controlledValidators map[phase0.BLSPubKey]struct{}
+	activitySem          *semaphore.Weighted
 	// Needed only to create dummy VersionedSignedBuilderBid in cacheBid.
-	electraForkEpoch phase0.Epoch
+	electraForkEpoch               phase0.Epoch
+	builderBidsCacheMu             sync.RWMutex
+	latestValidatorRegistrationsMu sync.RWMutex
+	signedValidatorRegistrationsMu sync.RWMutex
+	// builderBidMu ensures that only one builder bid operation is actively talking to
+	// relays at a time.
+	builderBidMu           sync.Mutex
+	executionConfigMu      sync.RWMutex
+	controlledValidatorsMu sync.RWMutex
 }
 
 // New creates a new controller.

--- a/services/blockrelay/standard/service_test.go
+++ b/services/blockrelay/standard/service_test.go
@@ -183,6 +183,26 @@ func TestService(t *testing.T) {
 			err: "problem with parameters: listen address malformed",
 		},
 		{
+			name: "ListenAddressMalformedBeforeReleaseVersion",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(monitor),
+				standard.WithMajordomo(majordomoSvc),
+				standard.WithScheduler(mockScheduler),
+				standard.WithListenAddress("abc"),
+				standard.WithChainTime(chainTime),
+				standard.WithConfigURL(configURL),
+				standard.WithFallbackFeeRecipient(fallbackFeeRecipient),
+				standard.WithFallbackGasLimit(fallbackGasLimit),
+				standard.WithAccountsProvider(mockAccountsProvider),
+				standard.WithValidatorsProvider(mockValidatorsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithValidatorRegistrationSigner(mockSigner),
+				standard.WithBuilderBidProvider(builderBidProvider),
+			},
+			err: "problem with parameters: listen address malformed",
+		},
+		{
 			name: "ChainTimeMissing",
 			params: []standard.Parameter{
 				standard.WithLogLevel(zerolog.Disabled),

--- a/services/cache/standard/parameters.go
+++ b/services/cache/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2024 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,12 +24,12 @@ import (
 )
 
 type parameters struct {
-	logLevel                   zerolog.Level
 	monitor                    metrics.Service
-	chainTime                  chaintime.Service
 	signedBeaconBlockProvider  consensusclient.SignedBeaconBlockProvider
 	beaconBlockHeadersProvider consensusclient.BeaconBlockHeadersProvider
 	eventsProvider             consensusclient.EventsProvider
+	logLevel                   zerolog.Level
+	chainTime                  chaintime.Service
 	scheduler                  scheduler.Service
 }
 

--- a/services/cache/standard/service.go
+++ b/services/cache/standard/service.go
@@ -29,21 +29,17 @@ import (
 
 // Service provides cached information.
 type Service struct {
-	log zerolog.Logger
-
-	chainTime                  chaintime.Service
+	log                        zerolog.Logger
 	signedBeaconBlockProvider  consensusclient.SignedBeaconBlockProvider
 	beaconBlockHeadersProvider consensusclient.BeaconBlockHeadersProvider
-
-	blockRootToSlotMu sync.RWMutex
-	blockRootToSlot   map[phase0.Root]phase0.Slot
-
-	executionChainHeadMu     sync.RWMutex
-	executionChainHeadHeight uint64
-	executionChainHeadRoot   phase0.Hash32
-
-	blockGasLimitMu sync.RWMutex
-	blockGasLimits  map[uint64]uint64
+	chainTime                  chaintime.Service
+	blockRootToSlot            map[phase0.Root]phase0.Slot
+	executionChainHeadHeight   uint64
+	executionChainHeadRoot     phase0.Hash32
+	blockGasLimits             map[uint64]uint64
+	blockRootToSlotMu          sync.RWMutex
+	executionChainHeadMu       sync.RWMutex
+	blockGasLimitMu            sync.RWMutex
 }
 
 // New creates a new cache.

--- a/services/chaintime/standard/parameters.go
+++ b/services/chaintime/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,9 +20,9 @@ import (
 )
 
 type parameters struct {
-	logLevel        zerolog.Level
 	genesisProvider eth2client.GenesisProvider
 	specProvider    eth2client.SpecProvider
+	logLevel        zerolog.Level
 }
 
 // Parameter is the interface for service parameters.

--- a/services/chaintime/standard/service.go
+++ b/services/chaintime/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -29,10 +29,10 @@ import (
 // Service provides chain time services.
 type Service struct {
 	log           zerolog.Logger
+	specProvider  client.SpecProvider
 	genesisTime   time.Time
 	slotDuration  time.Duration
 	slotsPerEpoch uint64
-	specProvider  client.SpecProvider
 }
 
 // New creates a new controller.

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -38,25 +38,25 @@ import (
 )
 
 type parameters struct {
-	logLevel                      zerolog.Level
 	monitor                       metrics.Service
 	specProvider                  eth2client.SpecProvider
 	chainTimeService              chaintime.Service
-	waitedForGenesis              bool
 	proposerDutiesProvider        eth2client.ProposerDutiesProvider
 	attesterDutiesProvider        eth2client.AttesterDutiesProvider
 	syncCommitteeDutiesProvider   eth2client.SyncCommitteeDutiesProvider
-	syncCommitteesSubscriber      synccommitteesubscriber.Service
 	validatingAccountsProvider    accountmanager.ValidatingAccountsProvider
+	eventsProvider                eth2client.EventsProvider
+	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
+	signedBeaconBlockProvider     eth2client.SignedBeaconBlockProvider
+	logLevel                      zerolog.Level
+	waitedForGenesis              bool
+	syncCommitteesSubscriber      synccommitteesubscriber.Service
 	proposalsPreparer             proposalpreparer.Service
 	scheduler                     scheduler.Service
-	eventsProvider                eth2client.EventsProvider
 	attester                      attester.Service
 	syncCommitteeMessenger        synccommitteemessenger.Service
 	syncCommitteeAggregator       synccommitteeaggregator.Service
 	beaconBlockProposer           beaconblockproposer.Service
-	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
-	signedBeaconBlockProvider     eth2client.SignedBeaconBlockProvider
 	attestationAggregator         attestationaggregator.Service
 	beaconCommitteeSubscriber     beaconcommitteesubscriber.Service
 	accountsRefresher             accountmanager.Refresher

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -324,87 +324,81 @@ func parseAndCheckParameters(ctx context.Context, params ...Parameter) (*paramet
 		p.apply(&parameters)
 	}
 
-	if parameters.monitor == nil {
-		return nil, errors.New("no monitor specified")
+	if err := parameters.validate(); err != nil {
+		return nil, err
 	}
-	if parameters.specProvider == nil {
-		return nil, errors.New("no spec provider specified")
-	}
-	if parameters.chainTimeService == nil {
-		return nil, errors.New("no chain time service specified")
-	}
-	if parameters.proposerDutiesProvider == nil {
-		return nil, errors.New("no proposer duties provider specified")
-	}
-	if parameters.attesterDutiesProvider == nil {
-		return nil, errors.New("no attester duties provider specified")
-	}
-	if parameters.eventsProvider == nil {
-		return nil, errors.New("no events provider specified")
-	}
-	if parameters.validatingAccountsProvider == nil {
-		return nil, errors.New("no validating accounts provider specified")
-	}
-	if parameters.proposalsPreparer == nil {
-		return nil, errors.New("no proposals preparer specified")
-	}
-	if parameters.scheduler == nil {
-		return nil, errors.New("no scheduler service specified")
-	}
-	if parameters.attester == nil {
-		return nil, errors.New("no attester specified")
-	}
-	if parameters.beaconBlockProposer == nil {
-		return nil, errors.New("no beacon block proposer specified")
-	}
-	if parameters.beaconBlockHeadersProvider == nil {
-		return nil, errors.New("no beacon block headers provider specified")
-	}
-	if parameters.signedBeaconBlockProvider == nil {
-		return nil, errors.New("no signed beacon block provider specified")
-	}
-	if parameters.attestationAggregator == nil {
-		return nil, errors.New("no attestation aggregator specified")
-	}
-	if parameters.beaconCommitteeSubscriber == nil {
-		return nil, errors.New("no beacon committee subscriber specified")
-	}
-	if parameters.accountsRefresher == nil {
-		return nil, errors.New("no accounts refresher specified")
-	}
-	if parameters.blockToSlotSetter == nil {
-		return nil, errors.New("no block to slot setter specified")
-	}
-	if parameters.multiInstance == nil {
-		return nil, errors.New("no multi instance service specified")
-	}
-	specResponse, err := parameters.specProvider.Spec(ctx, &api.SpecOpts{})
+	slotDuration, err := parameters.slotDuration(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to obtain spec")
-	}
-	spec := specResponse.Data
-	tmp, exists := spec["SECONDS_PER_SLOT"]
-	if !exists {
-		return nil, errors.New("SECONDS_PER_SLOT not found in spec")
-	}
-	slotDuration, ok := tmp.(time.Duration)
-	if !ok {
-		return nil, errors.New("SECONDS_PER_SLOT of unexpected type")
+		return nil, err
 	}
 	// maxProposalDelay can be 0, so no check for it here.
-	if parameters.maxAttestationDelay == 0 {
-		parameters.maxAttestationDelay = slotDuration / 3
-	}
-	if parameters.attestationAggregationDelay == 0 {
-		parameters.attestationAggregationDelay = slotDuration * 2 / 3
-	}
-	if parameters.maxSyncCommitteeMessageDelay == 0 {
-		parameters.maxSyncCommitteeMessageDelay = slotDuration / 3
-	}
-	if parameters.syncCommitteeAggregationDelay == 0 {
-		parameters.syncCommitteeAggregationDelay = slotDuration * 2 / 3
-	}
+	parameters.setDefaultDelays(slotDuration)
 	// Sync committee duties provider/messenger/aggregator/subscriber are optional so no checks here.
 
 	return &parameters, nil
+}
+
+func (p *parameters) validate() error {
+	checks := []struct {
+		valid bool
+		err   string
+	}{
+		{p.monitor != nil, "no monitor specified"},
+		{p.specProvider != nil, "no spec provider specified"},
+		{p.chainTimeService != nil, "no chain time service specified"},
+		{p.proposerDutiesProvider != nil, "no proposer duties provider specified"},
+		{p.attesterDutiesProvider != nil, "no attester duties provider specified"},
+		{p.eventsProvider != nil, "no events provider specified"},
+		{p.validatingAccountsProvider != nil, "no validating accounts provider specified"},
+		{p.proposalsPreparer != nil, "no proposals preparer specified"},
+		{p.scheduler != nil, "no scheduler service specified"},
+		{p.attester != nil, "no attester specified"},
+		{p.beaconBlockProposer != nil, "no beacon block proposer specified"},
+		{p.beaconBlockHeadersProvider != nil, "no beacon block headers provider specified"},
+		{p.signedBeaconBlockProvider != nil, "no signed beacon block provider specified"},
+		{p.attestationAggregator != nil, "no attestation aggregator specified"},
+		{p.beaconCommitteeSubscriber != nil, "no beacon committee subscriber specified"},
+		{p.accountsRefresher != nil, "no accounts refresher specified"},
+		{p.blockToSlotSetter != nil, "no block to slot setter specified"},
+		{p.multiInstance != nil, "no multi instance service specified"},
+	}
+	for _, check := range checks {
+		if !check.valid {
+			return errors.New(check.err)
+		}
+	}
+
+	return nil
+}
+
+func (p *parameters) slotDuration(ctx context.Context) (time.Duration, error) {
+	specResponse, err := p.specProvider.Spec(ctx, &api.SpecOpts{})
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to obtain spec")
+	}
+	secondsPerSlot, exists := specResponse.Data["SECONDS_PER_SLOT"]
+	if !exists {
+		return 0, errors.New("SECONDS_PER_SLOT not found in spec")
+	}
+	slotDuration, ok := secondsPerSlot.(time.Duration)
+	if !ok {
+		return 0, errors.New("SECONDS_PER_SLOT of unexpected type")
+	}
+
+	return slotDuration, nil
+}
+
+func (p *parameters) setDefaultDelays(slotDuration time.Duration) {
+	if p.maxAttestationDelay == 0 {
+		p.maxAttestationDelay = slotDuration / 3
+	}
+	if p.attestationAggregationDelay == 0 {
+		p.attestationAggregationDelay = slotDuration * 2 / 3
+	}
+	if p.maxSyncCommitteeMessageDelay == 0 {
+		p.maxSyncCommitteeMessageDelay = slotDuration / 3
+	}
+	if p.syncCommitteeAggregationDelay == 0 {
+		p.syncCommitteeAggregationDelay = slotDuration * 2 / 3
+	}
 }

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -53,15 +53,17 @@ var syncCommitteePreparationEpochs = uint64(5)
 type Service struct {
 	log                           zerolog.Logger
 	monitor                       metrics.Service
-	slotDuration                  time.Duration
-	slotsPerEpoch                 uint64
-	epochsPerSyncCommitteePeriod  uint64
 	chainTimeService              chaintime.Service
-	waitedForGenesis              bool
 	proposerDutiesProvider        eth2client.ProposerDutiesProvider
 	attesterDutiesProvider        eth2client.AttesterDutiesProvider
 	syncCommitteeDutiesProvider   eth2client.SyncCommitteeDutiesProvider
 	validatingAccountsProvider    accountmanager.ValidatingAccountsProvider
+	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
+	signedBeaconBlockProvider     eth2client.SignedBeaconBlockProvider
+	slotDuration                  time.Duration
+	slotsPerEpoch                 uint64
+	epochsPerSyncCommitteePeriod  uint64
+	waitedForGenesis              bool
 	proposalsPreparer             proposalpreparer.Service
 	scheduler                     scheduler.Service
 	attester                      attester.Service
@@ -69,13 +71,10 @@ type Service struct {
 	syncCommitteeAggregator       synccommitteeaggregator.Service
 	syncCommitteesSubscriber      synccommitteesubscriber.Service
 	beaconBlockProposer           beaconblockproposer.Service
-	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
-	signedBeaconBlockProvider     eth2client.SignedBeaconBlockProvider
 	attestationAggregator         attestationaggregator.Service
 	beaconCommitteeSubscriber     beaconcommitteesubscriber.Service
 	activeValidators              int
 	subscriptionInfos             map[phase0.Epoch]map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription
-	subscriptionInfosMutex        sync.Mutex
 	accountsRefresher             accountmanager.Refresher
 	blockToSlotSetter             cache.BlockRootToSlotSetter
 	maxProposalDelay              time.Duration
@@ -88,7 +87,6 @@ type Service struct {
 	fastTrackSyncCommittees       bool
 	fastTrackGrace                time.Duration
 	multiInstance                 multiinstance.Service
-
 	// Hard fork control.
 	handlingAltair     bool
 	altairForkEpoch    phase0.Epoch
@@ -97,15 +95,14 @@ type Service struct {
 	capellaForkEpoch   phase0.Epoch
 	handlingElectra    bool
 	electraForkEpoch   phase0.Epoch
-
 	// Tracking for reorgs.
 	lastBlockRoot             phase0.Root
 	lastBlockEpoch            phase0.Epoch
 	currentDutyDependentRoot  phase0.Root
 	previousDutyDependentRoot phase0.Root
-
 	// Tracking for attestations.
 	pendingAttestations      map[phase0.Slot]bool
+	subscriptionInfosMutex   sync.Mutex
 	pendingAttestationsMutex sync.RWMutex
 }
 
@@ -273,9 +270,9 @@ func (s *Service) startTickers(ctx context.Context,
 }
 
 type epochTickerData struct {
-	mutex          sync.Mutex
 	latestEpochRan int64
 	atGenesis      bool
+	mutex          sync.Mutex
 }
 
 // startEpochTicker starts a ticker that ticks at the beginning of each epoch.

--- a/services/metrics/prometheus/service.go
+++ b/services/metrics/prometheus/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2023 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -36,7 +36,7 @@ type Service struct {
 	strategyOperationTimer   *prometheus.HistogramVec
 }
 
-// module-wide log.
+// Module-wide log.
 var log zerolog.Logger
 
 // New creates a new prometheus metrics service.

--- a/services/multiinstance/always/parameters.go
+++ b/services/multiinstance/always/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,8 +21,8 @@ import (
 )
 
 type parameters struct {
-	logLevel zerolog.Level
 	monitor  metrics.Service
+	logLevel zerolog.Level
 }
 
 // Parameter is the interface for service parameters.

--- a/services/multiinstance/staticdelay/parameters.go
+++ b/services/multiinstance/staticdelay/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2024, 2025 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -25,11 +25,11 @@ import (
 )
 
 type parameters struct {
-	logLevel                   zerolog.Level
 	monitor                    metrics.Service
 	specProvider               consensusclient.SpecProvider
 	attestationPoolProvider    consensusclient.AttestationPoolProvider
 	beaconBlockHeadersProvider consensusclient.BeaconBlockHeadersProvider
+	logLevel                   zerolog.Level
 	chainTime                  chaintime.Service
 	attesterDelay              time.Duration
 	proposerDelay              time.Duration

--- a/services/proposalpreparer/standard/parameters.go
+++ b/services/proposalpreparer/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2024 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -26,12 +26,12 @@ import (
 )
 
 type parameters struct {
-	logLevel                       zerolog.Level
 	monitor                        metrics.Service
 	chainTimeService               chaintime.Service
 	validatingAccountsProvider     accountmanager.ValidatingAccountsProvider
-	proposalPreparationsSubmitters []eth2client.ProposalPreparationsSubmitter
 	executionConfigProvider        blockrelay.ExecutionConfigProvider
+	logLevel                       zerolog.Level
+	proposalPreparationsSubmitters []eth2client.ProposalPreparationsSubmitter
 }
 
 // Parameter is the interface for service parameters.

--- a/services/proposalpreparer/standard/service.go
+++ b/services/proposalpreparer/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2024 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -30,8 +30,8 @@ type Service struct {
 	log                            zerolog.Logger
 	chainTimeService               chaintime.Service
 	validatingAccountsProvider     accountmanager.ValidatingAccountsProvider
-	proposalPreparationsSubmitters []eth2client.ProposalPreparationsSubmitter
 	executionConfigProvider        blockrelay.ExecutionConfigProvider
+	proposalPreparationsSubmitters []eth2client.ProposalPreparationsSubmitter
 }
 
 // New creates a new proposal preparer.

--- a/services/scheduler/advanced/parameters.go
+++ b/services/scheduler/advanced/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22,8 +22,8 @@ import (
 )
 
 type parameters struct {
-	logLevel zerolog.Level
 	monitor  metrics.Service
+	logLevel zerolog.Level
 }
 
 // Parameter is the interface for service parameters.

--- a/services/scheduler/advanced/service.go
+++ b/services/scheduler/advanced/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2021, 2024 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -29,11 +29,11 @@ import (
 
 // job contains control points for a job.
 type job struct {
-	// stateLock is required for active or finalised.
-	stateLock deadlock.Mutex
 	active    atomic.Bool
 	finalised atomic.Bool
 	periodic  bool
+	// stateLock is required for active or finalised.
+	stateLock deadlock.Mutex
 	cancelCh  chan struct{}
 	runCh     chan struct{}
 }

--- a/services/signer/standard/parameters.go
+++ b/services/signer/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22,11 +22,11 @@ import (
 )
 
 type parameters struct {
-	logLevel       zerolog.Level
 	monitor        metrics.SignerMonitor
-	clientMonitor  metrics.ClientMonitor
 	specProvider   eth2client.SpecProvider
 	domainProvider eth2client.DomainProvider
+	logLevel       zerolog.Level
+	clientMonitor  metrics.ClientMonitor
 }
 
 // Parameter is the interface for service parameters.

--- a/services/signer/standard/service.go
+++ b/services/signer/standard/service.go
@@ -45,7 +45,7 @@ type Service struct {
 	beaconBuilderDomainType               *phase0.DomainType
 }
 
-// module-wide log.
+// Module-wide log.
 var log zerolog.Logger
 
 // New creates a new dirk account manager.

--- a/services/signer/standard/service.go
+++ b/services/signer/standard/service.go
@@ -102,30 +102,11 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 
 	// The following are optional.
-	var syncCommitteeDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_SYNC_COMMITTEE"); err == nil {
-		syncCommitteeDomainType = &tmp
-	}
-
-	var syncCommitteeSelectionProofDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF"); err == nil {
-		syncCommitteeSelectionProofDomainType = &tmp
-	}
-
-	var contributionAndProofDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_CONTRIBUTION_AND_PROOF"); err == nil {
-		contributionAndProofDomainType = &tmp
-	}
-
-	var applicationBuilderDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_APPLICATION_BUILDER"); err == nil {
-		applicationBuilderDomainType = &tmp
-	}
-
-	var blobSidecarDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_BLOB_SIDECAR"); err == nil {
-		blobSidecarDomainType = &tmp
-	}
+	syncCommitteeDomainType := optionalDomainType(spec, "DOMAIN_SYNC_COMMITTEE")
+	syncCommitteeSelectionProofDomainType := optionalDomainType(spec, "DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF")
+	contributionAndProofDomainType := optionalDomainType(spec, "DOMAIN_CONTRIBUTION_AND_PROOF")
+	applicationBuilderDomainType := optionalDomainType(spec, "DOMAIN_APPLICATION_BUILDER")
+	blobSidecarDomainType := optionalDomainType(spec, "DOMAIN_BLOB_SIDECAR")
 
 	var beaconBuilderDomainType *phase0.DomainType
 	if tmp, err := domainType(spec, "DOMAIN_BEACON_BUILDER"); err == nil {
@@ -165,4 +146,13 @@ func domainType(spec map[string]interface{}, input string) (phase0.DomainType, e
 		return phase0.DomainType{}, fmt.Errorf("%v of unexpected type", input)
 	}
 	return domainType, nil
+}
+
+func optionalDomainType(spec map[string]interface{}, input string) *phase0.DomainType {
+	domainType, err := domainType(spec, input)
+	if err != nil {
+		return nil
+	}
+
+	return &domainType
 }

--- a/services/signer/standard/service_test.go
+++ b/services/signer/standard/service_test.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/mock"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/services/signer/standard"
@@ -24,6 +26,21 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+type minimalSpecProvider struct{}
+
+func (*minimalSpecProvider) Spec(_ context.Context, _ *api.SpecOpts) (*api.Response[map[string]any], error) {
+	return &api.Response[map[string]any]{
+		Data: map[string]any{
+			"SLOTS_PER_EPOCH":            uint64(32),
+			"DOMAIN_BEACON_ATTESTER":     phase0.DomainType{0x01},
+			"DOMAIN_BEACON_PROPOSER":     phase0.DomainType{0x02},
+			"DOMAIN_RANDAO":              phase0.DomainType{0x03},
+			"DOMAIN_SELECTION_PROOF":     phase0.DomainType{0x04},
+			"DOMAIN_AGGREGATE_AND_PROOF": phase0.DomainType{0x05},
+		},
+	}, nil
+}
 
 func TestService(t *testing.T) {
 	specProvider := mock.NewSpecProvider()
@@ -104,4 +121,16 @@ func TestService(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServiceWithOptionalDomainsAbsent(t *testing.T) {
+	service, err := standard.New(context.Background(),
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithClientMonitor(nullmetrics.New()),
+		standard.WithSpecProvider(&minimalSpecProvider{}),
+		standard.WithDomainProvider(mock.NewDomainProvider()),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, service)
 }

--- a/services/synccommitteeaggregator/standard/parameters.go
+++ b/services/synccommitteeaggregator/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -25,13 +25,13 @@ import (
 )
 
 type parameters struct {
-	logLevel                            zerolog.Level
 	monitor                             metrics.Service
 	specProvider                        eth2client.SpecProvider
 	beaconBlockRootProvider             eth2client.BeaconBlockRootProvider
-	contributionAndProofSigner          signer.ContributionAndProofSigner
 	validatingAccountsProvider          accountmanager.ValidatingAccountsProvider
 	syncCommitteeContributionProvider   eth2client.SyncCommitteeContributionProvider
+	logLevel                            zerolog.Level
+	contributionAndProofSigner          signer.ContributionAndProofSigner
 	syncCommitteeContributionsSubmitter submitter.SyncCommitteeContributionsSubmitter
 	chainTime                           chaintime.Service
 }

--- a/services/synccommitteeaggregator/standard/service.go
+++ b/services/synccommitteeaggregator/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2021, 2024 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -39,18 +39,18 @@ import (
 type Service struct {
 	log                                  zerolog.Logger
 	monitor                              metrics.Service
+	beaconBlockRootProvider              eth2client.BeaconBlockRootProvider
+	validatingAccountsProvider           accountmanager.ValidatingAccountsProvider
+	syncCommitteeContributionProvider    eth2client.SyncCommitteeContributionProvider
 	slotsPerEpoch                        uint64
 	syncCommitteeSize                    uint64
 	syncCommitteeSubnetCount             uint64
 	targetAggregatorsPerSyncSubcommittee uint64
-	beaconBlockRootProvider              eth2client.BeaconBlockRootProvider
 	contributionAndProofSigner           signer.ContributionAndProofSigner
-	validatingAccountsProvider           accountmanager.ValidatingAccountsProvider
-	syncCommitteeContributionProvider    eth2client.SyncCommitteeContributionProvider
 	syncCommitteeContributionsSubmitter  eth2client.SyncCommitteeContributionsSubmitter
 	beaconBlockRoots                     map[phase0.Slot]phase0.Root
-	beaconBlockRootsMu                   sync.Mutex
 	chainTime                            chaintime.Service
+	beaconBlockRootsMu                   sync.Mutex
 }
 
 // New creates a new sync committee aggregator.

--- a/services/synccommitteemessenger/standard/parameters.go
+++ b/services/synccommitteemessenger/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -27,15 +27,15 @@ import (
 )
 
 type parameters struct {
-	logLevel                            zerolog.Level
-	processConcurrency                  int64
 	monitor                             metrics.Service
 	chainTimeService                    chaintime.Service
-	syncCommitteeAggregator             synccommitteeaggregator.Service
 	specProvider                        eth2client.SpecProvider
 	beaconBlockRootProvider             eth2client.BeaconBlockRootProvider
-	syncCommitteeMessagesSubmitter      submitter.SyncCommitteeMessagesSubmitter
 	validatingAccountsProvider          accountmanager.ValidatingAccountsProvider
+	logLevel                            zerolog.Level
+	processConcurrency                  int64
+	syncCommitteeAggregator             synccommitteeaggregator.Service
+	syncCommitteeMessagesSubmitter      submitter.SyncCommitteeMessagesSubmitter
 	syncCommitteeRootSigner             signer.SyncCommitteeRootSigner
 	syncCommitteeSelectionSigner        signer.SyncCommitteeSelectionSigner
 	syncCommitteeSubscriptionsSubmitter submitter.SyncCommitteeSubscriptionsSubmitter

--- a/services/synccommitteemessenger/standard/service.go
+++ b/services/synccommitteemessenger/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2021, 2024 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -48,15 +48,15 @@ const (
 type Service struct {
 	log                               zerolog.Logger
 	monitor                           metrics.Service
+	chainTimeService                  chaintime.Service
+	validatingAccountsProvider        accountmanager.ValidatingAccountsProvider
+	beaconBlockRootProvider           eth2client.BeaconBlockRootProvider
 	processConcurrency                int64
 	slotsPerEpoch                     uint64
 	syncCommitteeSize                 uint64
 	syncCommitteeSubnetCount          uint64
 	targetAggregatorsPerSyncCommittee uint64
-	chainTimeService                  chaintime.Service
 	syncCommitteeAggregator           synccommitteeaggregator.Service
-	validatingAccountsProvider        accountmanager.ValidatingAccountsProvider
-	beaconBlockRootProvider           eth2client.BeaconBlockRootProvider
 	syncCommitteeMessagesSubmitter    submitter.SyncCommitteeMessagesSubmitter
 	syncCommitteeSelectionSigner      signer.SyncCommitteeSelectionSigner
 	syncCommitteeRootSigner           signer.SyncCommitteeRootSigner

--- a/services/synccommitteesubscriber/standard/parameters.go
+++ b/services/synccommitteesubscriber/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22,8 +22,8 @@ import (
 )
 
 type parameters struct {
-	logLevel               zerolog.Level
 	monitor                metrics.Service
+	logLevel               zerolog.Level
 	syncCommitteeSubmitter submitter.SyncCommitteeSubscriptionsSubmitter
 }
 

--- a/services/validatorsmanager/standard/parameters.go
+++ b/services/validatorsmanager/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,10 +23,10 @@ import (
 )
 
 type parameters struct {
-	logLevel           zerolog.Level
 	monitor            metrics.ValidatorsManagerMonitor
-	clientMonitor      metrics.ClientMonitor
 	validatorsProvider eth2client.ValidatorsProvider
+	logLevel           zerolog.Level
+	clientMonitor      metrics.ClientMonitor
 	farFutureEpoch     phase0.Epoch
 }
 

--- a/services/validatorsmanager/standard/service.go
+++ b/services/validatorsmanager/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020, 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -27,16 +27,15 @@ import (
 
 // Service is the manager for validators.
 type Service struct {
-	log                zerolog.Logger
-	monitor            metrics.ValidatorsManagerMonitor
-	clientMonitor      metrics.ClientMonitor
-	validatorsProvider eth2client.ValidatorsProvider
-	farFutureEpoch     phase0.Epoch
-
-	validatorsMutex        sync.RWMutex
+	log                    zerolog.Logger
+	monitor                metrics.ValidatorsManagerMonitor
+	validatorsProvider     eth2client.ValidatorsProvider
+	clientMonitor          metrics.ClientMonitor
+	farFutureEpoch         phase0.Epoch
 	validatorsByIndex      map[phase0.ValidatorIndex]*phase0.Validator
 	validatorsByPubKey     map[phase0.BLSPubKey]*phase0.Validator
 	validatorPubKeyToIndex map[phase0.BLSPubKey]phase0.ValidatorIndex
+	validatorsMutex        sync.RWMutex
 }
 
 // New creates a new validator provider.

--- a/strategies/attestationdata/combinedmajority/parameters.go
+++ b/strategies/attestationdata/combinedmajority/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Attestant Limited.
+// Copyright © 2025 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package majority is a strategy that obtains attestation from multiple
+// Package majority is a strategy that obtains attestation from multiple
 // nodes and selects the best one.
 package combinedmajority
 

--- a/strategies/attestationdata/majority/parameters.go
+++ b/strategies/attestationdata/majority/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Attestant Limited.
+// Copyright © 2023 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package majority is a strategy that obtains attestation from multiple
+// Package majority is a strategy that obtains attestation from multiple
 // nodes and selects the best one.
 package majority
 

--- a/strategies/beaconblockproposal/best/parameters.go
+++ b/strategies/beaconblockproposal/best/parameters.go
@@ -29,11 +29,11 @@ import (
 )
 
 type parameters struct {
+	specProvider           eth2client.SpecProvider
 	logLevel               zerolog.Level
 	clientMonitor          metrics.ClientMonitor
 	processConcurrency     int64
 	chainTime              chaintime.Service
-	specProvider           eth2client.SpecProvider
 	proposalProviders      map[string]beaconblockproposer.ProposalDataProvider
 	timeout                time.Duration
 	blockRootToSlotCache   cache.BlockRootToSlotProvider

--- a/strategies/builderbid/best/parameters.go
+++ b/strategies/builderbid/best/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Attestant Limited.
+// Copyright © 2023 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package deadline is a strategy that obtains builder bids from multiple
+// Package deadline is a strategy that obtains builder bids from multiple
 // relays repeatedly up to the supplied deadline into a slot.
 package best
 
@@ -28,11 +28,11 @@ import (
 )
 
 type parameters struct {
-	logLevel              zerolog.Level
 	monitor               metrics.Service
 	specProvider          consensusclient.SpecProvider
 	domainProvider        consensusclient.DomainProvider
 	blockGasLimitProvider cache.BlockGasLimitProvider
+	logLevel              zerolog.Level
 	chainTime             chaintime.Service
 	timeout               time.Duration
 	releaseVersion        string

--- a/strategies/builderbid/best/service.go
+++ b/strategies/builderbid/best/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Attestant Limited.
+// Copyright © 2023 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -33,13 +33,13 @@ import (
 type Service struct {
 	log                      zerolog.Logger
 	monitor                  metrics.Service
-	chainTime                chaintime.Service
 	blockGasLimitProvider    cache.BlockGasLimitProvider
+	chainTime                chaintime.Service
 	timeout                  time.Duration
 	releaseVersion           string
 	relayPubkeys             map[phase0.BLSPubKey]*e2types.BLSPublicKey
-	relayPubkeysMu           sync.RWMutex
 	applicationBuilderDomain phase0.Domain
+	relayPubkeysMu           sync.RWMutex
 }
 
 // New creates a new builder bid strategy.

--- a/strategies/builderbid/deadline/metrics.go
+++ b/strategies/builderbid/deadline/metrics.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -131,6 +131,6 @@ func monitorBidDelta(provider string, delta *big.Int, pctDelta float64) {
 	ethDelta := new(big.Int).Div(delta, weiToETH)
 	bidDelta.WithLabelValues(provider).Observe(float64(ethDelta.Uint64()))
 
-	// move pct delta from percentage to decimal.
+	// Move pct delta from percentage to decimal.
 	bidPctDelta.WithLabelValues(provider).Observe(pctDelta)
 }

--- a/strategies/builderbid/deadline/parameters.go
+++ b/strategies/builderbid/deadline/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package deadline is a strategy that obtains builder bids from multiple
+// Package deadline is a strategy that obtains builder bids from multiple
 // relays repeatedly up to the supplied deadline into a slot.
 package deadline
 
@@ -28,11 +28,11 @@ import (
 )
 
 type parameters struct {
-	logLevel              zerolog.Level
 	monitor               metrics.Service
 	specProvider          consensusclient.SpecProvider
 	domainProvider        consensusclient.DomainProvider
 	blockGasLimitProvider cache.BlockGasLimitProvider
+	logLevel              zerolog.Level
 	chainTime             chaintime.Service
 	deadline              time.Duration
 	bidGap                time.Duration

--- a/strategies/builderbid/deadline/service.go
+++ b/strategies/builderbid/deadline/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -33,14 +33,14 @@ import (
 type Service struct {
 	log                      zerolog.Logger
 	monitor                  metrics.Service
-	chainTime                chaintime.Service
 	blockGasLimitProvider    cache.BlockGasLimitProvider
+	chainTime                chaintime.Service
 	deadline                 time.Duration
 	bidGap                   time.Duration
 	releaseVersion           string
 	relayPubkeys             map[phase0.BLSPubKey]*e2types.BLSPublicKey
-	relayPubkeysMu           sync.RWMutex
 	applicationBuilderDomain phase0.Domain
+	relayPubkeysMu           sync.RWMutex
 }
 
 // New creates a new builder bid strategy.

--- a/testing/logger/capture.go
+++ b/testing/logger/capture.go
@@ -15,6 +15,7 @@ package logger
 
 import (
 	"encoding/json"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -87,45 +88,32 @@ func (c *LogCapture) HasLog(fields map[string]any) bool {
 
 // hasField returns true if the entry has a matching field.
 func (*LogCapture) hasField(entry map[string]any, key string, value any) bool {
-	for entryKey, entryValue := range entry {
-		if entryKey != key {
-			continue
-		}
-		switch v := value.(type) {
-		case bool:
-			return entryValue == v
-		case string:
-			return entryValue == value.(string)
-		case int:
-			return int(entryValue.(float64)) == v
-		case int8:
-			return int8(entryValue.(float64)) == v
-		case int16:
-			return int16(entryValue.(float64)) == v
-		case int32:
-			return int32(entryValue.(float64)) == v
-		case int64:
-			return int64(entryValue.(float64)) == v
-		case uint:
-			return uint(entryValue.(float64)) == v
-		case uint8:
-			return uint8(entryValue.(float64)) == v
-		case uint16:
-			return uint16(entryValue.(float64)) == v
-		case uint32:
-			return uint32(entryValue.(float64)) == v
-		case uint64:
-			return uint64(entryValue.(float64)) == v
-		case float32:
-			return float32(entryValue.(float64)) == v
-		case float64:
-			return entryValue.(float64) == v
-		default:
-			panic("unhandled type")
-		}
+	entryValue, exists := entry[key]
+	if !exists {
+		return false
 	}
 
-	return false
+	return fieldsMatch(entryValue, value)
+}
+
+func fieldsMatch(entryValue any, value any) bool {
+	expected := reflect.ValueOf(value)
+	if expected.CanInt() {
+		return int64(entryValue.(float64)) == expected.Int()
+	}
+	if expected.CanUint() {
+		return uint64(entryValue.(float64)) == expected.Uint()
+	}
+	if expected.CanFloat() {
+		return entryValue.(float64) == expected.Float()
+	}
+
+	switch value.(type) {
+	case bool, string:
+		return entryValue == value
+	default:
+		panic("unhandled type")
+	}
 }
 
 // Entries returns all captures log entries.

--- a/testing/logger/capture.go
+++ b/testing/logger/capture.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2025 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,8 +24,8 @@ import (
 
 // LogCapture allows testing code to query log output.
 type LogCapture struct {
-	mu      sync.Mutex
 	entries []map[string]any
+	mu      sync.Mutex
 }
 
 // Write captures an individual log message.

--- a/testing/logger/capture_test.go
+++ b/testing/logger/capture_test.go
@@ -1,0 +1,58 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasLog(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields map[string]any
+		match  bool
+	}{
+		{
+			name: "MatchingTypedFields",
+			fields: map[string]any{
+				"active": true,
+				"count":  uint64(2),
+				"name":   "vouch",
+			},
+			match: true,
+		},
+		{
+			name: "MismatchedField",
+			fields: map[string]any{
+				"count": uint64(3),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capture := &LogCapture{
+				entries: []map[string]any{{
+					"active": true,
+					"count":  float64(2),
+					"name":   "vouch",
+				}},
+			}
+
+			require.Equal(t, test.match, capture.HasLog(test.fields))
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #420 (`gloas-epbs-proposer`), so this diff is the sweep alone. Retarget to `gloas` once #420 merges.

Pure style; no functional change. A full `./custom-gcl run` goes from **108 findings to 12**.

## What changed

| Rule | Before | After | Action |
|---|---:|---:|---|
| `attgo_struct_field_order` | 85 | 0 | Reordered 39 structs across 38 files |
| `attgo_capital_comment` | 20 | 9 | Capitalised the 11 that are ordinary prose |
| `attgo_no_pkg_logger` | 3 | 3 | Out of scope, see below |

Copyright headers on the touched files were bumped, as `attgo_current_year` requires.

## Why 12 remain

Nine `attgo_capital_comment` findings are left deliberately, because satisfying them would do harm:

- `// skipcq: ...` (3) and `//revive:disable:nolint` (3) are directives addressed to other tools. Capitalising them stops those tools recognising them, silently re-enabling whatever they suppress.
- `// attest carries out...` and `// sign signs...` document the unexported funcs `attest` and `sign`. A Go doc comment opens with the name of the thing it documents, so capitalising would assert an exported `Attest`/`Sign` that does not exist. The rule has an identifier exemption but it matches on a fixed list of following words, which `carries` and `signs` are not in.
- One is commented-out code.

The three `attgo_no_pkg_logger` findings (`logging.go`, `services/metrics/prometheus`, `services/signer/standard`) are a change to how vouch does logging rather than how it is formatted, so they are not folded into a formatting sweep.

## Verification

- The field reordering is a pure permutation: for all 45 changed files, the multiset of source lines is unchanged apart from the copyright headers and the 11 capitalised comments. Checked mechanically, not by eye.
- `go build ./...` clean.
- `gosilent test ./...` 896 tests pass.
- Field ordering follows the linter's own categorisation (logger, metrics, dependency, data, synchronization), applied as a stable sort so relative order within a category is preserved.

## Note

These findings all pre-date the Gloas work. Measured against `origin/gloas`, #420 introduces **zero** new lint findings and removes four.