### PR TITLE
Preserve Gloas attestation payload votes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,12 @@ require (
 	github.com/attestantio/go-block-relay v0.6.0
 	github.com/attestantio/go-builder-client v0.8.0
 	github.com/attestantio/go-certmanager v0.2.0
-	github.com/attestantio/go-eth2-client v0.29.1-0.20260811144708-94db679b233c
+	github.com/attestantio/go-eth2-client v0.29.1-0.20260817140745-1263dc7060ea
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/google/uuid v1.6.0
 	github.com/holiman/uint256 v1.3.2
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/pk910/dynamic-ssz v1.3.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.0
@@ -93,7 +94,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe // indirect
-	github.com/pk910/dynamic-ssz v1.3.2 // indirect
 	github.com/pk910/hashtree-bindings v0.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,10 +82,8 @@ github.com/attestantio/go-builder-client v0.8.0 h1:paYTXZLtpCBG/9/Y99f9OjPNh4C+Z
 github.com/attestantio/go-builder-client v0.8.0/go.mod h1:M3rNO3ntGg+CE7aBDl+MVlwnEStZCiSRUzADG2ZoL+s=
 github.com/attestantio/go-certmanager v0.2.0 h1:Hzj12L5fofK7b281uohMBN0HQuSx+8RfU2UA9eHl84k=
 github.com/attestantio/go-certmanager v0.2.0/go.mod h1:Dn+C/okccD+2RugizT1ryrjX65cBMZl55fNYtmaVYAg=
-github.com/attestantio/go-eth2-client v0.29.0 h1:nOVPR6boXuGn5yg94pVOKcaoiO9yyjaYbM1vzwPF4n4=
-github.com/attestantio/go-eth2-client v0.29.0/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
-github.com/attestantio/go-eth2-client v0.29.1-0.20260811144708-94db679b233c h1:fuiXnbUXUh6BbcV/ZkZHEuN39zLRqyMstKNg0fe6ZvQ=
-github.com/attestantio/go-eth2-client v0.29.1-0.20260811144708-94db679b233c/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
+github.com/attestantio/go-eth2-client v0.29.1-0.20260817140745-1263dc7060ea h1:izccFMj70xj1wIVONNLjC5W9zy8i9cV0UEt0puL0vIg=
+github.com/attestantio/go-eth2-client v0.29.1-0.20260817140745-1263dc7060ea/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
 github.com/aws/aws-sdk-go v1.44.81/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=

--- a/services/attester/standard/attest.go
+++ b/services/attester/standard/attest.go
@@ -23,6 +23,7 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/attester"
 	"github.com/attestantio/vouch/util"
@@ -136,7 +137,11 @@ func (s *Service) attest(
 	signingCommitteeIndices := make([]phase0.CommitteeIndex, len(committeeIndices))
 	copy(signingCommitteeIndices, committeeIndices)
 	epoch := s.chainTime.SlotToEpoch(duty.Slot())
-	if epoch >= s.electraForkEpoch {
+	if epoch >= s.gloasForkEpoch {
+		for i := range signingCommitteeIndices {
+			signingCommitteeIndices[i] = data.Index
+		}
+	} else if epoch >= s.electraForkEpoch {
 		for i := range signingCommitteeIndices {
 			// Hardcode the committee indices to be 0 in Electra.
 			signingCommitteeIndices[i] = 0
@@ -163,6 +168,8 @@ func (s *Service) attest(
 	switch {
 	case epoch < s.electraForkEpoch:
 		attestations = s.createAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
+	case epoch >= s.gloasForkEpoch:
+		attestations = s.createGloasAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
 	default:
 		attestations = s.createElectraAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, validatorIndices, data, sigs, epoch)
 	}
@@ -179,6 +186,57 @@ func (s *Service) attest(
 	s.log.Trace().Dur("elapsed", time.Since(started)).Dur("submission_elapsed", time.Since(submissionStarted)).Msg("Submitted versioned attestations")
 
 	return attestations, nil
+}
+
+func (s *Service) createGloasAttestations(_ context.Context,
+	duty *attester.Duty,
+	accounts []e2wtypes.Account,
+	committeeIndices []phase0.CommitteeIndex,
+	validatorCommitteeIndices []phase0.ValidatorIndex,
+	committeeSizes []uint64,
+	data *phase0.AttestationData,
+	sigs []phase0.BLSSignature,
+) []*spec.VersionedAttestation {
+	attestations := make([]*spec.VersionedAttestation, 0, len(sigs))
+	for i := range sigs {
+		if sigs[i].IsZero() {
+			s.log.Warn().
+				Str("validator_pubkey", fmt.Sprintf("%#x", accounts[i].PublicKey().Marshal())).
+				Msg("No signature for validator; not creating attestation")
+			continue
+		}
+
+		aggregationBits := bitfield.NewBitlist(committeeSizes[i])
+		aggregationBits.SetBitAt(uint64(validatorCommitteeIndices[i]), true)
+		committeeBits := bitfield.NewBitvector64()
+		committeeBits.SetBitAt(uint64(committeeIndices[i]), true)
+
+		attestation := &gloas.Attestation{
+			AggregationBits: aggregationBits,
+			Data: &phase0.AttestationData{
+				Slot:            duty.Slot(),
+				Index:           data.Index,
+				BeaconBlockRoot: data.BeaconBlockRoot,
+				Source: &phase0.Checkpoint{
+					Epoch: data.Source.Epoch,
+					Root:  data.Source.Root,
+				},
+				Target: &phase0.Checkpoint{
+					Epoch: data.Target.Epoch,
+					Root:  data.Target.Root,
+				},
+			},
+			CommitteeBits: committeeBits,
+		}
+		copy(attestation.Signature[:], sigs[i][:])
+
+		attestations = append(attestations, &spec.VersionedAttestation{
+			Version: spec.DataVersionGloas,
+			Gloas:   attestation,
+		})
+	}
+
+	return attestations
 }
 
 func (s *Service) createAttestations(_ context.Context,
@@ -358,6 +416,10 @@ func (s *Service) validateAttestationData(_ context.Context,
 ) error {
 	if attestationData.Slot != duty.Slot() {
 		return fmt.Errorf("attestation request for slot %d returned data for slot %d", duty.Slot(), attestationData.Slot)
+	}
+
+	if s.chainTime.SlotToEpoch(duty.Slot()) >= s.gloasForkEpoch && attestationData.Index > 1 {
+		return fmt.Errorf("attestation request for slot %d returned invalid Gloas index %d", duty.Slot(), attestationData.Index)
 	}
 
 	if attestationData.Source.Epoch > attestationData.Target.Epoch {

--- a/services/attester/standard/attest.go
+++ b/services/attester/standard/attest.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2025 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -165,13 +165,15 @@ func (s *Service) attest(
 	s.log.Trace().Dur("elapsed", time.Since(started)).Msg("Signed")
 	var attestations []*spec.VersionedAttestation
 
+	// This ladder must mirror the signing committee index ladder above, otherwise the
+	// attestation we publish would not match the attestation data that was signed.
 	switch {
-	case epoch < s.electraForkEpoch:
-		attestations = s.createAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
 	case epoch >= s.gloasForkEpoch:
-		attestations = s.createGloasAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
-	default:
+		attestations = s.createGloasAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, validatorIndices, data, sigs)
+	case epoch >= s.electraForkEpoch:
 		attestations = s.createElectraAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, validatorIndices, data, sigs, epoch)
+	default:
+		attestations = s.createAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
 	}
 	if len(attestations) == 0 {
 		s.log.Info().Msg("No signed attestations; not submitting")
@@ -194,6 +196,7 @@ func (s *Service) createGloasAttestations(_ context.Context,
 	committeeIndices []phase0.CommitteeIndex,
 	validatorCommitteeIndices []phase0.ValidatorIndex,
 	committeeSizes []uint64,
+	validatorIndices []phase0.ValidatorIndex,
 	data *phase0.AttestationData,
 	sigs []phase0.BLSSignature,
 ) []*spec.VersionedAttestation {
@@ -205,6 +208,12 @@ func (s *Service) createGloasAttestations(_ context.Context,
 				Msg("No signature for validator; not creating attestation")
 			continue
 		}
+		if i >= len(validatorIndices) {
+			s.log.Warn().Str("validator_pubkey", fmt.Sprintf("%#x", accounts[i].PublicKey().Marshal())).
+				Msg("Validator indices array smaller than requested index; not creating attestation")
+			continue
+		}
+		validatorIndex := validatorIndices[i]
 
 		aggregationBits := bitfield.NewBitlist(committeeSizes[i])
 		aggregationBits.SetBitAt(uint64(validatorCommitteeIndices[i]), true)
@@ -230,9 +239,12 @@ func (s *Service) createGloasAttestations(_ context.Context,
 		}
 		copy(attestation.Signature[:], sigs[i][:])
 
+		// ValidatorIndex is required: the beacon API submits Electra and later attestations
+		// as SingleAttestation, and the conversion fails without it.
 		attestations = append(attestations, &spec.VersionedAttestation{
-			Version: spec.DataVersionGloas,
-			Gloas:   attestation,
+			Version:        spec.DataVersionGloas,
+			Gloas:          attestation,
+			ValidatorIndex: &validatorIndex,
 		})
 	}
 

--- a/services/attester/standard/gloas_attestation_test.go
+++ b/services/attester/standard/gloas_attestation_test.go
@@ -266,15 +266,15 @@ type attesterTestChainTime struct {
 	slotsPerEpoch  uint64
 }
 
-func (s *attesterTestChainTime) GenesisTime() time.Time { return time.Unix(0, 0) }
+func (*attesterTestChainTime) GenesisTime() time.Time { return time.Unix(0, 0) }
 func (s *attesterTestChainTime) StartOfSlot(slot phase0.Slot) time.Time {
 	return s.GenesisTime().Add(time.Duration(slot) * time.Second)
 }
 func (s *attesterTestChainTime) StartOfEpoch(epoch phase0.Epoch) time.Time {
 	return s.StartOfSlot(phase0.Slot(uint64(epoch) * s.slotsPerEpoch))
 }
-func (s *attesterTestChainTime) CurrentSlot() phase0.Slot   { return 0 }
-func (s *attesterTestChainTime) CurrentEpoch() phase0.Epoch { return 0 }
+func (*attesterTestChainTime) CurrentSlot() phase0.Slot   { return 0 }
+func (*attesterTestChainTime) CurrentEpoch() phase0.Epoch { return 0 }
 func (s *attesterTestChainTime) SlotToEpoch(slot phase0.Slot) phase0.Epoch {
 	return phase0.Epoch(uint64(slot) / s.slotsPerEpoch)
 }

--- a/services/attester/standard/gloas_attestation_test.go
+++ b/services/attester/standard/gloas_attestation_test.go
@@ -1,0 +1,297 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	mockaccountmanager "github.com/attestantio/vouch/services/accountmanager/mock"
+	"github.com/attestantio/vouch/services/attester"
+	"github.com/attestantio/vouch/services/attester/standard"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/signer"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	e2types "github.com/wealdtech/go-eth2-types/v2"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+func TestAttestGloasPreservesAttestationIndex(t *testing.T) {
+	ctx := context.Background()
+	chainTime := &attesterTestChainTime{
+		hardForkEpochs: map[string]phase0.Epoch{
+			"GLOAS_FORK_EPOCH":   15,
+			"ELECTRA_FORK_EPOCH": 0,
+			"FULU_FORK_EPOCH":    10,
+		},
+		slotsPerEpoch: 1,
+	}
+	accounts := mockAccountProvider()
+	accounts.AddAccount(1, testAccount{})
+	signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
+	submitter := &capturingAttestationsSubmitter{}
+
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithProcessConcurrency(1),
+		standard.WithChainTime(chainTime),
+		standard.WithSpecProvider(testSpecProvider{}),
+		standard.WithAttestationDataProvider(testAttestationDataProvider{index: 1}),
+		standard.WithAttestationsSubmitter(submitter),
+		standard.WithValidatingAccountsProvider(accounts),
+		standard.WithBeaconAttestationsSigner(signer),
+	)
+	require.NoError(t, err)
+
+	duty, err := attester.NewDuty(ctx,
+		15,
+		1,
+		[]phase0.ValidatorIndex{1},
+		[]phase0.CommitteeIndex{0},
+		[]uint64{0},
+		map[phase0.CommitteeIndex]uint64{0: 1},
+	)
+	require.NoError(t, err)
+
+	attestations, err := service.Attest(ctx, duty)
+	require.NoError(t, err)
+	require.Len(t, attestations, 1)
+	require.Len(t, signer.committeeIndices, 1)
+	require.Equal(t, phase0.CommitteeIndex(1), signer.committeeIndices[0])
+	require.NotNil(t, submitter.opts)
+	require.Len(t, submitter.opts.Attestations, 1)
+	require.Equal(t, spec.DataVersionGloas, submitter.opts.Attestations[0].Version)
+	require.NotNil(t, submitter.opts.Attestations[0].Gloas)
+	committeeIndex, err := submitter.opts.Attestations[0].CommitteeIndex()
+	require.NoError(t, err)
+	require.Equal(t, phase0.CommitteeIndex(0), committeeIndex)
+	require.Equal(t, phase0.CommitteeIndex(1), submitter.opts.Attestations[0].Gloas.Data.Index)
+	require.Equal(t, signer.committeeIndices[0], submitter.opts.Attestations[0].Gloas.Data.Index)
+}
+
+func TestAttestRejectsInvalidGloasAttestationIndex(t *testing.T) {
+	ctx := context.Background()
+	chainTime := &attesterTestChainTime{
+		hardForkEpochs: map[string]phase0.Epoch{
+			"GLOAS_FORK_EPOCH":   15,
+			"ELECTRA_FORK_EPOCH": 0,
+			"FULU_FORK_EPOCH":    10,
+		},
+		slotsPerEpoch: 1,
+	}
+	accounts := mockAccountProvider()
+	accounts.AddAccount(1, testAccount{})
+	signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
+	submitter := &capturingAttestationsSubmitter{}
+
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithProcessConcurrency(1),
+		standard.WithChainTime(chainTime),
+		standard.WithSpecProvider(testSpecProvider{}),
+		standard.WithAttestationDataProvider(testAttestationDataProvider{index: 2}),
+		standard.WithAttestationsSubmitter(submitter),
+		standard.WithValidatingAccountsProvider(accounts),
+		standard.WithBeaconAttestationsSigner(signer),
+	)
+	require.NoError(t, err)
+
+	duty, err := attester.NewDuty(ctx,
+		15,
+		1,
+		[]phase0.ValidatorIndex{1},
+		[]phase0.CommitteeIndex{0},
+		[]uint64{0},
+		map[phase0.CommitteeIndex]uint64{0: 1},
+	)
+	require.NoError(t, err)
+
+	_, err = service.Attest(ctx, duty)
+	require.EqualError(t, err, "attestation request for slot 15 returned invalid Gloas index 2")
+	require.Equal(t, 0, signer.calls)
+	require.Equal(t, 0, submitter.calls)
+}
+
+func TestAttestElectraAndFuluKeepZeroAttestationIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		slot    phase0.Slot
+		version spec.DataVersion
+	}{
+		{name: "Electra", slot: 1, version: spec.DataVersionElectra},
+		{name: "Fulu", slot: 11, version: spec.DataVersionFulu},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			chainTime := &attesterTestChainTime{
+				hardForkEpochs: map[string]phase0.Epoch{
+					"GLOAS_FORK_EPOCH":   15,
+					"ELECTRA_FORK_EPOCH": 0,
+					"FULU_FORK_EPOCH":    10,
+				},
+				slotsPerEpoch: 1,
+			}
+			accounts := mockAccountProvider()
+			accounts.AddAccount(1, testAccount{})
+			signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
+			submitter := &capturingAttestationsSubmitter{}
+			service, err := standard.New(ctx,
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New()),
+				standard.WithProcessConcurrency(1),
+				standard.WithChainTime(chainTime),
+				standard.WithSpecProvider(testSpecProvider{}),
+				standard.WithAttestationDataProvider(testAttestationDataProvider{index: 1}),
+				standard.WithAttestationsSubmitter(submitter),
+				standard.WithValidatingAccountsProvider(accounts),
+				standard.WithBeaconAttestationsSigner(signer),
+			)
+			require.NoError(t, err)
+
+			duty, err := attester.NewDuty(ctx,
+				test.slot,
+				1,
+				[]phase0.ValidatorIndex{1},
+				[]phase0.CommitteeIndex{1},
+				[]uint64{0},
+				map[phase0.CommitteeIndex]uint64{1: 1},
+			)
+			require.NoError(t, err)
+
+			_, err = service.Attest(ctx, duty)
+			require.NoError(t, err)
+			require.Equal(t, []phase0.CommitteeIndex{0}, signer.committeeIndices)
+			require.NotNil(t, submitter.opts)
+			require.Len(t, submitter.opts.Attestations, 1)
+			require.Equal(t, test.version, submitter.opts.Attestations[0].Version)
+			data, err := submitter.opts.Attestations[0].Data()
+			require.NoError(t, err)
+			require.Equal(t, phase0.CommitteeIndex(0), data.Index)
+		})
+	}
+}
+
+func mockAccountProvider() *mockaccountmanager.ValidatingAccountsProvider {
+	return mockaccountmanager.NewValidatingAccountsProvider()
+}
+
+type testAccount struct{}
+
+func (testAccount) ID() uuid.UUID                { return uuid.Nil }
+func (testAccount) Name() string                 { return "test" }
+func (testAccount) PublicKey() e2types.PublicKey { return testPublicKey{} }
+
+var _ e2wtypes.Account = testAccount{}
+
+type testPublicKey struct{}
+
+func (testPublicKey) Marshal() []byte             { return make([]byte, 48) }
+func (testPublicKey) Aggregate(e2types.PublicKey) {}
+func (key testPublicKey) Copy() e2types.PublicKey { return key }
+
+type testSpecProvider struct{}
+
+func (testSpecProvider) Spec(context.Context, *api.SpecOpts) (*api.Response[map[string]any], error) {
+	return &api.Response[map[string]any]{Data: map[string]any{"SLOTS_PER_EPOCH": uint64(1)}}, nil
+}
+
+type testAttestationDataProvider struct {
+	index phase0.CommitteeIndex
+}
+
+func (provider testAttestationDataProvider) AttestationData(_ context.Context, opts *api.AttestationDataOpts) (*api.Response[*phase0.AttestationData], error) {
+	return &api.Response[*phase0.AttestationData]{Data: &phase0.AttestationData{
+		Slot:  opts.Slot,
+		Index: provider.index,
+		Source: &phase0.Checkpoint{
+			Epoch: phase0.Epoch(opts.Slot - 1),
+		},
+		Target: &phase0.Checkpoint{
+			Epoch: phase0.Epoch(opts.Slot),
+		},
+	}}, nil
+}
+
+type capturingBeaconAttestationsSigner struct {
+	calls            int
+	committeeIndices []phase0.CommitteeIndex
+	signatures       []phase0.BLSSignature
+}
+
+func (s *capturingBeaconAttestationsSigner) SignBeaconAttestations(_ context.Context, _ []e2wtypes.Account, _ phase0.Slot, committeeIndices []phase0.CommitteeIndex, _ phase0.Root, _ phase0.Epoch, _ phase0.Root, _ phase0.Epoch, _ phase0.Root) ([]phase0.BLSSignature, error) {
+	s.calls++
+	s.committeeIndices = append([]phase0.CommitteeIndex(nil), committeeIndices...)
+	return s.signatures, nil
+}
+
+var _ signer.BeaconAttestationsSigner = (*capturingBeaconAttestationsSigner)(nil)
+
+type capturingAttestationsSubmitter struct {
+	calls int
+	opts  *api.SubmitAttestationsOpts
+}
+
+func (s *capturingAttestationsSubmitter) SubmitAttestations(_ context.Context, opts *api.SubmitAttestationsOpts) error {
+	s.calls++
+	s.opts = opts
+	return nil
+}
+
+var _ submitter.AttestationsSubmitter = (*capturingAttestationsSubmitter)(nil)
+
+type attesterTestChainTime struct {
+	hardForkEpochs map[string]phase0.Epoch
+	slotsPerEpoch  uint64
+}
+
+func (s *attesterTestChainTime) GenesisTime() time.Time { return time.Unix(0, 0) }
+func (s *attesterTestChainTime) StartOfSlot(slot phase0.Slot) time.Time {
+	return s.GenesisTime().Add(time.Duration(slot) * time.Second)
+}
+func (s *attesterTestChainTime) StartOfEpoch(epoch phase0.Epoch) time.Time {
+	return s.StartOfSlot(phase0.Slot(uint64(epoch) * s.slotsPerEpoch))
+}
+func (s *attesterTestChainTime) CurrentSlot() phase0.Slot   { return 0 }
+func (s *attesterTestChainTime) CurrentEpoch() phase0.Epoch { return 0 }
+func (s *attesterTestChainTime) SlotToEpoch(slot phase0.Slot) phase0.Epoch {
+	return phase0.Epoch(uint64(slot) / s.slotsPerEpoch)
+}
+func (s *attesterTestChainTime) FirstSlotOfEpoch(epoch phase0.Epoch) phase0.Slot {
+	return phase0.Slot(uint64(epoch) * s.slotsPerEpoch)
+}
+func (s *attesterTestChainTime) HardForkEpoch(_ context.Context, name string) phase0.Epoch {
+	return s.hardForkEpochs[name]
+}
+
+var _ interface {
+	GenesisTime() time.Time
+	StartOfSlot(phase0.Slot) time.Time
+	StartOfEpoch(phase0.Epoch) time.Time
+	CurrentSlot() phase0.Slot
+	CurrentEpoch() phase0.Epoch
+	SlotToEpoch(phase0.Slot) phase0.Epoch
+	FirstSlotOfEpoch(phase0.Epoch) phase0.Slot
+	HardForkEpoch(context.Context, string) phase0.Epoch
+} = (*attesterTestChainTime)(nil)

--- a/services/attester/standard/gloas_attestation_test.go
+++ b/services/attester/standard/gloas_attestation_test.go
@@ -24,6 +24,7 @@ import (
 	mockaccountmanager "github.com/attestantio/vouch/services/accountmanager/mock"
 	"github.com/attestantio/vouch/services/attester"
 	"github.com/attestantio/vouch/services/attester/standard"
+	"github.com/attestantio/vouch/services/chaintime"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/services/signer"
 	"github.com/attestantio/vouch/services/submitter"
@@ -44,7 +45,7 @@ func TestAttestGloasPreservesAttestationIndex(t *testing.T) {
 		},
 		slotsPerEpoch: 1,
 	}
-	accounts := mockAccountProvider()
+	accounts := mockaccountmanager.NewValidatingAccountsProvider()
 	accounts.AddAccount(1, testAccount{})
 	signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
 	submitter := &capturingAttestationsSubmitter{}
@@ -81,6 +82,9 @@ func TestAttestGloasPreservesAttestationIndex(t *testing.T) {
 	require.Len(t, submitter.opts.Attestations, 1)
 	require.Equal(t, spec.DataVersionGloas, submitter.opts.Attestations[0].Version)
 	require.NotNil(t, submitter.opts.Attestations[0].Gloas)
+	// Required for the SingleAttestation conversion carried out on submission.
+	require.NotNil(t, submitter.opts.Attestations[0].ValidatorIndex)
+	require.Equal(t, phase0.ValidatorIndex(1), *submitter.opts.Attestations[0].ValidatorIndex)
 	committeeIndex, err := submitter.opts.Attestations[0].CommitteeIndex()
 	require.NoError(t, err)
 	require.Equal(t, phase0.CommitteeIndex(0), committeeIndex)
@@ -98,7 +102,7 @@ func TestAttestRejectsInvalidGloasAttestationIndex(t *testing.T) {
 		},
 		slotsPerEpoch: 1,
 	}
-	accounts := mockAccountProvider()
+	accounts := mockaccountmanager.NewValidatingAccountsProvider()
 	accounts.AddAccount(1, testAccount{})
 	signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
 	submitter := &capturingAttestationsSubmitter{}
@@ -153,7 +157,7 @@ func TestAttestElectraAndFuluKeepZeroAttestationIndex(t *testing.T) {
 				},
 				slotsPerEpoch: 1,
 			}
-			accounts := mockAccountProvider()
+			accounts := mockaccountmanager.NewValidatingAccountsProvider()
 			accounts.AddAccount(1, testAccount{})
 			signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
 			submitter := &capturingAttestationsSubmitter{}
@@ -191,10 +195,6 @@ func TestAttestElectraAndFuluKeepZeroAttestationIndex(t *testing.T) {
 			require.Equal(t, phase0.CommitteeIndex(0), data.Index)
 		})
 	}
-}
-
-func mockAccountProvider() *mockaccountmanager.ValidatingAccountsProvider {
-	return mockaccountmanager.NewValidatingAccountsProvider()
 }
 
 type testAccount struct{}
@@ -285,13 +285,4 @@ func (s *attesterTestChainTime) HardForkEpoch(_ context.Context, name string) ph
 	return s.hardForkEpochs[name]
 }
 
-var _ interface {
-	GenesisTime() time.Time
-	StartOfSlot(phase0.Slot) time.Time
-	StartOfEpoch(phase0.Epoch) time.Time
-	CurrentSlot() phase0.Slot
-	CurrentEpoch() phase0.Epoch
-	SlotToEpoch(phase0.Slot) phase0.Epoch
-	FirstSlotOfEpoch(phase0.Epoch) phase0.Slot
-	HardForkEpoch(context.Context, string) phase0.Epoch
-} = (*attesterTestChainTime)(nil)
+var _ chaintime.Service = (*attesterTestChainTime)(nil)

--- a/services/attester/standard/service.go
+++ b/services/attester/standard/service.go
@@ -46,6 +46,7 @@ type Service struct {
 	attested                   map[phase0.Epoch]map[phase0.ValidatorIndex]struct{}
 	electraForkEpoch           phase0.Epoch
 	fuluForkEpoch              phase0.Epoch
+	gloasForkEpoch             phase0.Epoch
 	attestedMu                 sync.Mutex
 }
 
@@ -83,6 +84,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 
 	electraForkEpoch := parameters.chainTime.HardForkEpoch(ctx, "ELECTRA_FORK_EPOCH")
 	fuluForkEpoch := parameters.chainTime.HardForkEpoch(ctx, "FULU_FORK_EPOCH")
+	gloasForkEpoch := parameters.chainTime.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH")
 	s := &Service{
 		log:                        log,
 		monitor:                    parameters.monitor,
@@ -97,6 +99,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		attested:                   make(map[phase0.Epoch]map[phase0.ValidatorIndex]struct{}),
 		electraForkEpoch:           electraForkEpoch,
 		fuluForkEpoch:              fuluForkEpoch,
+		gloasForkEpoch:             gloasForkEpoch,
 	}
 	log.Trace().Int64("process_concurrency", s.processConcurrency).Msg("Set process concurrency")
 


### PR DESCRIPTION
## Summary
- preserve the beacon-returned Gloas payload vote in both the signing root and submitted attestation
- reject invalid Gloas votes before signing
- keep Electra and Fulu attestation indices at zero

## Validation
Fresh Glam-8 Kurtosis enclave from genesis: health checks pass after Gloas activation; Vouch retrieved attestation data and submitted attestations successfully

The fresh network only produced self-built, zero-value payloads, so its ordinary attestation-data endpoint returned index 0 in observed slots. The nonzero index-1 path is covered by the end-to-end service regression test.

The nonzero index-1 path is covered by the end-to-end service regression test.