### PR TITLE
Add Gloas arms to attestation aggregation

### DIFF
--- a/services/attestationaggregator/standard/service.go
+++ b/services/attestationaggregator/standard/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/accountmanager"
 	"github.com/attestantio/vouch/services/attestationaggregator"
@@ -308,6 +309,20 @@ func createVersionedAggregateAndProof(duty *attestationaggregator.Duty, aggregat
 			Fulu:    aggregateAndProof,
 		}
 		return versionedAggregateAndProof, nil
+	case spec.DataVersionGloas:
+		if aggregateAttestation.Gloas == nil {
+			return nil, errors.New("no gloas attestation")
+		}
+		aggregateAndProof := &gloas.AggregateAndProof{
+			AggregatorIndex: duty.ValidatorIndex,
+			Aggregate:       aggregateAttestation.Gloas,
+			SelectionProof:  duty.SlotSignature,
+		}
+		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
+			Version: aggregateAttestation.Version,
+			Gloas:   aggregateAndProof,
+		}
+		return versionedAggregateAndProof, nil
 	default:
 		return &spec.VersionedAggregateAndProof{}, errors.New("unknown version")
 	}
@@ -404,6 +419,19 @@ func createVersionedSignedAggregateAndProof(aggregateAndProof *spec.VersionedAgg
 		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
 			Version: aggregateAndProof.Version,
 			Fulu:    signedAggregateAndProof,
+		}
+		return signedVersionedAggregateAndProof, nil
+	case spec.DataVersionGloas:
+		if aggregateAndProof.Gloas == nil {
+			return nil, errors.New("no gloas aggregate and proof")
+		}
+		signedAggregateAndProof := &gloas.SignedAggregateAndProof{
+			Message:   aggregateAndProof.Gloas,
+			Signature: sig,
+		}
+		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
+			Version: aggregateAndProof.Version,
+			Gloas:   signedAggregateAndProof,
 		}
 		return signedVersionedAggregateAndProof, nil
 	default:

--- a/services/attestationaggregator/standard/service_internal_test.go
+++ b/services/attestationaggregator/standard/service_internal_test.go
@@ -1,0 +1,114 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/attestationaggregator"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateVersionedAggregateAndProofGloas(t *testing.T) {
+	duty := &attestationaggregator.Duty{
+		ValidatorIndex: phase0.ValidatorIndex(42),
+		SlotSignature:  phase0.BLSSignature{1},
+	}
+	attestation := &gloas.Attestation{}
+
+	tests := []struct {
+		name                 string
+		versionedAttestation *spec.VersionedAttestation
+		err                  string
+	}{
+		{
+			name: "Valid",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionGloas,
+				Gloas:   attestation,
+			},
+		},
+		{
+			name: "MissingArm",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionGloas,
+			},
+			err: "no gloas attestation",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := createVersionedAggregateAndProof(duty, test.versionedAttestation)
+			if test.err != "" {
+				require.Nil(t, result)
+				require.EqualError(t, err, test.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, spec.DataVersionGloas, result.Version)
+			require.NotNil(t, result.Gloas)
+			require.Same(t, attestation, result.Gloas.Aggregate)
+			require.Equal(t, duty.ValidatorIndex, result.Gloas.AggregatorIndex)
+			require.Equal(t, duty.SlotSignature, result.Gloas.SelectionProof)
+		})
+	}
+}
+
+func TestCreateVersionedSignedAggregateAndProofGloas(t *testing.T) {
+	aggregateAndProof := &gloas.AggregateAndProof{}
+	sig := phase0.BLSSignature{2}
+
+	tests := []struct {
+		name                       string
+		versionedAggregateAndProof *spec.VersionedAggregateAndProof
+		err                        string
+	}{
+		{
+			name: "Valid",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionGloas,
+				Gloas:   aggregateAndProof,
+			},
+		},
+		{
+			name: "MissingArm",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionGloas,
+			},
+			err: "no gloas aggregate and proof",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := createVersionedSignedAggregateAndProof(test.versionedAggregateAndProof, sig)
+			if test.err != "" {
+				require.Nil(t, result)
+				require.EqualError(t, err, test.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, spec.DataVersionGloas, result.Version)
+			require.NotNil(t, result.Gloas)
+			require.Same(t, aggregateAndProof, result.Gloas.Message)
+			require.Equal(t, sig, result.Gloas.Signature)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- convert Gloas aggregate attestations into versioned aggregate-and-proof containers
- convert signed Gloas aggregate-and-proof containers for submission
- reject missing Gloas payload arms before signing or submission

## Validation

Fresh Glam-8 Kurtosis enclave from genesis: health checks pass after Gloas activation; Vouch retrieved attestation data and submitted attestations successfully