### PR TITLE
Derive duty deadlines from Gloas spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ gloas:
   - do not update execution chain head state from gloas blocks, as an execution payload bid carries no execution block number
   - report "builder" as a beacon block proposal source method
   - preserve the beacon node's gloas payload vote in both the attestation signing root and the submitted attestation, rejecting an invalid vote before signing
+  - convert gloas aggregate attestations and signed aggregate-and-proof containers for aggregation and submission, rejecting a missing gloas arm before signing
   - update go-eth2-client to a gloas pseudo-version
   - satisfy the attgo struct field order and comment capitalisation rules across services and strategies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ gloas:
   - report "builder" as a beacon block proposal source method
   - preserve the beacon node's gloas payload vote in both the attestation signing root and the submitted attestation, rejecting an invalid vote before signing
   - convert gloas aggregate attestations and signed aggregate-and-proof containers for aggregation and submission, rejecting a missing gloas arm before signing
+  - derive the four controller duty deadlines from the chain specification, choosing the pre-gloas or gloas deadline per duty from that duty's slot and retaining the legacy timing for pre-gloas networks
+  - default controller.max-attestation-delay, controller.attestation-aggregation-delay, controller.max-sync-committee-message-delay and controller.sync-committee-aggregation-delay to 0; the hardcoded defaults made the spec-derived deadlines unreachable
   - update go-eth2-client to a gloas pseudo-version
   - satisfy the attgo struct field order and comment capitalisation rules across services and strategies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ gloas:
   - cache the hard fork schedule in chaintime; known-fork lookups are allocation-free and unknown forks trigger a coalesced refresh
   - do not update execution chain head state from gloas blocks, as an execution payload bid carries no execution block number
   - report "builder" as a beacon block proposal source method
+  - preserve the beacon node's gloas payload vote in both the attestation signing root and the submitted attestation, rejecting an invalid vote before signing
   - update go-eth2-client to a gloas pseudo-version
   - satisfy the attgo struct field order and comment capitalisation rules across services and strategies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 gloas:
   - add gloas self-build beacon block proposal path: request an ePBS proposal with its payload, sign the beacon block and matching execution payload envelope, then publish the block followed by its envelope
+  - refuse a self-build gloas proposal whose execution payload pays no fee recipient, before its envelope is signed
   - extend the first and best beaconblockproposal strategies for ePBS proposals, rejecting malformed or payload-excluded responses when payload inclusion was requested
   - route the simple beaconblockproposal style through the first strategy; beacon node clients that do not support ePBS proposals now fail at startup
   - skip the relay auction under gloas and warn operators that their relay settings are ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ gloas:
   - do not update execution chain head state from gloas blocks, as an execution payload bid carries no execution block number
   - report "builder" as a beacon block proposal source method
   - update go-eth2-client to a gloas pseudo-version
+  - satisfy the attgo struct field order and comment capitalisation rules across services and strategies
 
 1.13.1:
   - initialise sync committee verification metrics to 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+gloas:
+  - add gloas self-build beacon block proposal path: request an ePBS proposal with its payload, sign the beacon block and matching execution payload envelope, then publish the block followed by its envelope
+  - extend the first and best beaconblockproposal strategies for ePBS proposals, rejecting malformed or payload-excluded responses when payload inclusion was requested
+  - route the simple beaconblockproposal style through the first strategy; beacon node clients that do not support ePBS proposals now fail at startup
+  - skip the relay auction under gloas and warn operators that their relay settings are ignored
+  - add eth2client.custom-spec-support to enable dynamic SSZ encoding and decoding for beacon nodes using a non-mainnet preset
+  - cache the hard fork schedule in chaintime; known-fork lookups are allocation-free and unknown forks trigger a coalesced refresh
+  - do not update execution chain head state from gloas blocks, as an execution payload bid carries no execution block number
+  - report "builder" as a beacon block proposal source method
+  - update go-eth2-client to a gloas pseudo-version
+
 1.13.1:
   - initialise sync committee verification metrics to 0
   - use dynssz v1.3.2 and corresponding lib updates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26.6-bookworm AS builder
 
 WORKDIR /app
 

--- a/clients_test.go
+++ b/clients_test.go
@@ -19,13 +19,18 @@ import (
 	nethttp "net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	bitfield "github.com/OffchainLabs/go-bitfield"
 	client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
+	apiv1gloas "github.com/attestantio/go-eth2-client/api/v1/gloas"
+	mockconsensusclient "github.com/attestantio/go-eth2-client/mock"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/metrics/null"
 	dynssz "github.com/pk910/dynamic-ssz"
 	"github.com/spf13/viper"
@@ -94,4 +99,47 @@ func TestFetchClientCustomSpecSupport(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, spec.DataVersionGloas, response.Data.Version)
 	require.Equal(t, block.Slot, response.Data.Gloas.Slot)
+}
+
+func TestSimpleProposalProviderRejectsZeroFeeRecipient(t *testing.T) {
+	ctx := context.Background()
+	const address = "http://proposal.test"
+	proposalClient, err := mockconsensusclient.New(ctx)
+	require.NoError(t, err)
+	proposalClient.EPBSProposalFunc = func(context.Context, *api.EPBSProposalOpts) (*api.Response[*api.VersionedEPBSProposal], error) {
+		return &api.Response[*api.VersionedEPBSProposal]{
+			Data: &api.VersionedEPBSProposal{
+				Version:                  spec.DataVersionGloas,
+				ExecutionPayloadIncluded: true,
+				GloasContents: &apiv1gloas.BlockContents{Block: &gloas.BeaconBlock{Body: &gloas.BeaconBlockBody{
+					SignedExecutionPayloadBid: &gloas.SignedExecutionPayloadBid{Message: &gloas.ExecutionPayloadBid{
+						FeeRecipient: bellatrix.ExecutionAddress{},
+					}},
+				}}},
+			},
+		}, nil
+	}
+	viper.Set("strategies.beaconblockproposal.style", "simple")
+	viper.Set("strategies.beaconblockproposal.beacon-node-addresses", []string{address})
+	viper.Set("strategies.beaconblockproposal.first.timeout", 10*time.Millisecond)
+	knownClientsMu.Lock()
+	knownClients[address] = proposalClient
+	knownClientsMu.Unlock()
+	t.Cleanup(func() {
+		viper.Reset()
+		knownClientsMu.Lock()
+		delete(knownClients, address)
+		delete(knownClients, "multi:"+address)
+		knownClientsMu.Unlock()
+	})
+
+	provider, err := selectProposalProvider(ctx, null.New(), nil, nil, nil)
+	require.NoError(t, err)
+	includePayload := true
+	response, err := provider.EPBSProposal(ctx, &api.EPBSProposalOpts{
+		Slot:           phase0.Slot(1),
+		IncludePayload: &includePayload,
+	})
+	require.Nil(t, response)
+	require.EqualError(t, err, "failed to obtain ePBS beacon block proposal before timeout")
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -418,18 +418,20 @@ This can be configured using the environment variables `VOUCH_<MODULE>_LOG_LEVEL
 
 Advanced options can change the performance of Vouch to be severely detrimental to its operation. It is strongly recommended that these options are not changed unless the user understands completely what they do and their possible performance impact.
 
+The duty timing options below are derived from the chain specification when they are not set. Setting one explicitly overrides that derivation for the lifetime of the process, including across hard forks that change the slot duration or the duty deadlines, so an explicit value that is valid today can schedule duties after the end of the slot on a future fork.
+
 ### controller.max-attestation-delay
 
-This is a duration parameter, that defaults to `4s`. It defines the maximum time that Vouch will wait from the start of a slot for a block before attesting on the basis that the slot is empty.
+This is a duration parameter, that defaults to a third of the slot duration reported by the chain (`4s` on a 12-second slot). It defines the maximum time that Vouch will wait from the start of a slot for a block before attesting on the basis that the slot is empty.
 
 ### controller.attestation-aggregation-delay
 
-This is a duration parameter, that defaults to `8s`. It defines the time that Vouch will wait from the start of a slot before aggregating existing attestations.
+This is a duration parameter, that defaults to two thirds of the slot duration reported by the chain (`8s` on a 12-second slot). It defines the time that Vouch will wait from the start of a slot before aggregating existing attestations.
 
 ### controller.max-sync-committee-message-delay
 
-This is a duration parameter, that defaults to `4s`. It defines the maximum time that Vouch will wait from the start of a slot for a block before generating sync committee messages on the basis that the slot is empty.
+This is a duration parameter, that defaults to a third of the slot duration reported by the chain (`4s` on a 12-second slot). It defines the maximum time that Vouch will wait from the start of a slot for a block before generating sync committee messages on the basis that the slot is empty.
 
 ### controller.sync-committee-aggregation-delay
 
-This is a duration parameter, that defaults to `8s`. It defines the time that Vouch will wait from the start of a slot before aggregating existing sync committee messages.
+This is a duration parameter, that defaults to two thirds of the slot duration reported by the chain (`8s` on a 12-second slot). It defines the time that Vouch will wait from the start of a slot before aggregating existing sync committee messages.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -418,20 +418,20 @@ This can be configured using the environment variables `VOUCH_<MODULE>_LOG_LEVEL
 
 Advanced options can change the performance of Vouch to be severely detrimental to its operation. It is strongly recommended that these options are not changed unless the user understands completely what they do and their possible performance impact.
 
-The duty timing options below are derived from the chain specification when they are not set. Before the Gloas fork the derived value is a fixed fraction of `SECONDS_PER_SLOT`. From Gloas onwards it is the deadline that the chain serves for that duty, in basis points of `SLOT_DURATION_MS`, falling back to the same fraction if the chain serves no value for it. Which of the two applies is decided per duty, from that duty's slot, so a Vouch that runs across the fork uses each side's deadlines for the duties on that side. Setting an option explicitly overrides the derivation on both sides of the fork for the lifetime of the process, so an explicit value that is valid today can schedule duties after the end of the slot on a future fork that shortens it.
+The duty timing options below are derived from the chain specification when they are not set. Before the Gloas fork the derived value is a fixed fraction of `SECONDS_PER_SLOT`. From Gloas onwards it is the deadline that the chain serves for that duty, in basis points of `SLOT_DURATION_MS`, falling back to the equivalent Gloas fraction if the chain serves no value for it. Gloas moves all four deadlines earlier, and its values are served under `_GLOAS`-suffixed keys; the unsuffixed keys continue to carry the pre-Gloas deadlines and are not used after the fork. Which of the two applies is decided per duty, from that duty's slot, so a Vouch that runs across the fork uses each side's deadlines for the duties on that side. Setting an option explicitly overrides the derivation on both sides of the fork for the lifetime of the process, so an explicit value that is valid today can schedule duties after the end of the slot on a future fork that shortens it.
 
 ### controller.max-attestation-delay
 
-This is a duration parameter, that defaults to a third of the slot duration (`4s` on a 12-second slot), or from Gloas onwards to `ATTESTATION_DUE_BPS` if the chain serves it. It defines the maximum time that Vouch will wait from the start of a slot for a block before attesting on the basis that the slot is empty.
+This is a duration parameter, that defaults to a third of the slot duration before the Gloas fork and to `ATTESTATION_DUE_BPS_GLOAS` from Gloas onwards; on a 12-second slot that is `4s` before Gloas and `3s` from Gloas. It defines the maximum time that Vouch will wait from the start of a slot for a block before attesting on the basis that the slot is empty.
 
 ### controller.attestation-aggregation-delay
 
-This is a duration parameter, that defaults to two thirds of the slot duration (`8s` on a 12-second slot), or from Gloas onwards to `AGGREGATE_DUE_BPS` if the chain serves it. It defines the time that Vouch will wait from the start of a slot before aggregating existing attestations.
+This is a duration parameter, that defaults to two thirds of the slot duration before the Gloas fork and to `AGGREGATE_DUE_BPS_GLOAS` from Gloas onwards; on a 12-second slot that is `8s` before Gloas and `6s` from Gloas. It defines the time that Vouch will wait from the start of a slot before aggregating existing attestations.
 
 ### controller.max-sync-committee-message-delay
 
-This is a duration parameter, that defaults to a third of the slot duration (`4s` on a 12-second slot), or from Gloas onwards to `SYNC_MESSAGE_DUE_BPS` if the chain serves it. It defines the maximum time that Vouch will wait from the start of a slot for a block before generating sync committee messages on the basis that the slot is empty.
+This is a duration parameter, that defaults to a third of the slot duration before the Gloas fork and to `SYNC_MESSAGE_DUE_BPS_GLOAS` from Gloas onwards; on a 12-second slot that is `4s` before Gloas and `3s` from Gloas. It defines the maximum time that Vouch will wait from the start of a slot for a block before generating sync committee messages on the basis that the slot is empty.
 
 ### controller.sync-committee-aggregation-delay
 
-This is a duration parameter, that defaults to two thirds of the slot duration (`8s` on a 12-second slot), or from Gloas onwards to `CONTRIBUTION_DUE_BPS` if the chain serves it. It defines the time that Vouch will wait from the start of a slot before aggregating existing sync committee messages.
+This is a duration parameter, that defaults to two thirds of the slot duration before the Gloas fork and to `CONTRIBUTION_DUE_BPS_GLOAS` from Gloas onwards; on a 12-second slot that is `8s` before Gloas and `6s` from Gloas. It defines the time that Vouch will wait from the start of a slot before aggregating existing sync committee messages.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -418,20 +418,20 @@ This can be configured using the environment variables `VOUCH_<MODULE>_LOG_LEVEL
 
 Advanced options can change the performance of Vouch to be severely detrimental to its operation. It is strongly recommended that these options are not changed unless the user understands completely what they do and their possible performance impact.
 
-The duty timing options below are derived from the chain specification when they are not set. Setting one explicitly overrides that derivation for the lifetime of the process, including across hard forks that change the slot duration or the duty deadlines, so an explicit value that is valid today can schedule duties after the end of the slot on a future fork.
+The duty timing options below are derived from the chain specification when they are not set. Before the Gloas fork the derived value is a fixed fraction of `SECONDS_PER_SLOT`. From Gloas onwards it is the deadline that the chain serves for that duty, in basis points of `SLOT_DURATION_MS`, falling back to the same fraction if the chain serves no value for it. Which of the two applies is decided per duty, from that duty's slot, so a Vouch that runs across the fork uses each side's deadlines for the duties on that side. Setting an option explicitly overrides the derivation on both sides of the fork for the lifetime of the process, so an explicit value that is valid today can schedule duties after the end of the slot on a future fork that shortens it.
 
 ### controller.max-attestation-delay
 
-This is a duration parameter, that defaults to a third of the slot duration reported by the chain (`4s` on a 12-second slot). It defines the maximum time that Vouch will wait from the start of a slot for a block before attesting on the basis that the slot is empty.
+This is a duration parameter, that defaults to a third of the slot duration (`4s` on a 12-second slot), or from Gloas onwards to `ATTESTATION_DUE_BPS` if the chain serves it. It defines the maximum time that Vouch will wait from the start of a slot for a block before attesting on the basis that the slot is empty.
 
 ### controller.attestation-aggregation-delay
 
-This is a duration parameter, that defaults to two thirds of the slot duration reported by the chain (`8s` on a 12-second slot). It defines the time that Vouch will wait from the start of a slot before aggregating existing attestations.
+This is a duration parameter, that defaults to two thirds of the slot duration (`8s` on a 12-second slot), or from Gloas onwards to `AGGREGATE_DUE_BPS` if the chain serves it. It defines the time that Vouch will wait from the start of a slot before aggregating existing attestations.
 
 ### controller.max-sync-committee-message-delay
 
-This is a duration parameter, that defaults to a third of the slot duration reported by the chain (`4s` on a 12-second slot). It defines the maximum time that Vouch will wait from the start of a slot for a block before generating sync committee messages on the basis that the slot is empty.
+This is a duration parameter, that defaults to a third of the slot duration (`4s` on a 12-second slot), or from Gloas onwards to `SYNC_MESSAGE_DUE_BPS` if the chain serves it. It defines the maximum time that Vouch will wait from the start of a slot for a block before generating sync committee messages on the basis that the slot is empty.
 
 ### controller.sync-committee-aggregation-delay
 
-This is a duration parameter, that defaults to two thirds of the slot duration reported by the chain (`8s` on a 12-second slot). It defines the time that Vouch will wait from the start of a slot before aggregating existing sync committee messages.
+This is a duration parameter, that defaults to two thirds of the slot duration (`8s` on a 12-second slot), or from Gloas onwards to `CONTRIBUTION_DUE_BPS` if the chain serves it. It defines the time that Vouch will wait from the start of a slot before aggregating existing sync committee messages.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/attestantio/go-block-relay v0.6.0
 	github.com/attestantio/go-builder-client v0.8.0
 	github.com/attestantio/go-certmanager v0.2.0
-	github.com/attestantio/go-eth2-client v0.29.1-0.20260811144708-94db679b233c
+	github.com/attestantio/go-eth2-client v0.29.1-0.20260813075519-56e9a537aee6
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/google/uuid v1.6.0
 	github.com/holiman/uint256 v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,12 @@ require (
 	github.com/attestantio/go-block-relay v0.6.0
 	github.com/attestantio/go-builder-client v0.8.0
 	github.com/attestantio/go-certmanager v0.2.0
-	github.com/attestantio/go-eth2-client v0.29.1-0.20260813075519-56e9a537aee6
+	github.com/attestantio/go-eth2-client v0.29.1-0.20260817140745-1263dc7060ea
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/google/uuid v1.6.0
 	github.com/holiman/uint256 v1.3.2
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/pk910/dynamic-ssz v1.3.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.0
@@ -93,7 +94,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe // indirect
-	github.com/pk910/dynamic-ssz v1.3.2 // indirect
 	github.com/pk910/hashtree-bindings v0.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,12 +82,8 @@ github.com/attestantio/go-builder-client v0.8.0 h1:paYTXZLtpCBG/9/Y99f9OjPNh4C+Z
 github.com/attestantio/go-builder-client v0.8.0/go.mod h1:M3rNO3ntGg+CE7aBDl+MVlwnEStZCiSRUzADG2ZoL+s=
 github.com/attestantio/go-certmanager v0.2.0 h1:Hzj12L5fofK7b281uohMBN0HQuSx+8RfU2UA9eHl84k=
 github.com/attestantio/go-certmanager v0.2.0/go.mod h1:Dn+C/okccD+2RugizT1ryrjX65cBMZl55fNYtmaVYAg=
-github.com/attestantio/go-eth2-client v0.29.0 h1:nOVPR6boXuGn5yg94pVOKcaoiO9yyjaYbM1vzwPF4n4=
-github.com/attestantio/go-eth2-client v0.29.0/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
-github.com/attestantio/go-eth2-client v0.29.1-0.20260811144708-94db679b233c h1:fuiXnbUXUh6BbcV/ZkZHEuN39zLRqyMstKNg0fe6ZvQ=
-github.com/attestantio/go-eth2-client v0.29.1-0.20260811144708-94db679b233c/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
-github.com/attestantio/go-eth2-client v0.29.1-0.20260813075519-56e9a537aee6 h1:U59++PPwmKYGKg2Fnmvpf5EQCLW1oi/13GcRK+mU6A4=
-github.com/attestantio/go-eth2-client v0.29.1-0.20260813075519-56e9a537aee6/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
+github.com/attestantio/go-eth2-client v0.29.1-0.20260817140745-1263dc7060ea h1:izccFMj70xj1wIVONNLjC5W9zy8i9cV0UEt0puL0vIg=
+github.com/attestantio/go-eth2-client v0.29.1-0.20260817140745-1263dc7060ea/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
 github.com/aws/aws-sdk-go v1.44.81/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/attestantio/go-eth2-client v0.29.0 h1:nOVPR6boXuGn5yg94pVOKcaoiO9yyja
 github.com/attestantio/go-eth2-client v0.29.0/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
 github.com/attestantio/go-eth2-client v0.29.1-0.20260811144708-94db679b233c h1:fuiXnbUXUh6BbcV/ZkZHEuN39zLRqyMstKNg0fe6ZvQ=
 github.com/attestantio/go-eth2-client v0.29.1-0.20260811144708-94db679b233c/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
+github.com/attestantio/go-eth2-client v0.29.1-0.20260813075519-56e9a537aee6 h1:U59++PPwmKYGKg2Fnmvpf5EQCLW1oi/13GcRK+mU6A4=
+github.com/attestantio/go-eth2-client v0.29.1-0.20260813075519-56e9a537aee6/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
 github.com/aws/aws-sdk-go v1.44.81/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=

--- a/logging.go
+++ b/logging.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// log.
+// Log.
 var log zerolog.Logger
 
 // initLogging initialises logging.

--- a/main.go
+++ b/main.go
@@ -250,10 +250,15 @@ func fetchConfig() error {
 	viper.SetDefault("eth2client.custom-spec-support", false)
 	viper.SetDefault("eth2client.allow-delayed-start", true)
 	viper.SetDefault("controller.max-proposal-delay", 0)
-	viper.SetDefault("controller.max-attestation-delay", 4*time.Second)
-	viper.SetDefault("controller.max-sync-committee-message-delay", 4*time.Second)
-	viper.SetDefault("controller.attestation-aggregation-delay", 8*time.Second)
-	viper.SetDefault("controller.sync-committee-aggregation-delay", 8*time.Second)
+	// The duty delays below default to 0, which the controller reads as "derive from the
+	// chain specification".  On a 12-second slot the derived values are the 4s/8s that were
+	// previously hardcoded here; on a chain that serves a different slot duration, or that
+	// serves explicit basis-point deadlines, the derived values follow the chain rather than
+	// silently scheduling duties past the end of the slot.
+	viper.SetDefault("controller.max-attestation-delay", 0)
+	viper.SetDefault("controller.max-sync-committee-message-delay", 0)
+	viper.SetDefault("controller.attestation-aggregation-delay", 0)
+	viper.SetDefault("controller.sync-committee-aggregation-delay", 0)
 	viper.SetDefault("controller.verify-sync-committee-inclusion", false)
 	viper.SetDefault("controller.fast-track.attestations", true)
 	viper.SetDefault("controller.fast-track.sync-committees", true)

--- a/main.go
+++ b/main.go
@@ -2044,7 +2044,7 @@ func obtainBuilderConfigsForPrivilegedBuilders(_ context.Context,
 	return nil
 }
 
-// select the signed beacon block provider based on user input.
+// Select the signed beacon block provider based on user input.
 func selectSignedBeaconBlockProvider(ctx context.Context,
 	monitor metrics.Service,
 ) (
@@ -2092,7 +2092,7 @@ func selectSignedBeaconBlockProvider(ctx context.Context,
 	return provider, nil
 }
 
-// select the beacon header provider based on user input.
+// Select the beacon header provider based on user input.
 func selectBeaconHeaderProvider(ctx context.Context,
 	monitor metrics.Service,
 ) (

--- a/main.go
+++ b/main.go
@@ -1462,10 +1462,20 @@ func selectProposalProvider(ctx context.Context,
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to fetch clients for simple beacon block proposal strategy")
 		}
-		var isProvider bool
-		proposalProvider, isProvider = beaconBlockProposalClient.(beaconblockproposer.ProposalDataProvider)
+		provider, isProvider := beaconBlockProposalClient.(beaconblockproposer.ProposalDataProvider)
 		if !isProvider {
 			return nil, errors.New("beacon block proposal client does not support ePBS proposals")
+		}
+		proposalProvider, err = firstbeaconblockproposalstrategy.New(ctx,
+			firstbeaconblockproposalstrategy.WithClientMonitor(monitor.(metrics.ClientMonitor)),
+			firstbeaconblockproposalstrategy.WithLogLevel(util.LogLevel("strategies.beaconblockproposal.first")),
+			firstbeaconblockproposalstrategy.WithProposalProviders(map[string]beaconblockproposer.ProposalDataProvider{
+				"simple": provider,
+			}),
+			firstbeaconblockproposalstrategy.WithTimeout(util.Timeout("strategies.beaconblockproposal.first")),
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to start simple beacon block proposal strategy")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -251,14 +251,15 @@ func fetchConfig() error {
 	viper.SetDefault("eth2client.allow-delayed-start", true)
 	viper.SetDefault("controller.max-proposal-delay", 0)
 	// The duty delays below default to 0, which the controller reads as "derive from the
-	// chain specification".  On a 12-second slot the derived values are the 4s/8s that were
-	// previously hardcoded here; on a chain that serves a different slot duration, or that
-	// serves explicit basis-point deadlines, the derived values follow the chain rather than
-	// silently scheduling duties past the end of the slot.
-	viper.SetDefault("controller.max-attestation-delay", 0)
-	viper.SetDefault("controller.max-sync-committee-message-delay", 0)
-	viper.SetDefault("controller.attestation-aggregation-delay", 0)
-	viper.SetDefault("controller.sync-committee-aggregation-delay", 0)
+	// chain specification".  On a 12-second slot the pre-Gloas derived values are the 4s/8s that
+	// were previously hardcoded here, and Gloas moves each of them earlier; on a chain that serves
+	// a different slot duration, or different basis-point deadlines, the derived values follow the
+	// chain rather than silently scheduling duties past the end of the slot.  The comments give the
+	// derived values on a 12-second slot, which is what mainnet and devnet-8 serve.
+	viper.SetDefault("controller.max-attestation-delay", 0)            // 4s pre-Gloas, 3s from Gloas.
+	viper.SetDefault("controller.max-sync-committee-message-delay", 0) // 4s pre-Gloas, 3s from Gloas.
+	viper.SetDefault("controller.attestation-aggregation-delay", 0)    // 8s pre-Gloas, 6s from Gloas.
+	viper.SetDefault("controller.sync-committee-aggregation-delay", 0) // 8s pre-Gloas, 6s from Gloas.
 	viper.SetDefault("controller.verify-sync-committee-inclusion", false)
 	viper.SetDefault("controller.fast-track.attestations", true)
 	viper.SetDefault("controller.fast-track.sync-committees", true)

--- a/services/accountmanager/dirk/parameters.go
+++ b/services/accountmanager/dirk/parameters.go
@@ -27,8 +27,11 @@ import (
 )
 
 type parameters struct {
-	logLevel               zerolog.Level
 	monitor                metrics.Service
+	domainProvider         eth2client.DomainProvider
+	farFutureEpochProvider eth2client.FarFutureEpochProvider
+	currentEpochProvider   chaintime.Service
+	logLevel               zerolog.Level
 	timeout                time.Duration
 	clientMonitor          metrics.ClientMonitor
 	processConcurrency     int64
@@ -38,10 +41,7 @@ type parameters struct {
 	clientCertURI          string
 	clientKeyURI           string
 	caCertURI              string
-	domainProvider         eth2client.DomainProvider
 	validatorsManager      validatorsmanager.Service
-	farFutureEpochProvider eth2client.FarFutureEpochProvider
-	currentEpochProvider   chaintime.Service
 }
 
 // Parameter is the interface for service parameters.

--- a/services/accountmanager/dirk/service.go
+++ b/services/accountmanager/dirk/service.go
@@ -46,8 +46,9 @@ import (
 // Service is the manager for dirk accounts.
 type Service struct {
 	log                  zerolog.Logger
-	mutex                sync.RWMutex
 	monitor              metrics.Service
+	domainProvider       eth2client.DomainProvider
+	currentEpochProvider chaintime.Service
 	clientMonitor        metrics.ClientMonitor
 	timeout              time.Duration
 	processConcurrency   int64
@@ -57,10 +58,9 @@ type Service struct {
 	accounts             map[phase0.BLSPubKey]e2wtypes.Account
 	pubKeys              []phase0.BLSPubKey
 	validatorsManager    validatorsmanager.Service
-	domainProvider       eth2client.DomainProvider
 	farFutureEpoch       phase0.Epoch
-	currentEpochProvider chaintime.Service
 	wallets              map[string]e2wtypes.Wallet
+	mutex                sync.RWMutex
 	walletsMutex         sync.RWMutex
 }
 

--- a/services/accountmanager/wallet/parameters.go
+++ b/services/accountmanager/wallet/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,17 +23,17 @@ import (
 )
 
 type parameters struct {
-	logLevel               zerolog.Level
 	monitor                metrics.Service
+	specProvider           eth2client.SpecProvider
+	domainProvider         eth2client.DomainProvider
+	farFutureEpochProvider eth2client.FarFutureEpochProvider
+	currentEpochProvider   chaintime.Service
+	logLevel               zerolog.Level
 	processConcurrency     int64
 	locations              []string
 	accountPaths           []string
 	passphrases            [][]byte
 	validatorsManager      validatorsmanager.Service
-	specProvider           eth2client.SpecProvider
-	domainProvider         eth2client.DomainProvider
-	farFutureEpochProvider eth2client.FarFutureEpochProvider
-	currentEpochProvider   chaintime.Service
 }
 
 // Parameter is the interface for service parameters.

--- a/services/accountmanager/wallet/service.go
+++ b/services/accountmanager/wallet/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2025 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -44,8 +44,9 @@ import (
 // Service is the manager for wallet accounts.
 type Service struct {
 	log                  zerolog.Logger
-	mutex                sync.RWMutex
 	monitor              metrics.Service
+	domainProvider       eth2client.DomainProvider
+	currentEpochProvider chaintime.Service
 	processConcurrency   int64
 	stores               []e2wtypes.Store
 	accountPaths         []string
@@ -53,9 +54,8 @@ type Service struct {
 	accounts             map[phase0.BLSPubKey]e2wtypes.Account
 	validatorsManager    validatorsmanager.Service
 	slotsPerEpoch        phase0.Slot
-	domainProvider       eth2client.DomainProvider
 	farFutureEpoch       phase0.Epoch
-	currentEpochProvider chaintime.Service
+	mutex                sync.RWMutex
 }
 
 // New creates a new wallet account manager.

--- a/services/attestationaggregator/standard/parameters.go
+++ b/services/attestationaggregator/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -25,11 +25,11 @@ import (
 )
 
 type parameters struct {
-	logLevel                       zerolog.Level
 	monitor                        metrics.Service
 	specProvider                   eth2client.SpecProvider
 	validatingAccountsProvider     accountmanager.ValidatingAccountsProvider
 	aggregateAttestationProvider   eth2client.AggregateAttestationProvider
+	logLevel                       zerolog.Level
 	aggregateAttestationsSubmitter submitter.AggregateAttestationsSubmitter
 	slotSelectionSigner            signer.SlotSelectionSigner
 	aggregateAndProofSigner        signer.AggregateAndProofSigner

--- a/services/attestationaggregator/standard/service.go
+++ b/services/attestationaggregator/standard/service.go
@@ -212,117 +212,31 @@ func (s *Service) Aggregate(ctx context.Context, duty *attestationaggregator.Dut
 func createVersionedAggregateAndProof(duty *attestationaggregator.Duty, aggregateAttestation *spec.VersionedAttestation) (*spec.VersionedAggregateAndProof, error) {
 	switch aggregateAttestation.Version {
 	case spec.DataVersionPhase0:
-		if aggregateAttestation.Phase0 == nil {
-			return nil, errors.New("no phase0 attestation")
-		}
-		aggregateAndProof := &phase0.AggregateAndProof{
-			AggregatorIndex: duty.ValidatorIndex,
-			Aggregate:       aggregateAttestation.Phase0,
-			SelectionProof:  duty.SlotSignature,
-		}
-		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
-			Version: aggregateAttestation.Version,
-			Phase0:  aggregateAndProof,
-		}
-		return versionedAggregateAndProof, nil
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Phase0, "phase0")
 	case spec.DataVersionAltair:
-		if aggregateAttestation.Altair == nil {
-			return nil, errors.New("no altair attestation")
-		}
-		aggregateAndProof := &phase0.AggregateAndProof{
-			AggregatorIndex: duty.ValidatorIndex,
-			Aggregate:       aggregateAttestation.Altair,
-			SelectionProof:  duty.SlotSignature,
-		}
-		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
-			Version: aggregateAttestation.Version,
-			Altair:  aggregateAndProof,
-		}
-		return versionedAggregateAndProof, nil
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Altair, "altair")
 	case spec.DataVersionBellatrix:
-		if aggregateAttestation.Bellatrix == nil {
-			return nil, errors.New("no bellatrix attestation")
-		}
-		aggregateAndProof := &phase0.AggregateAndProof{
-			AggregatorIndex: duty.ValidatorIndex,
-			Aggregate:       aggregateAttestation.Bellatrix,
-			SelectionProof:  duty.SlotSignature,
-		}
-		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
-			Version:   aggregateAttestation.Version,
-			Bellatrix: aggregateAndProof,
-		}
-		return versionedAggregateAndProof, nil
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Bellatrix, "bellatrix")
 	case spec.DataVersionCapella:
-		if aggregateAttestation.Capella == nil {
-			return nil, errors.New("no capella attestation")
-		}
-		aggregateAndProof := &phase0.AggregateAndProof{
-			AggregatorIndex: duty.ValidatorIndex,
-			Aggregate:       aggregateAttestation.Capella,
-			SelectionProof:  duty.SlotSignature,
-		}
-		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
-			Version: aggregateAttestation.Version,
-			Capella: aggregateAndProof,
-		}
-		return versionedAggregateAndProof, nil
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Capella, "capella")
 	case spec.DataVersionDeneb:
-		if aggregateAttestation.Deneb == nil {
-			return nil, errors.New("no deneb attestation")
-		}
-		aggregateAndProof := &phase0.AggregateAndProof{
-			AggregatorIndex: duty.ValidatorIndex,
-			Aggregate:       aggregateAttestation.Deneb,
-			SelectionProof:  duty.SlotSignature,
-		}
-		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
-			Version: aggregateAttestation.Version,
-			Deneb:   aggregateAndProof,
-		}
-		return versionedAggregateAndProof, nil
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Deneb, "deneb")
 	case spec.DataVersionElectra:
-		if aggregateAttestation.Electra == nil {
-			return nil, errors.New("no electra attestation")
-		}
-		aggregateAndProof := &electra.AggregateAndProof{
-			AggregatorIndex: duty.ValidatorIndex,
-			Aggregate:       aggregateAttestation.Electra,
-			SelectionProof:  duty.SlotSignature,
-		}
-		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
-			Version: aggregateAttestation.Version,
-			Electra: aggregateAndProof,
-		}
-		return versionedAggregateAndProof, nil
+		return createVersionedElectraAggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Electra, "electra")
 	case spec.DataVersionFulu:
-		if aggregateAttestation.Fulu == nil {
-			return nil, errors.New("no fulu attestation")
-		}
-		aggregateAndProof := &electra.AggregateAndProof{
-			AggregatorIndex: duty.ValidatorIndex,
-			Aggregate:       aggregateAttestation.Fulu,
-			SelectionProof:  duty.SlotSignature,
-		}
-		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
-			Version: aggregateAttestation.Version,
-			Fulu:    aggregateAndProof,
-		}
-		return versionedAggregateAndProof, nil
+		return createVersionedElectraAggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Fulu, "fulu")
 	case spec.DataVersionGloas:
 		if aggregateAttestation.Gloas == nil {
 			return nil, errors.New("no gloas attestation")
 		}
-		aggregateAndProof := &gloas.AggregateAndProof{
-			AggregatorIndex: duty.ValidatorIndex,
-			Aggregate:       aggregateAttestation.Gloas,
-			SelectionProof:  duty.SlotSignature,
-		}
-		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
+		return &spec.VersionedAggregateAndProof{
 			Version: aggregateAttestation.Version,
-			Gloas:   aggregateAndProof,
-		}
-		return versionedAggregateAndProof, nil
+			Gloas: &gloas.AggregateAndProof{
+				AggregatorIndex: duty.ValidatorIndex,
+				Aggregate:       aggregateAttestation.Gloas,
+				SelectionProof:  duty.SlotSignature,
+			},
+		}, nil
 	default:
 		return &spec.VersionedAggregateAndProof{}, errors.New("unknown version")
 	}
@@ -331,112 +245,143 @@ func createVersionedAggregateAndProof(duty *attestationaggregator.Duty, aggregat
 func createVersionedSignedAggregateAndProof(aggregateAndProof *spec.VersionedAggregateAndProof, sig phase0.BLSSignature) (*spec.VersionedSignedAggregateAndProof, error) {
 	switch aggregateAndProof.Version {
 	case spec.DataVersionPhase0:
-		if aggregateAndProof.Phase0 == nil {
-			return nil, errors.New("no phase0 aggregate and proof")
-		}
-		signedAggregateAndProof := &phase0.SignedAggregateAndProof{
-			Message:   aggregateAndProof.Phase0,
-			Signature: sig,
-		}
-		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
-			Version: aggregateAndProof.Version,
-			Phase0:  signedAggregateAndProof,
-		}
-		return signedVersionedAggregateAndProof, nil
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Phase0, sig, "phase0")
 	case spec.DataVersionAltair:
-		if aggregateAndProof.Altair == nil {
-			return nil, errors.New("no altair aggregate and proof")
-		}
-		signedAggregateAndProof := &phase0.SignedAggregateAndProof{
-			Message:   aggregateAndProof.Altair,
-			Signature: sig,
-		}
-		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
-			Version: aggregateAndProof.Version,
-			Altair:  signedAggregateAndProof,
-		}
-		return signedVersionedAggregateAndProof, nil
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Altair, sig, "altair")
 	case spec.DataVersionBellatrix:
-		if aggregateAndProof.Bellatrix == nil {
-			return nil, errors.New("no bellatrix aggregate and proof")
-		}
-		signedAggregateAndProof := &phase0.SignedAggregateAndProof{
-			Message:   aggregateAndProof.Bellatrix,
-			Signature: sig,
-		}
-		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
-			Version:   aggregateAndProof.Version,
-			Bellatrix: signedAggregateAndProof,
-		}
-		return signedVersionedAggregateAndProof, nil
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Bellatrix, sig, "bellatrix")
 	case spec.DataVersionCapella:
-		if aggregateAndProof.Capella == nil {
-			return nil, errors.New("no capella aggregate and proof")
-		}
-		signedAggregateAndProof := &phase0.SignedAggregateAndProof{
-			Message:   aggregateAndProof.Capella,
-			Signature: sig,
-		}
-		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
-			Version: aggregateAndProof.Version,
-			Capella: signedAggregateAndProof,
-		}
-		return signedVersionedAggregateAndProof, nil
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Capella, sig, "capella")
 	case spec.DataVersionDeneb:
-		if aggregateAndProof.Deneb == nil {
-			return nil, errors.New("no deneb aggregate and proof")
-		}
-		signedAggregateAndProof := &phase0.SignedAggregateAndProof{
-			Message:   aggregateAndProof.Deneb,
-			Signature: sig,
-		}
-		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
-			Version: aggregateAndProof.Version,
-			Deneb:   signedAggregateAndProof,
-		}
-		return signedVersionedAggregateAndProof, nil
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Deneb, sig, "deneb")
 	case spec.DataVersionElectra:
-		if aggregateAndProof.Electra == nil {
-			return nil, errors.New("no electra aggregate and proof")
-		}
-		signedAggregateAndProof := &electra.SignedAggregateAndProof{
-			Message:   aggregateAndProof.Electra,
-			Signature: sig,
-		}
-		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
-			Version: aggregateAndProof.Version,
-			Electra: signedAggregateAndProof,
-		}
-		return signedVersionedAggregateAndProof, nil
+		return createVersionedElectraSignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Electra, sig, "electra")
 	case spec.DataVersionFulu:
-		if aggregateAndProof.Fulu == nil {
-			return nil, errors.New("no fulu aggregate and proof")
-		}
-		signedAggregateAndProof := &electra.SignedAggregateAndProof{
-			Message:   aggregateAndProof.Fulu,
-			Signature: sig,
-		}
-		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
-			Version: aggregateAndProof.Version,
-			Fulu:    signedAggregateAndProof,
-		}
-		return signedVersionedAggregateAndProof, nil
+		return createVersionedElectraSignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Fulu, sig, "fulu")
 	case spec.DataVersionGloas:
 		if aggregateAndProof.Gloas == nil {
 			return nil, errors.New("no gloas aggregate and proof")
 		}
-		signedAggregateAndProof := &gloas.SignedAggregateAndProof{
-			Message:   aggregateAndProof.Gloas,
-			Signature: sig,
-		}
-		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
+		return &spec.VersionedSignedAggregateAndProof{
 			Version: aggregateAndProof.Version,
-			Gloas:   signedAggregateAndProof,
-		}
-		return signedVersionedAggregateAndProof, nil
+			Gloas: &gloas.SignedAggregateAndProof{
+				Message:   aggregateAndProof.Gloas,
+				Signature: sig,
+			},
+		}, nil
 	default:
 		return &spec.VersionedSignedAggregateAndProof{}, errors.New("unknown version")
 	}
+}
+
+func createVersionedPhase0AggregateAndProof(duty *attestationaggregator.Duty,
+	version spec.DataVersion,
+	aggregateAttestation *phase0.Attestation,
+	name string,
+) (*spec.VersionedAggregateAndProof, error) {
+	if aggregateAttestation == nil {
+		return nil, errors.New("no " + name + " attestation")
+	}
+	aggregateAndProof := &phase0.AggregateAndProof{
+		AggregatorIndex: duty.ValidatorIndex,
+		Aggregate:       aggregateAttestation,
+		SelectionProof:  duty.SlotSignature,
+	}
+	result := &spec.VersionedAggregateAndProof{Version: version}
+	switch version {
+	case spec.DataVersionPhase0:
+		result.Phase0 = aggregateAndProof
+	case spec.DataVersionAltair:
+		result.Altair = aggregateAndProof
+	case spec.DataVersionBellatrix:
+		result.Bellatrix = aggregateAndProof
+	case spec.DataVersionCapella:
+		result.Capella = aggregateAndProof
+	case spec.DataVersionDeneb:
+		result.Deneb = aggregateAndProof
+	default:
+		return nil, errors.New("unknown version")
+	}
+	return result, nil
+}
+
+func createVersionedElectraAggregateAndProof(duty *attestationaggregator.Duty,
+	version spec.DataVersion,
+	aggregateAttestation *electra.Attestation,
+	name string,
+) (*spec.VersionedAggregateAndProof, error) {
+	if aggregateAttestation == nil {
+		return nil, errors.New("no " + name + " attestation")
+	}
+	aggregateAndProof := &electra.AggregateAndProof{
+		AggregatorIndex: duty.ValidatorIndex,
+		Aggregate:       aggregateAttestation,
+		SelectionProof:  duty.SlotSignature,
+	}
+	result := &spec.VersionedAggregateAndProof{Version: version}
+	switch version {
+	case spec.DataVersionElectra:
+		result.Electra = aggregateAndProof
+	case spec.DataVersionFulu:
+		result.Fulu = aggregateAndProof
+	default:
+		return nil, errors.New("unknown version")
+	}
+	return result, nil
+}
+
+func createVersionedPhase0SignedAggregateAndProof(version spec.DataVersion,
+	aggregateAndProof *phase0.AggregateAndProof,
+	sig phase0.BLSSignature,
+	name string,
+) (*spec.VersionedSignedAggregateAndProof, error) {
+	if aggregateAndProof == nil {
+		return nil, errors.New("no " + name + " aggregate and proof")
+	}
+	signedAggregateAndProof := &phase0.SignedAggregateAndProof{
+		Message:   aggregateAndProof,
+		Signature: sig,
+	}
+	result := &spec.VersionedSignedAggregateAndProof{Version: version}
+	switch version {
+	case spec.DataVersionPhase0:
+		result.Phase0 = signedAggregateAndProof
+	case spec.DataVersionAltair:
+		result.Altair = signedAggregateAndProof
+	case spec.DataVersionBellatrix:
+		result.Bellatrix = signedAggregateAndProof
+	case spec.DataVersionCapella:
+		result.Capella = signedAggregateAndProof
+	case spec.DataVersionDeneb:
+		result.Deneb = signedAggregateAndProof
+	default:
+		return nil, errors.New("unknown version")
+	}
+	return result, nil
+}
+
+func createVersionedElectraSignedAggregateAndProof(version spec.DataVersion,
+	aggregateAndProof *electra.AggregateAndProof,
+	sig phase0.BLSSignature,
+	name string,
+) (*spec.VersionedSignedAggregateAndProof, error) {
+	if aggregateAndProof == nil {
+		return nil, errors.New("no " + name + " aggregate and proof")
+	}
+	signedAggregateAndProof := &electra.SignedAggregateAndProof{
+		Message:   aggregateAndProof,
+		Signature: sig,
+	}
+	result := &spec.VersionedSignedAggregateAndProof{Version: version}
+	switch version {
+	case spec.DataVersionElectra:
+		result.Electra = signedAggregateAndProof
+	case spec.DataVersionFulu:
+		result.Fulu = signedAggregateAndProof
+	default:
+		return nil, errors.New("unknown version")
+	}
+	return result, nil
 }
 
 // AggregatorsAndSignatures reports signatures and whether validators are attestation aggregators for a given slot.

--- a/services/attestationaggregator/standard/service.go
+++ b/services/attestationaggregator/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -42,10 +42,10 @@ import (
 type Service struct {
 	log                            zerolog.Logger
 	monitor                        metrics.Service
-	targetAggregatorsPerCommittee  uint64
-	slotsPerEpoch                  uint64
 	validatingAccountsProvider     accountmanager.ValidatingAccountsProvider
 	aggregateAttestationProvider   eth2client.AggregateAttestationProvider
+	targetAggregatorsPerCommittee  uint64
+	slotsPerEpoch                  uint64
 	aggregateAttestationsSubmitter submitter.AggregateAttestationsSubmitter
 	slotSelectionSigner            signer.SlotSelectionSigner
 	aggregateAndProofSigner        signer.AggregateAndProofSigner

--- a/services/attestationaggregator/standard/service.go
+++ b/services/attestationaggregator/standard/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/accountmanager"
 	"github.com/attestantio/vouch/services/attestationaggregator"
@@ -308,6 +309,20 @@ func createVersionedAggregateAndProof(duty *attestationaggregator.Duty, aggregat
 			Fulu:    aggregateAndProof,
 		}
 		return versionedAggregateAndProof, nil
+	case spec.DataVersionGloas:
+		if aggregateAttestation.Gloas == nil {
+			return nil, errors.New("no gloas attestation")
+		}
+		aggregateAndProof := &gloas.AggregateAndProof{
+			AggregatorIndex: duty.ValidatorIndex,
+			Aggregate:       aggregateAttestation.Gloas,
+			SelectionProof:  duty.SlotSignature,
+		}
+		versionedAggregateAndProof := &spec.VersionedAggregateAndProof{
+			Version: aggregateAttestation.Version,
+			Gloas:   aggregateAndProof,
+		}
+		return versionedAggregateAndProof, nil
 	default:
 		return &spec.VersionedAggregateAndProof{}, errors.New("unknown version")
 	}
@@ -404,6 +419,19 @@ func createVersionedSignedAggregateAndProof(aggregateAndProof *spec.VersionedAgg
 		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
 			Version: aggregateAndProof.Version,
 			Fulu:    signedAggregateAndProof,
+		}
+		return signedVersionedAggregateAndProof, nil
+	case spec.DataVersionGloas:
+		if aggregateAndProof.Gloas == nil {
+			return nil, errors.New("no gloas aggregate and proof")
+		}
+		signedAggregateAndProof := &gloas.SignedAggregateAndProof{
+			Message:   aggregateAndProof.Gloas,
+			Signature: sig,
+		}
+		signedVersionedAggregateAndProof := &spec.VersionedSignedAggregateAndProof{
+			Version: aggregateAndProof.Version,
+			Gloas:   signedAggregateAndProof,
 		}
 		return signedVersionedAggregateAndProof, nil
 	default:

--- a/services/attestationaggregator/standard/service.go
+++ b/services/attestationaggregator/standard/service.go
@@ -212,19 +212,19 @@ func (s *Service) Aggregate(ctx context.Context, duty *attestationaggregator.Dut
 func createVersionedAggregateAndProof(duty *attestationaggregator.Duty, aggregateAttestation *spec.VersionedAttestation) (*spec.VersionedAggregateAndProof, error) {
 	switch aggregateAttestation.Version {
 	case spec.DataVersionPhase0:
-		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Phase0, "phase0")
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Phase0)
 	case spec.DataVersionAltair:
-		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Altair, "altair")
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Altair)
 	case spec.DataVersionBellatrix:
-		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Bellatrix, "bellatrix")
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Bellatrix)
 	case spec.DataVersionCapella:
-		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Capella, "capella")
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Capella)
 	case spec.DataVersionDeneb:
-		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Deneb, "deneb")
+		return createVersionedPhase0AggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Deneb)
 	case spec.DataVersionElectra:
-		return createVersionedElectraAggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Electra, "electra")
+		return createVersionedElectraAggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Electra)
 	case spec.DataVersionFulu:
-		return createVersionedElectraAggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Fulu, "fulu")
+		return createVersionedElectraAggregateAndProof(duty, aggregateAttestation.Version, aggregateAttestation.Fulu)
 	case spec.DataVersionGloas:
 		if aggregateAttestation.Gloas == nil {
 			return nil, errors.New("no gloas attestation")
@@ -238,26 +238,26 @@ func createVersionedAggregateAndProof(duty *attestationaggregator.Duty, aggregat
 			},
 		}, nil
 	default:
-		return &spec.VersionedAggregateAndProof{}, errors.New("unknown version")
+		return nil, errors.New("unknown version")
 	}
 }
 
 func createVersionedSignedAggregateAndProof(aggregateAndProof *spec.VersionedAggregateAndProof, sig phase0.BLSSignature) (*spec.VersionedSignedAggregateAndProof, error) {
 	switch aggregateAndProof.Version {
 	case spec.DataVersionPhase0:
-		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Phase0, sig, "phase0")
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Phase0, sig)
 	case spec.DataVersionAltair:
-		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Altair, sig, "altair")
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Altair, sig)
 	case spec.DataVersionBellatrix:
-		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Bellatrix, sig, "bellatrix")
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Bellatrix, sig)
 	case spec.DataVersionCapella:
-		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Capella, sig, "capella")
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Capella, sig)
 	case spec.DataVersionDeneb:
-		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Deneb, sig, "deneb")
+		return createVersionedPhase0SignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Deneb, sig)
 	case spec.DataVersionElectra:
-		return createVersionedElectraSignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Electra, sig, "electra")
+		return createVersionedElectraSignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Electra, sig)
 	case spec.DataVersionFulu:
-		return createVersionedElectraSignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Fulu, sig, "fulu")
+		return createVersionedElectraSignedAggregateAndProof(aggregateAndProof.Version, aggregateAndProof.Fulu, sig)
 	case spec.DataVersionGloas:
 		if aggregateAndProof.Gloas == nil {
 			return nil, errors.New("no gloas aggregate and proof")
@@ -270,17 +270,16 @@ func createVersionedSignedAggregateAndProof(aggregateAndProof *spec.VersionedAgg
 			},
 		}, nil
 	default:
-		return &spec.VersionedSignedAggregateAndProof{}, errors.New("unknown version")
+		return nil, errors.New("unknown version")
 	}
 }
 
 func createVersionedPhase0AggregateAndProof(duty *attestationaggregator.Duty,
 	version spec.DataVersion,
 	aggregateAttestation *phase0.Attestation,
-	name string,
 ) (*spec.VersionedAggregateAndProof, error) {
 	if aggregateAttestation == nil {
-		return nil, errors.New("no " + name + " attestation")
+		return nil, errors.New("no " + version.String() + " attestation")
 	}
 	aggregateAndProof := &phase0.AggregateAndProof{
 		AggregatorIndex: duty.ValidatorIndex,
@@ -308,10 +307,9 @@ func createVersionedPhase0AggregateAndProof(duty *attestationaggregator.Duty,
 func createVersionedElectraAggregateAndProof(duty *attestationaggregator.Duty,
 	version spec.DataVersion,
 	aggregateAttestation *electra.Attestation,
-	name string,
 ) (*spec.VersionedAggregateAndProof, error) {
 	if aggregateAttestation == nil {
-		return nil, errors.New("no " + name + " attestation")
+		return nil, errors.New("no " + version.String() + " attestation")
 	}
 	aggregateAndProof := &electra.AggregateAndProof{
 		AggregatorIndex: duty.ValidatorIndex,
@@ -333,10 +331,9 @@ func createVersionedElectraAggregateAndProof(duty *attestationaggregator.Duty,
 func createVersionedPhase0SignedAggregateAndProof(version spec.DataVersion,
 	aggregateAndProof *phase0.AggregateAndProof,
 	sig phase0.BLSSignature,
-	name string,
 ) (*spec.VersionedSignedAggregateAndProof, error) {
 	if aggregateAndProof == nil {
-		return nil, errors.New("no " + name + " aggregate and proof")
+		return nil, errors.New("no " + version.String() + " aggregate and proof")
 	}
 	signedAggregateAndProof := &phase0.SignedAggregateAndProof{
 		Message:   aggregateAndProof,
@@ -363,10 +360,9 @@ func createVersionedPhase0SignedAggregateAndProof(version spec.DataVersion,
 func createVersionedElectraSignedAggregateAndProof(version spec.DataVersion,
 	aggregateAndProof *electra.AggregateAndProof,
 	sig phase0.BLSSignature,
-	name string,
 ) (*spec.VersionedSignedAggregateAndProof, error) {
 	if aggregateAndProof == nil {
-		return nil, errors.New("no " + name + " aggregate and proof")
+		return nil, errors.New("no " + version.String() + " aggregate and proof")
 	}
 	signedAggregateAndProof := &electra.SignedAggregateAndProof{
 		Message:   aggregateAndProof,

--- a/services/attestationaggregator/standard/service_internal_test.go
+++ b/services/attestationaggregator/standard/service_internal_test.go
@@ -1,0 +1,114 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/attestationaggregator"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateVersionedAggregateAndProofGloas(t *testing.T) {
+	duty := &attestationaggregator.Duty{
+		ValidatorIndex: phase0.ValidatorIndex(42),
+		SlotSignature:  phase0.BLSSignature{1},
+	}
+	attestation := &gloas.Attestation{}
+
+	tests := []struct {
+		name                 string
+		versionedAttestation *spec.VersionedAttestation
+		err                  string
+	}{
+		{
+			name: "Valid",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionGloas,
+				Gloas:   attestation,
+			},
+		},
+		{
+			name: "MissingArm",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionGloas,
+			},
+			err: "no gloas attestation",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := createVersionedAggregateAndProof(duty, test.versionedAttestation)
+			if test.err != "" {
+				require.Nil(t, result)
+				require.EqualError(t, err, test.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, spec.DataVersionGloas, result.Version)
+			require.NotNil(t, result.Gloas)
+			require.Same(t, attestation, result.Gloas.Aggregate)
+			require.Equal(t, duty.ValidatorIndex, result.Gloas.AggregatorIndex)
+			require.Equal(t, duty.SlotSignature, result.Gloas.SelectionProof)
+		})
+	}
+}
+
+func TestCreateVersionedSignedAggregateAndProofGloas(t *testing.T) {
+	aggregateAndProof := &gloas.AggregateAndProof{}
+	sig := phase0.BLSSignature{2}
+
+	tests := []struct {
+		name                       string
+		versionedAggregateAndProof *spec.VersionedAggregateAndProof
+		err                        string
+	}{
+		{
+			name: "Valid",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionGloas,
+				Gloas:   aggregateAndProof,
+			},
+		},
+		{
+			name: "MissingArm",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionGloas,
+			},
+			err: "no gloas aggregate and proof",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := createVersionedSignedAggregateAndProof(test.versionedAggregateAndProof, sig)
+			if test.err != "" {
+				require.Nil(t, result)
+				require.EqualError(t, err, test.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, spec.DataVersionGloas, result.Version)
+			require.NotNil(t, result.Gloas)
+			require.Same(t, aggregateAndProof, result.Gloas.Message)
+			require.Equal(t, sig, result.Gloas.Signature)
+		})
+	}
+}

--- a/services/attestationaggregator/standard/service_internal_test.go
+++ b/services/attestationaggregator/standard/service_internal_test.go
@@ -24,91 +24,122 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testAggregateSlot is the slot carried by the attestations the tests supply.  Asserting on it
+// proves the conversion carried the supplied attestation through rather than leaving it nil.
+const testAggregateSlot = phase0.Slot(99)
+
+// aggregateOf returns the aggregate attestation held by the arm the version names, so a
+// conversion that populated the wrong arm - or left the aggregate nil - is visible to the caller.
+func aggregateOf(t *testing.T, aggregateAndProof *spec.VersionedAggregateAndProof) any {
+	t.Helper()
+
+	switch aggregateAndProof.Version {
+	case spec.DataVersionPhase0:
+		return aggregateAndProof.Phase0.Aggregate
+	case spec.DataVersionAltair:
+		return aggregateAndProof.Altair.Aggregate
+	case spec.DataVersionBellatrix:
+		return aggregateAndProof.Bellatrix.Aggregate
+	case spec.DataVersionCapella:
+		return aggregateAndProof.Capella.Aggregate
+	case spec.DataVersionDeneb:
+		return aggregateAndProof.Deneb.Aggregate
+	case spec.DataVersionElectra:
+		return aggregateAndProof.Electra.Aggregate
+	case spec.DataVersionFulu:
+		return aggregateAndProof.Fulu.Aggregate
+	case spec.DataVersionGloas:
+		return aggregateAndProof.Gloas.Aggregate
+	default:
+		require.FailNow(t, "no aggregate for version", aggregateAndProof.Version.String())
+
+		return nil
+	}
+}
+
 func TestCreateVersionedAggregateAndProof(t *testing.T) {
 	duty := &attestationaggregator.Duty{
 		ValidatorIndex: phase0.ValidatorIndex(42),
 		SlotSignature:  phase0.BLSSignature{1},
 	}
+	phase0Attestation := &phase0.Attestation{Data: &phase0.AttestationData{Slot: testAggregateSlot}}
+	electraAttestation := &electra.Attestation{Data: &phase0.AttestationData{Slot: testAggregateSlot}}
+	gloasAttestation := &gloas.Attestation{Data: &phase0.AttestationData{Slot: testAggregateSlot}}
 
 	tests := []struct {
 		name                 string
 		versionedAttestation *spec.VersionedAttestation
-		err                  string
+		expectedAggregate    any
 	}{
 		{
 			name: "Phase0",
 			versionedAttestation: &spec.VersionedAttestation{
 				Version: spec.DataVersionPhase0,
-				Phase0:  &phase0.Attestation{},
+				Phase0:  phase0Attestation,
 			},
+			expectedAggregate: phase0Attestation,
 		},
 		{
 			name: "Altair",
 			versionedAttestation: &spec.VersionedAttestation{
 				Version: spec.DataVersionAltair,
-				Altair:  &phase0.Attestation{},
+				Altair:  phase0Attestation,
 			},
+			expectedAggregate: phase0Attestation,
 		},
 		{
 			name: "Bellatrix",
 			versionedAttestation: &spec.VersionedAttestation{
 				Version:   spec.DataVersionBellatrix,
-				Bellatrix: &phase0.Attestation{},
+				Bellatrix: phase0Attestation,
 			},
+			expectedAggregate: phase0Attestation,
 		},
 		{
 			name: "Capella",
 			versionedAttestation: &spec.VersionedAttestation{
 				Version: spec.DataVersionCapella,
-				Capella: &phase0.Attestation{},
+				Capella: phase0Attestation,
 			},
+			expectedAggregate: phase0Attestation,
 		},
 		{
 			name: "Deneb",
 			versionedAttestation: &spec.VersionedAttestation{
 				Version: spec.DataVersionDeneb,
-				Deneb:   &phase0.Attestation{},
+				Deneb:   phase0Attestation,
 			},
+			expectedAggregate: phase0Attestation,
 		},
 		{
 			name: "Electra",
 			versionedAttestation: &spec.VersionedAttestation{
 				Version: spec.DataVersionElectra,
-				Electra: &electra.Attestation{},
+				Electra: electraAttestation,
 			},
+			expectedAggregate: electraAttestation,
 		},
 		{
 			name: "Fulu",
 			versionedAttestation: &spec.VersionedAttestation{
 				Version: spec.DataVersionFulu,
-				Fulu:    &electra.Attestation{},
+				Fulu:    electraAttestation,
 			},
+			expectedAggregate: electraAttestation,
 		},
 		{
 			name: "Gloas",
 			versionedAttestation: &spec.VersionedAttestation{
 				Version: spec.DataVersionGloas,
-				Gloas:   &gloas.Attestation{},
+				Gloas:   gloasAttestation,
 			},
-		},
-		{
-			name: "MissingArm",
-			versionedAttestation: &spec.VersionedAttestation{
-				Version: spec.DataVersionGloas,
-			},
-			err: "no gloas attestation",
+			expectedAggregate: gloasAttestation,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result, err := createVersionedAggregateAndProof(duty, test.versionedAttestation)
-			if test.err != "" {
-				require.Nil(t, result)
-				require.EqualError(t, err, test.err)
-				return
-			}
-
 			require.NoError(t, err)
 			require.Equal(t, test.versionedAttestation.Version, result.Version)
 			aggregatorIndex, err := result.AggregatorIndex()
@@ -117,97 +148,99 @@ func TestCreateVersionedAggregateAndProof(t *testing.T) {
 			selectionProof, err := result.SelectionProof()
 			require.NoError(t, err)
 			require.Equal(t, duty.SlotSignature, selectionProof)
+			require.Same(t, test.expectedAggregate, aggregateOf(t, result))
 		})
 	}
 }
 
 func TestCreateVersionedSignedAggregateAndProof(t *testing.T) {
 	sig := phase0.BLSSignature{2}
+	phase0AggregateAndProof := &phase0.AggregateAndProof{
+		Aggregate: &phase0.Attestation{Data: &phase0.AttestationData{Slot: testAggregateSlot}},
+	}
+	electraAggregateAndProof := &electra.AggregateAndProof{
+		Aggregate: &electra.Attestation{Data: &phase0.AttestationData{Slot: testAggregateSlot}},
+	}
+	gloasAggregateAndProof := &gloas.AggregateAndProof{
+		Aggregate: &gloas.Attestation{Data: &phase0.AttestationData{Slot: testAggregateSlot}},
+	}
 
 	tests := []struct {
 		name                       string
 		versionedAggregateAndProof *spec.VersionedAggregateAndProof
-		err                        string
 	}{
 		{
 			name: "Phase0",
 			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
 				Version: spec.DataVersionPhase0,
-				Phase0:  &phase0.AggregateAndProof{},
+				Phase0:  phase0AggregateAndProof,
 			},
 		},
 		{
 			name: "Altair",
 			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
 				Version: spec.DataVersionAltair,
-				Altair:  &phase0.AggregateAndProof{},
+				Altair:  phase0AggregateAndProof,
 			},
 		},
 		{
 			name: "Bellatrix",
 			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
 				Version:   spec.DataVersionBellatrix,
-				Bellatrix: &phase0.AggregateAndProof{},
+				Bellatrix: phase0AggregateAndProof,
 			},
 		},
 		{
 			name: "Capella",
 			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
 				Version: spec.DataVersionCapella,
-				Capella: &phase0.AggregateAndProof{},
+				Capella: phase0AggregateAndProof,
 			},
 		},
 		{
 			name: "Deneb",
 			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
 				Version: spec.DataVersionDeneb,
-				Deneb:   &phase0.AggregateAndProof{},
+				Deneb:   phase0AggregateAndProof,
 			},
 		},
 		{
 			name: "Electra",
 			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
 				Version: spec.DataVersionElectra,
-				Electra: &electra.AggregateAndProof{},
+				Electra: electraAggregateAndProof,
 			},
 		},
 		{
 			name: "Fulu",
 			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
 				Version: spec.DataVersionFulu,
-				Fulu:    &electra.AggregateAndProof{},
+				Fulu:    electraAggregateAndProof,
 			},
 		},
 		{
 			name: "Gloas",
 			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
 				Version: spec.DataVersionGloas,
-				Gloas:   &gloas.AggregateAndProof{},
+				Gloas:   gloasAggregateAndProof,
 			},
-		},
-		{
-			name: "MissingArm",
-			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
-				Version: spec.DataVersionGloas,
-			},
-			err: "no gloas aggregate and proof",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result, err := createVersionedSignedAggregateAndProof(test.versionedAggregateAndProof, sig)
-			if test.err != "" {
-				require.Nil(t, result)
-				require.EqualError(t, err, test.err)
-				return
-			}
-
 			require.NoError(t, err)
 			require.Equal(t, test.versionedAggregateAndProof.Version, result.Version)
 			signature, err := result.Signature()
 			require.NoError(t, err)
 			require.Equal(t, sig, signature)
+			// Slot() reads through Message.Aggregate.Data without a nil guard, and the multinode
+			// submitter calls it on every submission, so this proves the message was carried
+			// through rather than left nil.
+			slot, err := result.Slot()
+			require.NoError(t, err)
+			require.Equal(t, testAggregateSlot, slot)
 		})
 	}
 }
@@ -227,6 +260,7 @@ func TestCreateVersionedAggregateAndProofRejectsMissingArms(t *testing.T) {
 		{name: "Electra", version: spec.DataVersionElectra, err: "no electra attestation"},
 		{name: "Fulu", version: spec.DataVersionFulu, err: "no fulu attestation"},
 		{name: "Gloas", version: spec.DataVersionGloas, err: "no gloas attestation"},
+		{name: "Unknown", version: spec.DataVersionUnknown, err: "unknown version"},
 	}
 
 	for _, test := range tests {
@@ -252,6 +286,7 @@ func TestCreateVersionedSignedAggregateAndProofRejectsMissingArms(t *testing.T) 
 		{name: "Electra", version: spec.DataVersionElectra, err: "no electra aggregate and proof"},
 		{name: "Fulu", version: spec.DataVersionFulu, err: "no fulu aggregate and proof"},
 		{name: "Gloas", version: spec.DataVersionGloas, err: "no gloas aggregate and proof"},
+		{name: "Unknown", version: spec.DataVersionUnknown, err: "unknown version"},
 	}
 
 	for _, test := range tests {

--- a/services/attestationaggregator/standard/service_internal_test.go
+++ b/services/attestationaggregator/standard/service_internal_test.go
@@ -17,18 +17,18 @@ import (
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/attestationaggregator"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateVersionedAggregateAndProofGloas(t *testing.T) {
+func TestCreateVersionedAggregateAndProof(t *testing.T) {
 	duty := &attestationaggregator.Duty{
 		ValidatorIndex: phase0.ValidatorIndex(42),
 		SlotSignature:  phase0.BLSSignature{1},
 	}
-	attestation := &gloas.Attestation{}
 
 	tests := []struct {
 		name                 string
@@ -36,10 +36,59 @@ func TestCreateVersionedAggregateAndProofGloas(t *testing.T) {
 		err                  string
 	}{
 		{
-			name: "Valid",
+			name: "Phase0",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionPhase0,
+				Phase0:  &phase0.Attestation{},
+			},
+		},
+		{
+			name: "Altair",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionAltair,
+				Altair:  &phase0.Attestation{},
+			},
+		},
+		{
+			name: "Bellatrix",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version:   spec.DataVersionBellatrix,
+				Bellatrix: &phase0.Attestation{},
+			},
+		},
+		{
+			name: "Capella",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionCapella,
+				Capella: &phase0.Attestation{},
+			},
+		},
+		{
+			name: "Deneb",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionDeneb,
+				Deneb:   &phase0.Attestation{},
+			},
+		},
+		{
+			name: "Electra",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionElectra,
+				Electra: &electra.Attestation{},
+			},
+		},
+		{
+			name: "Fulu",
+			versionedAttestation: &spec.VersionedAttestation{
+				Version: spec.DataVersionFulu,
+				Fulu:    &electra.Attestation{},
+			},
+		},
+		{
+			name: "Gloas",
 			versionedAttestation: &spec.VersionedAttestation{
 				Version: spec.DataVersionGloas,
-				Gloas:   attestation,
+				Gloas:   &gloas.Attestation{},
 			},
 		},
 		{
@@ -61,17 +110,18 @@ func TestCreateVersionedAggregateAndProofGloas(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, spec.DataVersionGloas, result.Version)
-			require.NotNil(t, result.Gloas)
-			require.Same(t, attestation, result.Gloas.Aggregate)
-			require.Equal(t, duty.ValidatorIndex, result.Gloas.AggregatorIndex)
-			require.Equal(t, duty.SlotSignature, result.Gloas.SelectionProof)
+			require.Equal(t, test.versionedAttestation.Version, result.Version)
+			aggregatorIndex, err := result.AggregatorIndex()
+			require.NoError(t, err)
+			require.Equal(t, duty.ValidatorIndex, aggregatorIndex)
+			selectionProof, err := result.SelectionProof()
+			require.NoError(t, err)
+			require.Equal(t, duty.SlotSignature, selectionProof)
 		})
 	}
 }
 
-func TestCreateVersionedSignedAggregateAndProofGloas(t *testing.T) {
-	aggregateAndProof := &gloas.AggregateAndProof{}
+func TestCreateVersionedSignedAggregateAndProof(t *testing.T) {
 	sig := phase0.BLSSignature{2}
 
 	tests := []struct {
@@ -80,10 +130,59 @@ func TestCreateVersionedSignedAggregateAndProofGloas(t *testing.T) {
 		err                        string
 	}{
 		{
-			name: "Valid",
+			name: "Phase0",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionPhase0,
+				Phase0:  &phase0.AggregateAndProof{},
+			},
+		},
+		{
+			name: "Altair",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionAltair,
+				Altair:  &phase0.AggregateAndProof{},
+			},
+		},
+		{
+			name: "Bellatrix",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version:   spec.DataVersionBellatrix,
+				Bellatrix: &phase0.AggregateAndProof{},
+			},
+		},
+		{
+			name: "Capella",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionCapella,
+				Capella: &phase0.AggregateAndProof{},
+			},
+		},
+		{
+			name: "Deneb",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionDeneb,
+				Deneb:   &phase0.AggregateAndProof{},
+			},
+		},
+		{
+			name: "Electra",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionElectra,
+				Electra: &electra.AggregateAndProof{},
+			},
+		},
+		{
+			name: "Fulu",
+			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
+				Version: spec.DataVersionFulu,
+				Fulu:    &electra.AggregateAndProof{},
+			},
+		},
+		{
+			name: "Gloas",
 			versionedAggregateAndProof: &spec.VersionedAggregateAndProof{
 				Version: spec.DataVersionGloas,
-				Gloas:   aggregateAndProof,
+				Gloas:   &gloas.AggregateAndProof{},
 			},
 		},
 		{
@@ -105,10 +204,61 @@ func TestCreateVersionedSignedAggregateAndProofGloas(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, spec.DataVersionGloas, result.Version)
-			require.NotNil(t, result.Gloas)
-			require.Same(t, aggregateAndProof, result.Gloas.Message)
-			require.Equal(t, sig, result.Gloas.Signature)
+			require.Equal(t, test.versionedAggregateAndProof.Version, result.Version)
+			signature, err := result.Signature()
+			require.NoError(t, err)
+			require.Equal(t, sig, signature)
+		})
+	}
+}
+
+func TestCreateVersionedAggregateAndProofRejectsMissingArms(t *testing.T) {
+	duty := &attestationaggregator.Duty{}
+	tests := []struct {
+		name    string
+		version spec.DataVersion
+		err     string
+	}{
+		{name: "Phase0", version: spec.DataVersionPhase0, err: "no phase0 attestation"},
+		{name: "Altair", version: spec.DataVersionAltair, err: "no altair attestation"},
+		{name: "Bellatrix", version: spec.DataVersionBellatrix, err: "no bellatrix attestation"},
+		{name: "Capella", version: spec.DataVersionCapella, err: "no capella attestation"},
+		{name: "Deneb", version: spec.DataVersionDeneb, err: "no deneb attestation"},
+		{name: "Electra", version: spec.DataVersionElectra, err: "no electra attestation"},
+		{name: "Fulu", version: spec.DataVersionFulu, err: "no fulu attestation"},
+		{name: "Gloas", version: spec.DataVersionGloas, err: "no gloas attestation"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := createVersionedAggregateAndProof(duty, &spec.VersionedAttestation{Version: test.version})
+			require.Nil(t, result)
+			require.EqualError(t, err, test.err)
+		})
+	}
+}
+
+func TestCreateVersionedSignedAggregateAndProofRejectsMissingArms(t *testing.T) {
+	tests := []struct {
+		name    string
+		version spec.DataVersion
+		err     string
+	}{
+		{name: "Phase0", version: spec.DataVersionPhase0, err: "no phase0 aggregate and proof"},
+		{name: "Altair", version: spec.DataVersionAltair, err: "no altair aggregate and proof"},
+		{name: "Bellatrix", version: spec.DataVersionBellatrix, err: "no bellatrix aggregate and proof"},
+		{name: "Capella", version: spec.DataVersionCapella, err: "no capella aggregate and proof"},
+		{name: "Deneb", version: spec.DataVersionDeneb, err: "no deneb aggregate and proof"},
+		{name: "Electra", version: spec.DataVersionElectra, err: "no electra aggregate and proof"},
+		{name: "Fulu", version: spec.DataVersionFulu, err: "no fulu aggregate and proof"},
+		{name: "Gloas", version: spec.DataVersionGloas, err: "no gloas aggregate and proof"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := createVersionedSignedAggregateAndProof(&spec.VersionedAggregateAndProof{Version: test.version}, phase0.BLSSignature{})
+			require.Nil(t, result)
+			require.EqualError(t, err, test.err)
 		})
 	}
 }

--- a/services/attester/standard/attest.go
+++ b/services/attester/standard/attest.go
@@ -23,6 +23,7 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/attester"
 	"github.com/attestantio/vouch/util"
@@ -136,7 +137,11 @@ func (s *Service) attest(
 	signingCommitteeIndices := make([]phase0.CommitteeIndex, len(committeeIndices))
 	copy(signingCommitteeIndices, committeeIndices)
 	epoch := s.chainTime.SlotToEpoch(duty.Slot())
-	if epoch >= s.electraForkEpoch {
+	if epoch >= s.gloasForkEpoch {
+		for i := range signingCommitteeIndices {
+			signingCommitteeIndices[i] = data.Index
+		}
+	} else if epoch >= s.electraForkEpoch {
 		for i := range signingCommitteeIndices {
 			// Hardcode the committee indices to be 0 in Electra.
 			signingCommitteeIndices[i] = 0
@@ -163,6 +168,8 @@ func (s *Service) attest(
 	switch {
 	case epoch < s.electraForkEpoch:
 		attestations = s.createAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
+	case epoch >= s.gloasForkEpoch:
+		attestations = s.createGloasAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
 	default:
 		attestations = s.createElectraAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, validatorIndices, data, sigs, epoch)
 	}
@@ -179,6 +186,57 @@ func (s *Service) attest(
 	s.log.Trace().Dur("elapsed", time.Since(started)).Dur("submission_elapsed", time.Since(submissionStarted)).Msg("Submitted versioned attestations")
 
 	return attestations, nil
+}
+
+func (s *Service) createGloasAttestations(_ context.Context,
+	duty *attester.Duty,
+	accounts []e2wtypes.Account,
+	committeeIndices []phase0.CommitteeIndex,
+	validatorCommitteeIndices []phase0.ValidatorIndex,
+	committeeSizes []uint64,
+	data *phase0.AttestationData,
+	sigs []phase0.BLSSignature,
+) []*spec.VersionedAttestation {
+	attestations := make([]*spec.VersionedAttestation, 0, len(sigs))
+	for i := range sigs {
+		if sigs[i].IsZero() {
+			s.log.Warn().
+				Str("validator_pubkey", fmt.Sprintf("%#x", accounts[i].PublicKey().Marshal())).
+				Msg("No signature for validator; not creating attestation")
+			continue
+		}
+
+		aggregationBits := bitfield.NewBitlist(committeeSizes[i])
+		aggregationBits.SetBitAt(uint64(validatorCommitteeIndices[i]), true)
+		committeeBits := bitfield.NewBitvector64()
+		committeeBits.SetBitAt(uint64(committeeIndices[i]), true)
+
+		attestation := &gloas.Attestation{
+			AggregationBits: aggregationBits,
+			Data: &phase0.AttestationData{
+				Slot:            duty.Slot(),
+				Index:           data.Index,
+				BeaconBlockRoot: data.BeaconBlockRoot,
+				Source: &phase0.Checkpoint{
+					Epoch: data.Source.Epoch,
+					Root:  data.Source.Root,
+				},
+				Target: &phase0.Checkpoint{
+					Epoch: data.Target.Epoch,
+					Root:  data.Target.Root,
+				},
+			},
+			CommitteeBits: committeeBits,
+		}
+		copy(attestation.Signature[:], sigs[i][:])
+
+		attestations = append(attestations, &spec.VersionedAttestation{
+			Version: spec.DataVersionGloas,
+			Gloas:   attestation,
+		})
+	}
+
+	return attestations
 }
 
 func (s *Service) createAttestations(_ context.Context,
@@ -358,6 +416,10 @@ func (s *Service) validateAttestationData(_ context.Context,
 ) error {
 	if attestationData.Slot != duty.Slot() {
 		return fmt.Errorf("attestation request for slot %d returned data for slot %d", duty.Slot(), attestationData.Slot)
+	}
+
+	if s.chainTime.SlotToEpoch(duty.Slot()) >= s.gloasForkEpoch && attestationData.Index > 1 {
+		return fmt.Errorf("attestation request for slot %d returned invalid Gloas index %d", duty.Slot(), attestationData.Index)
 	}
 
 	if attestationData.Source.Epoch > attestationData.Target.Epoch {

--- a/services/attester/standard/attest.go
+++ b/services/attester/standard/attest.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2025 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -165,13 +165,15 @@ func (s *Service) attest(
 	s.log.Trace().Dur("elapsed", time.Since(started)).Msg("Signed")
 	var attestations []*spec.VersionedAttestation
 
+	// This ladder must mirror the signing committee index ladder above, otherwise the
+	// attestation we publish would not match the attestation data that was signed.
 	switch {
-	case epoch < s.electraForkEpoch:
-		attestations = s.createAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
 	case epoch >= s.gloasForkEpoch:
-		attestations = s.createGloasAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
-	default:
+		attestations = s.createGloasAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, validatorIndices, data, sigs)
+	case epoch >= s.electraForkEpoch:
 		attestations = s.createElectraAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, validatorIndices, data, sigs, epoch)
+	default:
+		attestations = s.createAttestations(ctx, duty, accounts, committeeIndices, validatorCommitteeIndices, committeeSizes, data, sigs)
 	}
 	if len(attestations) == 0 {
 		s.log.Info().Msg("No signed attestations; not submitting")
@@ -194,6 +196,7 @@ func (s *Service) createGloasAttestations(_ context.Context,
 	committeeIndices []phase0.CommitteeIndex,
 	validatorCommitteeIndices []phase0.ValidatorIndex,
 	committeeSizes []uint64,
+	validatorIndices []phase0.ValidatorIndex,
 	data *phase0.AttestationData,
 	sigs []phase0.BLSSignature,
 ) []*spec.VersionedAttestation {
@@ -205,6 +208,12 @@ func (s *Service) createGloasAttestations(_ context.Context,
 				Msg("No signature for validator; not creating attestation")
 			continue
 		}
+		if i >= len(validatorIndices) {
+			s.log.Warn().Str("validator_pubkey", fmt.Sprintf("%#x", accounts[i].PublicKey().Marshal())).
+				Msg("Validator indices array smaller than requested index; not creating attestation")
+			continue
+		}
+		validatorIndex := validatorIndices[i]
 
 		aggregationBits := bitfield.NewBitlist(committeeSizes[i])
 		aggregationBits.SetBitAt(uint64(validatorCommitteeIndices[i]), true)
@@ -230,9 +239,12 @@ func (s *Service) createGloasAttestations(_ context.Context,
 		}
 		copy(attestation.Signature[:], sigs[i][:])
 
+		// ValidatorIndex is required: the beacon API submits Electra and later attestations
+		// as SingleAttestation, and the conversion fails without it.
 		attestations = append(attestations, &spec.VersionedAttestation{
-			Version: spec.DataVersionGloas,
-			Gloas:   attestation,
+			Version:        spec.DataVersionGloas,
+			Gloas:          attestation,
+			ValidatorIndex: &validatorIndex,
 		})
 	}
 

--- a/services/attester/standard/attest.go
+++ b/services/attester/standard/attest.go
@@ -315,7 +315,7 @@ func (s *Service) createElectraAttestations(_ context.Context,
 				Msg("No signature for validator; not creating attestation")
 			continue
 		}
-		if len(validatorIndices) < i {
+		if i >= len(validatorIndices) {
 			s.log.Warn().Str("validator_pubkey", fmt.Sprintf("%#x", accounts[i].PublicKey().Marshal())).
 				Msg("Validator indices array smaller than requested index; not creating attestation")
 			continue

--- a/services/attester/standard/gloas_attestation_test.go
+++ b/services/attester/standard/gloas_attestation_test.go
@@ -266,15 +266,15 @@ type attesterTestChainTime struct {
 	slotsPerEpoch  uint64
 }
 
-func (s *attesterTestChainTime) GenesisTime() time.Time { return time.Unix(0, 0) }
+func (*attesterTestChainTime) GenesisTime() time.Time { return time.Unix(0, 0) }
 func (s *attesterTestChainTime) StartOfSlot(slot phase0.Slot) time.Time {
 	return s.GenesisTime().Add(time.Duration(slot) * time.Second)
 }
 func (s *attesterTestChainTime) StartOfEpoch(epoch phase0.Epoch) time.Time {
 	return s.StartOfSlot(phase0.Slot(uint64(epoch) * s.slotsPerEpoch))
 }
-func (s *attesterTestChainTime) CurrentSlot() phase0.Slot   { return 0 }
-func (s *attesterTestChainTime) CurrentEpoch() phase0.Epoch { return 0 }
+func (*attesterTestChainTime) CurrentSlot() phase0.Slot   { return 0 }
+func (*attesterTestChainTime) CurrentEpoch() phase0.Epoch { return 0 }
 func (s *attesterTestChainTime) SlotToEpoch(slot phase0.Slot) phase0.Epoch {
 	return phase0.Epoch(uint64(slot) / s.slotsPerEpoch)
 }

--- a/services/attester/standard/gloas_attestation_test.go
+++ b/services/attester/standard/gloas_attestation_test.go
@@ -1,0 +1,297 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	mockaccountmanager "github.com/attestantio/vouch/services/accountmanager/mock"
+	"github.com/attestantio/vouch/services/attester"
+	"github.com/attestantio/vouch/services/attester/standard"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/signer"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	e2types "github.com/wealdtech/go-eth2-types/v2"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+func TestAttestGloasPreservesAttestationIndex(t *testing.T) {
+	ctx := context.Background()
+	chainTime := &attesterTestChainTime{
+		hardForkEpochs: map[string]phase0.Epoch{
+			"GLOAS_FORK_EPOCH":   15,
+			"ELECTRA_FORK_EPOCH": 0,
+			"FULU_FORK_EPOCH":    10,
+		},
+		slotsPerEpoch: 1,
+	}
+	accounts := mockAccountProvider()
+	accounts.AddAccount(1, testAccount{})
+	signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
+	submitter := &capturingAttestationsSubmitter{}
+
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithProcessConcurrency(1),
+		standard.WithChainTime(chainTime),
+		standard.WithSpecProvider(testSpecProvider{}),
+		standard.WithAttestationDataProvider(testAttestationDataProvider{index: 1}),
+		standard.WithAttestationsSubmitter(submitter),
+		standard.WithValidatingAccountsProvider(accounts),
+		standard.WithBeaconAttestationsSigner(signer),
+	)
+	require.NoError(t, err)
+
+	duty, err := attester.NewDuty(ctx,
+		15,
+		1,
+		[]phase0.ValidatorIndex{1},
+		[]phase0.CommitteeIndex{0},
+		[]uint64{0},
+		map[phase0.CommitteeIndex]uint64{0: 1},
+	)
+	require.NoError(t, err)
+
+	attestations, err := service.Attest(ctx, duty)
+	require.NoError(t, err)
+	require.Len(t, attestations, 1)
+	require.Len(t, signer.committeeIndices, 1)
+	require.Equal(t, phase0.CommitteeIndex(1), signer.committeeIndices[0])
+	require.NotNil(t, submitter.opts)
+	require.Len(t, submitter.opts.Attestations, 1)
+	require.Equal(t, spec.DataVersionGloas, submitter.opts.Attestations[0].Version)
+	require.NotNil(t, submitter.opts.Attestations[0].Gloas)
+	committeeIndex, err := submitter.opts.Attestations[0].CommitteeIndex()
+	require.NoError(t, err)
+	require.Equal(t, phase0.CommitteeIndex(0), committeeIndex)
+	require.Equal(t, phase0.CommitteeIndex(1), submitter.opts.Attestations[0].Gloas.Data.Index)
+	require.Equal(t, signer.committeeIndices[0], submitter.opts.Attestations[0].Gloas.Data.Index)
+}
+
+func TestAttestRejectsInvalidGloasAttestationIndex(t *testing.T) {
+	ctx := context.Background()
+	chainTime := &attesterTestChainTime{
+		hardForkEpochs: map[string]phase0.Epoch{
+			"GLOAS_FORK_EPOCH":   15,
+			"ELECTRA_FORK_EPOCH": 0,
+			"FULU_FORK_EPOCH":    10,
+		},
+		slotsPerEpoch: 1,
+	}
+	accounts := mockAccountProvider()
+	accounts.AddAccount(1, testAccount{})
+	signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
+	submitter := &capturingAttestationsSubmitter{}
+
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithProcessConcurrency(1),
+		standard.WithChainTime(chainTime),
+		standard.WithSpecProvider(testSpecProvider{}),
+		standard.WithAttestationDataProvider(testAttestationDataProvider{index: 2}),
+		standard.WithAttestationsSubmitter(submitter),
+		standard.WithValidatingAccountsProvider(accounts),
+		standard.WithBeaconAttestationsSigner(signer),
+	)
+	require.NoError(t, err)
+
+	duty, err := attester.NewDuty(ctx,
+		15,
+		1,
+		[]phase0.ValidatorIndex{1},
+		[]phase0.CommitteeIndex{0},
+		[]uint64{0},
+		map[phase0.CommitteeIndex]uint64{0: 1},
+	)
+	require.NoError(t, err)
+
+	_, err = service.Attest(ctx, duty)
+	require.EqualError(t, err, "attestation request for slot 15 returned invalid Gloas index 2")
+	require.Equal(t, 0, signer.calls)
+	require.Equal(t, 0, submitter.calls)
+}
+
+func TestAttestElectraAndFuluKeepZeroAttestationIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		slot    phase0.Slot
+		version spec.DataVersion
+	}{
+		{name: "Electra", slot: 1, version: spec.DataVersionElectra},
+		{name: "Fulu", slot: 11, version: spec.DataVersionFulu},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			chainTime := &attesterTestChainTime{
+				hardForkEpochs: map[string]phase0.Epoch{
+					"GLOAS_FORK_EPOCH":   15,
+					"ELECTRA_FORK_EPOCH": 0,
+					"FULU_FORK_EPOCH":    10,
+				},
+				slotsPerEpoch: 1,
+			}
+			accounts := mockAccountProvider()
+			accounts.AddAccount(1, testAccount{})
+			signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
+			submitter := &capturingAttestationsSubmitter{}
+			service, err := standard.New(ctx,
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(nullmetrics.New()),
+				standard.WithProcessConcurrency(1),
+				standard.WithChainTime(chainTime),
+				standard.WithSpecProvider(testSpecProvider{}),
+				standard.WithAttestationDataProvider(testAttestationDataProvider{index: 1}),
+				standard.WithAttestationsSubmitter(submitter),
+				standard.WithValidatingAccountsProvider(accounts),
+				standard.WithBeaconAttestationsSigner(signer),
+			)
+			require.NoError(t, err)
+
+			duty, err := attester.NewDuty(ctx,
+				test.slot,
+				1,
+				[]phase0.ValidatorIndex{1},
+				[]phase0.CommitteeIndex{1},
+				[]uint64{0},
+				map[phase0.CommitteeIndex]uint64{1: 1},
+			)
+			require.NoError(t, err)
+
+			_, err = service.Attest(ctx, duty)
+			require.NoError(t, err)
+			require.Equal(t, []phase0.CommitteeIndex{0}, signer.committeeIndices)
+			require.NotNil(t, submitter.opts)
+			require.Len(t, submitter.opts.Attestations, 1)
+			require.Equal(t, test.version, submitter.opts.Attestations[0].Version)
+			data, err := submitter.opts.Attestations[0].Data()
+			require.NoError(t, err)
+			require.Equal(t, phase0.CommitteeIndex(0), data.Index)
+		})
+	}
+}
+
+func mockAccountProvider() *mockaccountmanager.ValidatingAccountsProvider {
+	return mockaccountmanager.NewValidatingAccountsProvider()
+}
+
+type testAccount struct{}
+
+func (testAccount) ID() uuid.UUID                { return uuid.Nil }
+func (testAccount) Name() string                 { return "test" }
+func (testAccount) PublicKey() e2types.PublicKey { return testPublicKey{} }
+
+var _ e2wtypes.Account = testAccount{}
+
+type testPublicKey struct{}
+
+func (testPublicKey) Marshal() []byte             { return make([]byte, 48) }
+func (testPublicKey) Aggregate(e2types.PublicKey) {}
+func (key testPublicKey) Copy() e2types.PublicKey { return key }
+
+type testSpecProvider struct{}
+
+func (testSpecProvider) Spec(context.Context, *api.SpecOpts) (*api.Response[map[string]any], error) {
+	return &api.Response[map[string]any]{Data: map[string]any{"SLOTS_PER_EPOCH": uint64(1)}}, nil
+}
+
+type testAttestationDataProvider struct {
+	index phase0.CommitteeIndex
+}
+
+func (provider testAttestationDataProvider) AttestationData(_ context.Context, opts *api.AttestationDataOpts) (*api.Response[*phase0.AttestationData], error) {
+	return &api.Response[*phase0.AttestationData]{Data: &phase0.AttestationData{
+		Slot:  opts.Slot,
+		Index: provider.index,
+		Source: &phase0.Checkpoint{
+			Epoch: phase0.Epoch(opts.Slot - 1),
+		},
+		Target: &phase0.Checkpoint{
+			Epoch: phase0.Epoch(opts.Slot),
+		},
+	}}, nil
+}
+
+type capturingBeaconAttestationsSigner struct {
+	calls            int
+	committeeIndices []phase0.CommitteeIndex
+	signatures       []phase0.BLSSignature
+}
+
+func (s *capturingBeaconAttestationsSigner) SignBeaconAttestations(_ context.Context, _ []e2wtypes.Account, _ phase0.Slot, committeeIndices []phase0.CommitteeIndex, _ phase0.Root, _ phase0.Epoch, _ phase0.Root, _ phase0.Epoch, _ phase0.Root) ([]phase0.BLSSignature, error) {
+	s.calls++
+	s.committeeIndices = append([]phase0.CommitteeIndex(nil), committeeIndices...)
+	return s.signatures, nil
+}
+
+var _ signer.BeaconAttestationsSigner = (*capturingBeaconAttestationsSigner)(nil)
+
+type capturingAttestationsSubmitter struct {
+	calls int
+	opts  *api.SubmitAttestationsOpts
+}
+
+func (s *capturingAttestationsSubmitter) SubmitAttestations(_ context.Context, opts *api.SubmitAttestationsOpts) error {
+	s.calls++
+	s.opts = opts
+	return nil
+}
+
+var _ submitter.AttestationsSubmitter = (*capturingAttestationsSubmitter)(nil)
+
+type attesterTestChainTime struct {
+	hardForkEpochs map[string]phase0.Epoch
+	slotsPerEpoch  uint64
+}
+
+func (s *attesterTestChainTime) GenesisTime() time.Time { return time.Unix(0, 0) }
+func (s *attesterTestChainTime) StartOfSlot(slot phase0.Slot) time.Time {
+	return s.GenesisTime().Add(time.Duration(slot) * time.Second)
+}
+func (s *attesterTestChainTime) StartOfEpoch(epoch phase0.Epoch) time.Time {
+	return s.StartOfSlot(phase0.Slot(uint64(epoch) * s.slotsPerEpoch))
+}
+func (s *attesterTestChainTime) CurrentSlot() phase0.Slot   { return 0 }
+func (s *attesterTestChainTime) CurrentEpoch() phase0.Epoch { return 0 }
+func (s *attesterTestChainTime) SlotToEpoch(slot phase0.Slot) phase0.Epoch {
+	return phase0.Epoch(uint64(slot) / s.slotsPerEpoch)
+}
+func (s *attesterTestChainTime) FirstSlotOfEpoch(epoch phase0.Epoch) phase0.Slot {
+	return phase0.Slot(uint64(epoch) * s.slotsPerEpoch)
+}
+func (s *attesterTestChainTime) HardForkEpoch(_ context.Context, name string) phase0.Epoch {
+	return s.hardForkEpochs[name]
+}
+
+var _ interface {
+	GenesisTime() time.Time
+	StartOfSlot(phase0.Slot) time.Time
+	StartOfEpoch(phase0.Epoch) time.Time
+	CurrentSlot() phase0.Slot
+	CurrentEpoch() phase0.Epoch
+	SlotToEpoch(phase0.Slot) phase0.Epoch
+	FirstSlotOfEpoch(phase0.Epoch) phase0.Slot
+	HardForkEpoch(context.Context, string) phase0.Epoch
+} = (*attesterTestChainTime)(nil)

--- a/services/attester/standard/gloas_attestation_test.go
+++ b/services/attester/standard/gloas_attestation_test.go
@@ -24,6 +24,7 @@ import (
 	mockaccountmanager "github.com/attestantio/vouch/services/accountmanager/mock"
 	"github.com/attestantio/vouch/services/attester"
 	"github.com/attestantio/vouch/services/attester/standard"
+	"github.com/attestantio/vouch/services/chaintime"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/services/signer"
 	"github.com/attestantio/vouch/services/submitter"
@@ -44,7 +45,7 @@ func TestAttestGloasPreservesAttestationIndex(t *testing.T) {
 		},
 		slotsPerEpoch: 1,
 	}
-	accounts := mockAccountProvider()
+	accounts := mockaccountmanager.NewValidatingAccountsProvider()
 	accounts.AddAccount(1, testAccount{})
 	signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
 	submitter := &capturingAttestationsSubmitter{}
@@ -81,6 +82,9 @@ func TestAttestGloasPreservesAttestationIndex(t *testing.T) {
 	require.Len(t, submitter.opts.Attestations, 1)
 	require.Equal(t, spec.DataVersionGloas, submitter.opts.Attestations[0].Version)
 	require.NotNil(t, submitter.opts.Attestations[0].Gloas)
+	// Required for the SingleAttestation conversion carried out on submission.
+	require.NotNil(t, submitter.opts.Attestations[0].ValidatorIndex)
+	require.Equal(t, phase0.ValidatorIndex(1), *submitter.opts.Attestations[0].ValidatorIndex)
 	committeeIndex, err := submitter.opts.Attestations[0].CommitteeIndex()
 	require.NoError(t, err)
 	require.Equal(t, phase0.CommitteeIndex(0), committeeIndex)
@@ -98,7 +102,7 @@ func TestAttestRejectsInvalidGloasAttestationIndex(t *testing.T) {
 		},
 		slotsPerEpoch: 1,
 	}
-	accounts := mockAccountProvider()
+	accounts := mockaccountmanager.NewValidatingAccountsProvider()
 	accounts.AddAccount(1, testAccount{})
 	signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
 	submitter := &capturingAttestationsSubmitter{}
@@ -153,7 +157,7 @@ func TestAttestElectraAndFuluKeepZeroAttestationIndex(t *testing.T) {
 				},
 				slotsPerEpoch: 1,
 			}
-			accounts := mockAccountProvider()
+			accounts := mockaccountmanager.NewValidatingAccountsProvider()
 			accounts.AddAccount(1, testAccount{})
 			signer := &capturingBeaconAttestationsSigner{signatures: []phase0.BLSSignature{{0x01}}}
 			submitter := &capturingAttestationsSubmitter{}
@@ -191,10 +195,6 @@ func TestAttestElectraAndFuluKeepZeroAttestationIndex(t *testing.T) {
 			require.Equal(t, phase0.CommitteeIndex(0), data.Index)
 		})
 	}
-}
-
-func mockAccountProvider() *mockaccountmanager.ValidatingAccountsProvider {
-	return mockaccountmanager.NewValidatingAccountsProvider()
 }
 
 type testAccount struct{}
@@ -285,13 +285,4 @@ func (s *attesterTestChainTime) HardForkEpoch(_ context.Context, name string) ph
 	return s.hardForkEpochs[name]
 }
 
-var _ interface {
-	GenesisTime() time.Time
-	StartOfSlot(phase0.Slot) time.Time
-	StartOfEpoch(phase0.Epoch) time.Time
-	CurrentSlot() phase0.Slot
-	CurrentEpoch() phase0.Epoch
-	SlotToEpoch(phase0.Slot) phase0.Epoch
-	FirstSlotOfEpoch(phase0.Epoch) phase0.Slot
-	HardForkEpoch(context.Context, string) phase0.Epoch
-} = (*attesterTestChainTime)(nil)
+var _ chaintime.Service = (*attesterTestChainTime)(nil)

--- a/services/attester/standard/parameters.go
+++ b/services/attester/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020, 2025 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -27,15 +27,15 @@ import (
 )
 
 type parameters struct {
-	logLevel                   zerolog.Level
-	processConcurrency         int64
 	monitor                    metrics.Service
-	grace                      time.Duration
-	chainTime                  chaintime.Service
 	specProvider               eth2client.SpecProvider
 	attestationDataProvider    eth2client.AttestationDataProvider
-	attestationsSubmitter      submitter.AttestationsSubmitter
 	validatingAccountsProvider accountmanager.ValidatingAccountsProvider
+	logLevel                   zerolog.Level
+	processConcurrency         int64
+	grace                      time.Duration
+	chainTime                  chaintime.Service
+	attestationsSubmitter      submitter.AttestationsSubmitter
 	beaconAttestationsSigner   signer.BeaconAttestationsSigner
 }
 

--- a/services/attester/standard/service.go
+++ b/services/attester/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2025 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -35,18 +35,18 @@ import (
 type Service struct {
 	log                        zerolog.Logger
 	monitor                    metrics.Service
+	validatingAccountsProvider accountmanager.ValidatingAccountsProvider
+	attestationDataProvider    eth2client.AttestationDataProvider
 	processConcurrency         int64
 	slotsPerEpoch              uint64
 	grace                      time.Duration
 	chainTime                  chaintime.Service
-	validatingAccountsProvider accountmanager.ValidatingAccountsProvider
-	attestationDataProvider    eth2client.AttestationDataProvider
 	attestationsSubmitter      submitter.AttestationsSubmitter
 	beaconAttestationsSigner   signer.BeaconAttestationsSigner
 	attested                   map[phase0.Epoch]map[phase0.ValidatorIndex]struct{}
-	attestedMu                 sync.Mutex
 	electraForkEpoch           phase0.Epoch
 	fuluForkEpoch              phase0.Epoch
+	attestedMu                 sync.Mutex
 }
 
 // New creates a new beacon block attester.

--- a/services/attester/standard/service.go
+++ b/services/attester/standard/service.go
@@ -46,6 +46,7 @@ type Service struct {
 	attested                   map[phase0.Epoch]map[phase0.ValidatorIndex]struct{}
 	electraForkEpoch           phase0.Epoch
 	fuluForkEpoch              phase0.Epoch
+	gloasForkEpoch             phase0.Epoch
 	attestedMu                 sync.Mutex
 }
 
@@ -83,6 +84,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 
 	electraForkEpoch := parameters.chainTime.HardForkEpoch(ctx, "ELECTRA_FORK_EPOCH")
 	fuluForkEpoch := parameters.chainTime.HardForkEpoch(ctx, "FULU_FORK_EPOCH")
+	gloasForkEpoch := parameters.chainTime.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH")
 	s := &Service{
 		log:                        log,
 		monitor:                    parameters.monitor,
@@ -97,6 +99,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		attested:                   make(map[phase0.Epoch]map[phase0.ValidatorIndex]struct{}),
 		electraForkEpoch:           electraForkEpoch,
 		fuluForkEpoch:              fuluForkEpoch,
+		gloasForkEpoch:             gloasForkEpoch,
 	}
 	log.Trace().Int64("process_concurrency", s.processConcurrency).Msg("Set process concurrency")
 

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -23,6 +23,7 @@ import (
 	mockblockauctioneer "github.com/attestantio/go-block-relay/services/blockauctioneer/mock"
 	consensusapi "github.com/attestantio/go-eth2-client/api"
 	mockconsensusclient "github.com/attestantio/go-eth2-client/mock"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -61,6 +62,7 @@ func TestProposeGloas(t *testing.T) {
 		foreignBuilderIndex        bool
 		envelopeRootMismatch       bool
 		envelopePayloadMissing     bool
+		envelopeZeroFeeRecipient   bool
 		executionPayloadBidMissing bool
 		envelopeSignerErr          error
 		envelopeSubmitterErr       error
@@ -109,6 +111,12 @@ func TestProposeGloas(t *testing.T) {
 			executionPayloadIncluded: true,
 			envelopePayloadMissing:   true,
 			err:                      "failed to propose block: ePBS execution payload envelope has no payload",
+		},
+		{
+			name:                     "ZeroPayloadFeeRecipient",
+			executionPayloadIncluded: true,
+			envelopeZeroFeeRecipient: true,
+			err:                      "failed to propose block: ePBS execution payload envelope has 0 fee recipient",
 		},
 		{
 			name:                       "MissingExecutionPayloadBid",
@@ -165,7 +173,7 @@ func TestProposeGloas(t *testing.T) {
 					}
 					response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 					response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
-					setSelfBuildBuilderIndex(t, response.Data)
+					setSelfBuildProposal(t, response.Data)
 					blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 					require.NoError(t, err)
 					response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -181,6 +189,9 @@ func TestProposeGloas(t *testing.T) {
 					}
 					if test.envelopePayloadMissing {
 						response.Data.GloasContents.ExecutionPayloadEnvelope.Payload = nil
+					}
+					if test.envelopeZeroFeeRecipient {
+						response.Data.GloasContents.ExecutionPayloadEnvelope.Payload.FeeRecipient = bellatrix.ExecutionAddress{}
 					}
 					if test.executionPayloadBidMissing {
 						response.Data.GloasContents.Block.Body.SignedExecutionPayloadBid = nil
@@ -384,11 +395,14 @@ func TestProposeGloasProposalSourceSubmissionFailure(t *testing.T) {
 	require.Nil(t, envelopeSubmitter.opts)
 }
 
-func setSelfBuildBuilderIndex(t *testing.T, proposal *consensusapi.VersionedEPBSProposal) {
+// setSelfBuildProposal marks a mock proposal as self-built and gives its payload a
+// fee recipient.  The mock leaves the fee recipient zero, which the proposer rejects.
+func setSelfBuildProposal(t *testing.T, proposal *consensusapi.VersionedEPBSProposal) {
 	t.Helper()
 
 	proposal.GloasContents.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex = gloas.BuilderIndex(math.MaxUint64)
 	proposal.GloasContents.ExecutionPayloadEnvelope.BuilderIndex = gloas.BuilderIndex(math.MaxUint64)
+	proposal.GloasContents.ExecutionPayloadEnvelope.Payload.FeeRecipient = bellatrix.ExecutionAddress{0x06}
 	bodyRoot, err := proposal.GloasContents.Block.Body.HashTreeRoot()
 	require.NoError(t, err)
 	convertedBodyRoot := phase0.Root(bodyRoot)
@@ -421,7 +435,7 @@ func newGloasProposerForProposalSource(
 		if response.Data.ExecutionPayloadIncluded {
 			response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 			response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
-			setSelfBuildBuilderIndex(t, response.Data)
+			setSelfBuildProposal(t, response.Data)
 			blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 			require.NoError(t, err)
 			response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -504,7 +518,7 @@ func TestProposeGloasSignsRetainedBodyRoot(t *testing.T) {
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
-		setSelfBuildBuilderIndex(t, response.Data)
+		setSelfBuildProposal(t, response.Data)
 
 		block := response.Data.GloasContents.Block
 		generatedRoot, err := block.Body.HashTreeRoot()
@@ -591,7 +605,7 @@ func TestProposeGloasMissingBodyRootFails(t *testing.T) {
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
-		setSelfBuildBuilderIndex(t, response.Data)
+		setSelfBuildProposal(t, response.Data)
 		blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 		require.NoError(t, err)
 		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -651,7 +665,7 @@ func TestProposeGloasStartsBothSignaturesBeforePublication(t *testing.T) {
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
-		setSelfBuildBuilderIndex(t, response.Data)
+		setSelfBuildProposal(t, response.Data)
 		blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 		require.NoError(t, err)
 		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -740,7 +754,7 @@ func TestProposeGloasCancelsPeerSigningAfterFailure(t *testing.T) {
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
-		setSelfBuildBuilderIndex(t, response.Data)
+		setSelfBuildProposal(t, response.Data)
 		blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 		require.NoError(t, err)
 		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -830,7 +844,7 @@ func TestProposeGloasCancelsBlockedBlockSigningAfterEnvelopeFailure(t *testing.T
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
-		setSelfBuildBuilderIndex(t, response.Data)
+		setSelfBuildProposal(t, response.Data)
 		blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 		require.NoError(t, err)
 		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -60,14 +60,12 @@ func TestProposeGloas(t *testing.T) {
 		forkEpochAtConstruction  phase0.Epoch
 		forkEpochAtUse           phase0.Epoch
 		updateForkEpochAtUse     bool
-		proposalSource           string
 		err                      string
 	}{
 		{
 			name:                     "PayloadIncluded",
 			executionPayloadIncluded: true,
 			builderBoostFactor:       100,
-			proposalSource:           "local",
 		},
 		{
 			name:                     "ForkEpochAvailableAfterConstruction",
@@ -90,7 +88,6 @@ func TestProposeGloas(t *testing.T) {
 		{
 			name:                     "PayloadExcluded",
 			executionPayloadIncluded: false,
-			proposalSource:           "builder",
 			err:                      "failed to propose block: ePBS proposal excludes requested execution payload",
 		},
 		{
@@ -154,13 +151,6 @@ func TestProposeGloas(t *testing.T) {
 
 			chainTime := &forkChainTime{gloasForkEpoch: test.forkEpochAtConstruction}
 			var monitor metrics.Service = nullmetrics.New()
-			if test.proposalSource != "" {
-				monitor, err = prometheusmetrics.New(ctx,
-					prometheusmetrics.WithLogLevel(zerolog.Disabled),
-					prometheusmetrics.WithAddress("localhost:0"),
-				)
-				require.NoError(t, err)
-			}
 
 			params := []standard.Parameter{
 				standard.WithLogLevel(zerolog.TraceLevel),
@@ -185,10 +175,6 @@ func TestProposeGloas(t *testing.T) {
 			}
 			service, err := standard.New(ctx, params...)
 			require.NoError(t, err)
-			var proposalSourceCountBefore float64
-			if test.proposalSource != "" {
-				proposalSourceCountBefore = beaconBlockProposalSourceCount(t, test.proposalSource)
-			}
 			if test.updateForkEpochAtUse {
 				chainTime.gloasForkEpoch = test.forkEpochAtUse
 			}
@@ -198,9 +184,6 @@ func TestProposeGloas(t *testing.T) {
 			duty.SetRandaoReveal(phase0.BLSSignature{0x02})
 
 			err = service.Propose(ctx, duty)
-			if test.proposalSource != "" {
-				require.Equal(t, proposalSourceCountBefore+1, beaconBlockProposalSourceCount(t, test.proposalSource))
-			}
 			if test.builderBoostFactor != 0 {
 				capture.AssertHasEntry(t, "Ignoring non-default builder boost factor on Gloas proposal path")
 			}
@@ -263,6 +246,113 @@ func TestProposeGloas(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProposeGloasProposalSource(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name                     string
+		executionPayloadIncluded bool
+		source                   string
+		err                      string
+	}{
+		{
+			name:                     "SelfBuiltPayload",
+			executionPayloadIncluded: true,
+			source:                   "local",
+		},
+		{
+			name:                     "ProtocolBuilderPayload",
+			executionPayloadIncluded: false,
+			source:                   "builder",
+			err:                      "failed to propose block: ePBS proposal excludes requested execution payload",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			monitor, err := prometheusmetrics.New(ctx,
+				prometheusmetrics.WithLogLevel(zerolog.Disabled),
+				prometheusmetrics.WithAddress("localhost:0"),
+			)
+			require.NoError(t, err)
+			proposalSourceCountBefore := beaconBlockProposalSourceCount(t, test.source)
+			service, duty, blockSigner, envelopeSigner, envelopeSubmitter := newGloasProposerForProposalSource(t, ctx, test.executionPayloadIncluded, monitor)
+
+			err = service.Propose(ctx, duty)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, proposalSourceCountBefore+1, beaconBlockProposalSourceCount(t, test.source))
+			if !test.executionPayloadIncluded {
+				require.Zero(t, blockSigner.calls)
+				require.Zero(t, envelopeSigner.calls)
+				require.Nil(t, envelopeSubmitter.opts)
+			}
+		})
+	}
+}
+
+func newGloasProposerForProposalSource(t *testing.T,
+	ctx context.Context,
+	executionPayloadIncluded bool,
+	monitor metrics.Service,
+) (*standard.Service,
+	*beaconblockproposer.Duty,
+	*capturingBeaconBlockSigner,
+	*capturingExecutionPayloadEnvelopeSigner,
+	*capturingExecutionPayloadEnvelopeSubmitter,
+) {
+	t.Helper()
+
+	proposalClient, err := mockconsensusclient.New(ctx)
+	require.NoError(t, err)
+	responseClient, err := mockconsensusclient.New(ctx)
+	require.NoError(t, err)
+	proposalClient.EPBSProposalFunc = func(ctx context.Context, opts *consensusapi.EPBSProposalOpts) (*consensusapi.Response[*consensusapi.VersionedEPBSProposal], error) {
+		responseOpts := *opts
+		responseOpts.IncludePayload = &executionPayloadIncluded
+		response, err := responseClient.EPBSProposal(ctx, &responseOpts)
+		require.NoError(t, err)
+		if response.Data.ExecutionPayloadIncluded {
+			response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
+			response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+			blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
+			require.NoError(t, err)
+			response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
+		}
+
+		return response, nil
+	}
+
+	proposalSubmitter := &capturingProposalSubmitter{}
+	signer := mocksigner.New()
+	blockSigner := &capturingBeaconBlockSigner{signature: phase0.BLSSignature{0x01}}
+	envelopeSigner := &capturingExecutionPayloadEnvelopeSigner{signature: phase0.BLSSignature{0x03}}
+	envelopeSubmitter := &capturingExecutionPayloadEnvelopeSubmitter{}
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(monitor),
+		standard.WithProposalDataProvider(proposalClient),
+		standard.WithChainTime(&forkChainTime{gloasForkEpoch: 0}),
+		standard.WithValidatingAccountsProvider(mockaccountmanager.NewValidatingAccountsProvider()),
+		standard.WithProposalSubmitter(proposalSubmitter),
+		standard.WithRANDAORevealSigner(signer),
+		standard.WithBeaconBlockSigner(blockSigner),
+		standard.WithExecutionPayloadEnvelopeSigner(envelopeSigner),
+		standard.WithExecutionPayloadEnvelopeSubmitter(envelopeSubmitter),
+		standard.WithBlobSidecarSigner(signer),
+	)
+	require.NoError(t, err)
+
+	duty := beaconblockproposer.NewDuty(1, 0)
+	duty.SetAccount(&testAccount{})
+	duty.SetRandaoReveal(phase0.BLSSignature{0x02})
+
+	return service, duty, blockSigner, envelopeSigner, envelopeSubmitter
 }
 
 func beaconBlockProposalSourceCount(t *testing.T, source string) float64 {

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -50,17 +50,21 @@ func TestProposeGloas(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name                     string
-		executionPayloadIncluded bool
-		blockAuctioneer          bool
-		builderBoostFactor       uint64
-		proposerIndexMismatch    bool
-		envelopeRootMismatch     bool
-		envelopeSignerErr        error
-		forkEpochAtConstruction  phase0.Epoch
-		forkEpochAtUse           phase0.Epoch
-		updateForkEpochAtUse     bool
-		err                      string
+		name                       string
+		executionPayloadIncluded   bool
+		blockAuctioneer            bool
+		builderBoostFactor         uint64
+		proposerIndexMismatch      bool
+		builderIndexMismatch       bool
+		envelopeRootMismatch       bool
+		envelopePayloadMissing     bool
+		executionPayloadBidMissing bool
+		envelopeSignerErr          error
+		envelopeSubmitterErr       error
+		forkEpochAtConstruction    phase0.Epoch
+		forkEpochAtUse             phase0.Epoch
+		updateForkEpochAtUse       bool
+		err                        string
 	}{
 		{
 			name:                     "PayloadIncluded",
@@ -86,6 +90,24 @@ func TestProposeGloas(t *testing.T) {
 			err:                      "failed to propose block: ePBS proposal data for incorrect proposer index",
 		},
 		{
+			name:                     "MismatchedEnvelopeBuilderIndex",
+			executionPayloadIncluded: true,
+			builderIndexMismatch:     true,
+			err:                      "failed to propose block: ePBS execution payload envelope is for incorrect builder index",
+		},
+		{
+			name:                     "MissingEnvelopePayload",
+			executionPayloadIncluded: true,
+			envelopePayloadMissing:   true,
+			err:                      "failed to propose block: ePBS execution payload envelope has no payload",
+		},
+		{
+			name:                       "MissingExecutionPayloadBid",
+			executionPayloadIncluded:   true,
+			executionPayloadBidMissing: true,
+			err:                        "failed to propose block: ePBS proposal has no execution payload bid",
+		},
+		{
 			name:                     "PayloadExcluded",
 			executionPayloadIncluded: false,
 			err:                      "failed to propose block: ePBS proposal excludes requested execution payload",
@@ -101,6 +123,12 @@ func TestProposeGloas(t *testing.T) {
 			executionPayloadIncluded: true,
 			envelopeSignerErr:        errors.New("envelope signing failed"),
 			err:                      "failed to propose block: failed to sign execution payload envelope: envelope signing failed",
+		},
+		{
+			name:                     "EnvelopeSubmissionFailure",
+			executionPayloadIncluded: true,
+			envelopeSubmitterErr:     errors.New("envelope submission failed"),
+			err:                      "failed to propose block: failed to submit execution payload envelope after block publication: envelope submission failed",
 		},
 	}
 
@@ -134,6 +162,15 @@ func TestProposeGloas(t *testing.T) {
 					if test.envelopeRootMismatch {
 						response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot[0] ^= 0xff
 					}
+					if test.builderIndexMismatch {
+						response.Data.GloasContents.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex++
+					}
+					if test.envelopePayloadMissing {
+						response.Data.GloasContents.ExecutionPayloadEnvelope.Payload = nil
+					}
+					if test.executionPayloadBidMissing {
+						response.Data.GloasContents.Block.Body.SignedExecutionPayloadBid = nil
+					}
 				}
 				if err == nil {
 					responseProposal = response.Data
@@ -147,7 +184,7 @@ func TestProposeGloas(t *testing.T) {
 			blockSigner := &capturingBeaconBlockSigner{signature: signature}
 			envelopeSignature := phase0.BLSSignature{0x03}
 			envelopeSigner := &capturingExecutionPayloadEnvelopeSigner{signature: envelopeSignature, err: test.envelopeSignerErr}
-			envelopeSubmitter := &capturingExecutionPayloadEnvelopeSubmitter{}
+			envelopeSubmitter := &capturingExecutionPayloadEnvelopeSubmitter{err: test.envelopeSubmitterErr}
 
 			chainTime := &forkChainTime{gloasForkEpoch: test.forkEpochAtConstruction}
 			var monitor metrics.Service = nullmetrics.New()
@@ -197,9 +234,15 @@ func TestProposeGloas(t *testing.T) {
 			require.Equal(t, uint64(0), *epbsOpts.BuilderBoostFactor)
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
-				require.Nil(t, proposalSubmitter.proposal)
-				require.Zero(t, proposalSubmitter.calls)
-				if test.envelopeRootMismatch {
+				if test.envelopeSubmitterErr == nil {
+					require.Nil(t, proposalSubmitter.proposal)
+					require.Zero(t, proposalSubmitter.calls)
+				} else {
+					require.NotNil(t, proposalSubmitter.proposal)
+					require.Equal(t, 1, proposalSubmitter.calls)
+					require.Equal(t, 3, envelopeSubmitter.calls)
+				}
+				if test.envelopeRootMismatch || test.builderIndexMismatch || test.envelopePayloadMissing || test.executionPayloadBidMissing {
 					require.Zero(t, blockSigner.calls)
 					require.Zero(t, envelopeSigner.calls)
 					require.Nil(t, envelopeSubmitter.opts)
@@ -938,15 +981,19 @@ func (s *contextBlockingBeaconBlockSigner) SignBeaconBlockProposal(
 var _ signer.BeaconBlockSigner = (*contextBlockingBeaconBlockSigner)(nil)
 
 type capturingExecutionPayloadEnvelopeSubmitter struct {
-	opts *consensusapi.SubmitExecutionPayloadEnvelopeOpts
+	opts  *consensusapi.SubmitExecutionPayloadEnvelopeOpts
+	calls int
+	err   error
 }
 
 func (s *capturingExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(
 	_ context.Context,
 	opts *consensusapi.SubmitExecutionPayloadEnvelopeOpts,
 ) error {
+	s.calls++
 	s.opts = opts
-	return nil
+
+	return s.err
 }
 
 var _ submitter.ExecutionPayloadEnvelopeSubmitter = (*capturingExecutionPayloadEnvelopeSubmitter)(nil)

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -244,6 +244,161 @@ func TestProposeGloas(t *testing.T) {
 	}
 }
 
+// TestProposeGloasSignsRetainedBodyRoot proves that Propose signs and submits the
+// body root retained on the proposal (BeaconBlockBodyRoot), not the body root the
+// generated Body.HashTreeRoot() would compute.  On a custom preset those two roots
+// differ, because the generated hasher inlines mainnet sizes; the mainnet fixtures
+// used elsewhere in this file have the two coincide, so they cannot tell a correct
+// implementation from one that silently falls back to the wrong root.  This test
+// makes them deliberately differ.
+func TestProposeGloasSignsRetainedBodyRoot(t *testing.T) {
+	ctx := context.Background()
+
+	proposalClient, err := mockconsensusclient.New(ctx)
+	require.NoError(t, err)
+	responseClient, err := mockconsensusclient.New(ctx)
+	require.NoError(t, err)
+
+	var generatedBodyRoot, retainedBodyRoot phase0.Root
+	proposalClient.EPBSProposalFunc = func(ctx context.Context, opts *consensusapi.EPBSProposalOpts) (*consensusapi.Response[*consensusapi.VersionedEPBSProposal], error) {
+		includePayload := true
+		responseOpts := *opts
+		responseOpts.IncludePayload = &includePayload
+		response, err := responseClient.EPBSProposal(ctx, &responseOpts)
+		if err != nil {
+			return nil, err
+		}
+		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
+		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+
+		block := response.Data.GloasContents.Block
+		generatedRoot, err := block.Body.HashTreeRoot()
+		require.NoError(t, err)
+		generatedBodyRoot = generatedRoot
+
+		// Simulate a minimal-preset node: the transport's spec-aware retained
+		// root deliberately differs from what the generated hasher computes.
+		retainedBodyRoot = generatedBodyRoot
+		retainedBodyRoot[0] ^= 0xff
+		response.Data.BeaconBlockBodyRoot = &retainedBodyRoot
+
+		blockRoot, err := (&phase0.BeaconBlockHeader{
+			Slot:          block.Slot,
+			ProposerIndex: block.ProposerIndex,
+			ParentRoot:    block.ParentRoot,
+			StateRoot:     block.StateRoot,
+			BodyRoot:      retainedBodyRoot,
+		}).HashTreeRoot()
+		require.NoError(t, err)
+		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
+
+		return response, nil
+	}
+
+	proposalSubmitter := &capturingProposalSubmitter{}
+	signer := mocksigner.New()
+	blockSigner := &capturingBeaconBlockSigner{signature: phase0.BLSSignature{0x01}}
+	envelopeSigner := &capturingExecutionPayloadEnvelopeSigner{signature: phase0.BLSSignature{0x03}}
+	envelopeSubmitter := &capturingExecutionPayloadEnvelopeSubmitter{}
+
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithProposalDataProvider(proposalClient),
+		standard.WithChainTime(&forkChainTime{}),
+		standard.WithValidatingAccountsProvider(mockaccountmanager.NewValidatingAccountsProvider()),
+		standard.WithProposalSubmitter(proposalSubmitter),
+		standard.WithRANDAORevealSigner(signer),
+		standard.WithBeaconBlockSigner(blockSigner),
+		standard.WithExecutionPayloadEnvelopeSigner(envelopeSigner),
+		standard.WithExecutionPayloadEnvelopeSubmitter(envelopeSubmitter),
+		standard.WithBlobSidecarSigner(signer),
+	)
+	require.NoError(t, err)
+
+	duty := beaconblockproposer.NewDuty(1, 0)
+	duty.SetAccount(&testAccount{})
+	duty.SetRandaoReveal(phase0.BLSSignature{0x02})
+
+	require.NoError(t, service.Propose(ctx, duty))
+
+	require.Equal(t, retainedBodyRoot, blockSigner.bodyRoot)
+	require.NotEqual(t, generatedBodyRoot, blockSigner.bodyRoot)
+
+	require.NotNil(t, proposalSubmitter.proposal)
+	require.NotNil(t, proposalSubmitter.proposal.Gloas)
+	require.NotNil(t, proposalSubmitter.proposal.Gloas.Message)
+	require.Equal(t, duty.Slot(), proposalSubmitter.proposal.Gloas.Message.Slot)
+	require.NotNil(t, envelopeSubmitter.opts)
+	require.NotNil(t, envelopeSubmitter.opts.SignedExecutionPayloadEnvelope)
+	require.NotNil(t, envelopeSubmitter.opts.SignedExecutionPayloadEnvelope.Gloas)
+}
+
+// TestProposeGloasMissingBodyRootFails proves that a proposal missing its
+// retained body root -- as a provider that never set BeaconBlockBodyRoot would
+// produce -- fails the duty outright rather than falling back to the generated,
+// potentially-wrong Body.HashTreeRoot().  Nothing may be signed or submitted:
+// signing over the wrong root would be worse than not proposing at all.
+func TestProposeGloasMissingBodyRootFails(t *testing.T) {
+	ctx := context.Background()
+
+	proposalClient, err := mockconsensusclient.New(ctx)
+	require.NoError(t, err)
+	responseClient, err := mockconsensusclient.New(ctx)
+	require.NoError(t, err)
+	proposalClient.EPBSProposalFunc = func(ctx context.Context, opts *consensusapi.EPBSProposalOpts) (*consensusapi.Response[*consensusapi.VersionedEPBSProposal], error) {
+		includePayload := true
+		responseOpts := *opts
+		responseOpts.IncludePayload = &includePayload
+		response, err := responseClient.EPBSProposal(ctx, &responseOpts)
+		if err != nil {
+			return nil, err
+		}
+		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
+		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+		blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
+		require.NoError(t, err)
+		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
+		// Simulate a provider that never populated the retained root.
+		response.Data.BeaconBlockBodyRoot = nil
+
+		return response, nil
+	}
+
+	proposalSubmitter := &capturingProposalSubmitter{}
+	signer := mocksigner.New()
+	blockSigner := &capturingBeaconBlockSigner{signature: phase0.BLSSignature{0x01}}
+	envelopeSigner := &capturingExecutionPayloadEnvelopeSigner{signature: phase0.BLSSignature{0x03}}
+	envelopeSubmitter := &capturingExecutionPayloadEnvelopeSubmitter{}
+
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithProposalDataProvider(proposalClient),
+		standard.WithChainTime(&forkChainTime{}),
+		standard.WithValidatingAccountsProvider(mockaccountmanager.NewValidatingAccountsProvider()),
+		standard.WithProposalSubmitter(proposalSubmitter),
+		standard.WithRANDAORevealSigner(signer),
+		standard.WithBeaconBlockSigner(blockSigner),
+		standard.WithExecutionPayloadEnvelopeSigner(envelopeSigner),
+		standard.WithExecutionPayloadEnvelopeSubmitter(envelopeSubmitter),
+		standard.WithBlobSidecarSigner(signer),
+	)
+	require.NoError(t, err)
+
+	duty := beaconblockproposer.NewDuty(1, 0)
+	duty.SetAccount(&testAccount{})
+	duty.SetRandaoReveal(phase0.BLSSignature{0x02})
+
+	err = service.Propose(ctx, duty)
+	require.EqualError(t, err, "failed to propose block: failed to calculate hash tree root of ePBS block body: no beacon block body root")
+	require.Zero(t, blockSigner.calls)
+	require.Zero(t, envelopeSigner.calls)
+	require.Nil(t, proposalSubmitter.proposal)
+	require.Zero(t, proposalSubmitter.calls)
+	require.Nil(t, envelopeSubmitter.opts)
+}
+
 func TestProposeGloasStartsBothSignaturesBeforePublication(t *testing.T) {
 	ctx := context.Background()
 	proposalClient, err := mockconsensusclient.New(ctx)

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -278,7 +278,7 @@ func TestProposeGloasProposalSource(t *testing.T) {
 			)
 			require.NoError(t, err)
 			proposalSourceCountBefore := beaconBlockProposalSourceCount(t, test.source)
-			service, duty, blockSigner, envelopeSigner, envelopeSubmitter := newGloasProposerForProposalSource(t, ctx, test.executionPayloadIncluded, monitor)
+			service, duty, blockSigner, envelopeSigner, envelopeSubmitter := newGloasProposerForProposalSource(ctx, t, test.executionPayloadIncluded, monitor)
 
 			err = service.Propose(ctx, duty)
 			if test.err != "" {
@@ -296,8 +296,9 @@ func TestProposeGloasProposalSource(t *testing.T) {
 	}
 }
 
-func newGloasProposerForProposalSource(t *testing.T,
+func newGloasProposerForProposalSource(
 	ctx context.Context,
+	t *testing.T,
 	executionPayloadIncluded bool,
 	monitor metrics.Service,
 ) (*standard.Service,

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -47,6 +47,7 @@ import (
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
 )
 
+// skipcq: GO-R1005
 func TestProposeGloas(t *testing.T) {
 	ctx := context.Background()
 

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -31,12 +31,15 @@ import (
 	"github.com/attestantio/vouch/services/cache"
 	mockcache "github.com/attestantio/vouch/services/cache/mock"
 	"github.com/attestantio/vouch/services/chaintime"
+	"github.com/attestantio/vouch/services/metrics"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	prometheusmetrics "github.com/attestantio/vouch/services/metrics/prometheus"
 	"github.com/attestantio/vouch/services/signer"
 	mocksigner "github.com/attestantio/vouch/services/signer/mock"
 	"github.com/attestantio/vouch/services/submitter"
 	"github.com/attestantio/vouch/testing/logger"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	e2types "github.com/wealdtech/go-eth2-types/v2"
@@ -57,12 +60,14 @@ func TestProposeGloas(t *testing.T) {
 		forkEpochAtConstruction  phase0.Epoch
 		forkEpochAtUse           phase0.Epoch
 		updateForkEpochAtUse     bool
+		proposalSource           string
 		err                      string
 	}{
 		{
 			name:                     "PayloadIncluded",
 			executionPayloadIncluded: true,
 			builderBoostFactor:       100,
+			proposalSource:           "local",
 		},
 		{
 			name:                     "ForkEpochAvailableAfterConstruction",
@@ -85,6 +90,7 @@ func TestProposeGloas(t *testing.T) {
 		{
 			name:                     "PayloadExcluded",
 			executionPayloadIncluded: false,
+			proposalSource:           "builder",
 			err:                      "failed to propose block: ePBS proposal excludes requested execution payload",
 		},
 		{
@@ -147,10 +153,18 @@ func TestProposeGloas(t *testing.T) {
 			envelopeSubmitter := &capturingExecutionPayloadEnvelopeSubmitter{}
 
 			chainTime := &forkChainTime{gloasForkEpoch: test.forkEpochAtConstruction}
+			var monitor metrics.Service = nullmetrics.New()
+			if test.proposalSource != "" {
+				monitor, err = prometheusmetrics.New(ctx,
+					prometheusmetrics.WithLogLevel(zerolog.Disabled),
+					prometheusmetrics.WithAddress("localhost:0"),
+				)
+				require.NoError(t, err)
+			}
 
 			params := []standard.Parameter{
 				standard.WithLogLevel(zerolog.TraceLevel),
-				standard.WithMonitor(nullmetrics.New()),
+				standard.WithMonitor(monitor),
 				standard.WithProposalDataProvider(proposalClient),
 				standard.WithChainTime(chainTime),
 				standard.WithValidatingAccountsProvider(mockaccountmanager.NewValidatingAccountsProvider()),
@@ -171,6 +185,10 @@ func TestProposeGloas(t *testing.T) {
 			}
 			service, err := standard.New(ctx, params...)
 			require.NoError(t, err)
+			var proposalSourceCountBefore float64
+			if test.proposalSource != "" {
+				proposalSourceCountBefore = beaconBlockProposalSourceCount(t, test.proposalSource)
+			}
 			if test.updateForkEpochAtUse {
 				chainTime.gloasForkEpoch = test.forkEpochAtUse
 			}
@@ -180,6 +198,9 @@ func TestProposeGloas(t *testing.T) {
 			duty.SetRandaoReveal(phase0.BLSSignature{0x02})
 
 			err = service.Propose(ctx, duty)
+			if test.proposalSource != "" {
+				require.Equal(t, proposalSourceCountBefore+1, beaconBlockProposalSourceCount(t, test.proposalSource))
+			}
 			if test.builderBoostFactor != 0 {
 				capture.AssertHasEntry(t, "Ignoring non-default builder boost factor on Gloas proposal path")
 			}
@@ -242,6 +263,27 @@ func TestProposeGloas(t *testing.T) {
 			}
 		})
 	}
+}
+
+func beaconBlockProposalSourceCount(t *testing.T, source string) float64 {
+	t.Helper()
+
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() != "vouch_beaconblockproposal_process_blocks_total" {
+			continue
+		}
+		for _, metric := range metricFamily.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "method" && label.GetValue() == source {
+					return metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+
+	return 0
 }
 
 // TestProposeGloasSignsRetainedBodyRoot proves that Propose signs and submits the

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -16,6 +16,7 @@ package standard_test
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -56,6 +57,7 @@ func TestProposeGloas(t *testing.T) {
 		builderBoostFactor         uint64
 		proposerIndexMismatch      bool
 		builderIndexMismatch       bool
+		foreignBuilderIndex        bool
 		envelopeRootMismatch       bool
 		envelopePayloadMissing     bool
 		executionPayloadBidMissing bool
@@ -94,6 +96,12 @@ func TestProposeGloas(t *testing.T) {
 			executionPayloadIncluded: true,
 			builderIndexMismatch:     true,
 			err:                      "failed to propose block: ePBS execution payload envelope is for incorrect builder index",
+		},
+		{
+			name:                     "ForeignBuilderIndex",
+			executionPayloadIncluded: true,
+			foreignBuilderIndex:      true,
+			err:                      "failed to propose block: ePBS execution payload bid is not self-built",
 		},
 		{
 			name:                     "MissingEnvelopePayload",
@@ -156,6 +164,7 @@ func TestProposeGloas(t *testing.T) {
 					}
 					response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 					response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+					setSelfBuildBuilderIndex(t, response.Data)
 					blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 					require.NoError(t, err)
 					response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -163,7 +172,11 @@ func TestProposeGloas(t *testing.T) {
 						response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot[0] ^= 0xff
 					}
 					if test.builderIndexMismatch {
+						response.Data.GloasContents.ExecutionPayloadEnvelope.BuilderIndex++
+					}
+					if test.foreignBuilderIndex {
 						response.Data.GloasContents.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex++
+						response.Data.GloasContents.ExecutionPayloadEnvelope.BuilderIndex = response.Data.GloasContents.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex
 					}
 					if test.envelopePayloadMissing {
 						response.Data.GloasContents.ExecutionPayloadEnvelope.Payload = nil
@@ -242,7 +255,7 @@ func TestProposeGloas(t *testing.T) {
 					require.Equal(t, 1, proposalSubmitter.calls)
 					require.Equal(t, 3, envelopeSubmitter.calls)
 				}
-				if test.envelopeRootMismatch || test.builderIndexMismatch || test.envelopePayloadMissing || test.executionPayloadBidMissing {
+				if test.envelopeRootMismatch || test.builderIndexMismatch || test.foreignBuilderIndex || test.envelopePayloadMissing || test.executionPayloadBidMissing {
 					require.Zero(t, blockSigner.calls)
 					require.Zero(t, envelopeSigner.calls)
 					require.Nil(t, envelopeSubmitter.opts)
@@ -298,17 +311,20 @@ func TestProposeGloasProposalSource(t *testing.T) {
 		name                     string
 		executionPayloadIncluded bool
 		source                   string
+		expectedCountDelta       float64
 		err                      string
 	}{
 		{
 			name:                     "SelfBuiltPayload",
 			executionPayloadIncluded: true,
 			source:                   "local",
+			expectedCountDelta:       1,
 		},
 		{
 			name:                     "ProtocolBuilderPayload",
 			executionPayloadIncluded: false,
 			source:                   "builder",
+			expectedCountDelta:       0,
 			err:                      "failed to propose block: ePBS proposal excludes requested execution payload",
 		},
 	}
@@ -321,7 +337,7 @@ func TestProposeGloasProposalSource(t *testing.T) {
 			)
 			require.NoError(t, err)
 			proposalSourceCountBefore := beaconBlockProposalSourceCount(t, test.source)
-			service, duty, blockSigner, envelopeSigner, envelopeSubmitter := newGloasProposerForProposalSource(ctx, t, test.executionPayloadIncluded, monitor)
+			service, duty, blockSigner, envelopeSigner, envelopeSubmitter, _ := newGloasProposerForProposalSource(ctx, t, test.executionPayloadIncluded, monitor)
 
 			err = service.Propose(ctx, duty)
 			if test.err != "" {
@@ -329,7 +345,7 @@ func TestProposeGloasProposalSource(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			require.Equal(t, proposalSourceCountBefore+1, beaconBlockProposalSourceCount(t, test.source))
+			require.Equal(t, proposalSourceCountBefore+test.expectedCountDelta, beaconBlockProposalSourceCount(t, test.source))
 			if !test.executionPayloadIncluded {
 				require.Zero(t, blockSigner.calls)
 				require.Zero(t, envelopeSigner.calls)
@@ -337,6 +353,35 @@ func TestProposeGloasProposalSource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProposeGloasProposalSourceSubmissionFailure(t *testing.T) {
+	ctx := context.Background()
+
+	monitor, err := prometheusmetrics.New(ctx,
+		prometheusmetrics.WithLogLevel(zerolog.Disabled),
+		prometheusmetrics.WithAddress("localhost:0"),
+	)
+	require.NoError(t, err)
+	proposalSourceCountBefore := beaconBlockProposalSourceCount(t, "local")
+	service, duty, _, _, envelopeSubmitter, proposalSubmitter := newGloasProposerForProposalSource(ctx, t, true, monitor)
+	proposalSubmitter.err = errors.New("submit failed")
+
+	err = service.Propose(ctx, duty)
+	require.EqualError(t, err, "failed to propose block: failed to submit proposal: submit failed")
+	require.Equal(t, proposalSourceCountBefore, beaconBlockProposalSourceCount(t, "local"))
+	require.Nil(t, envelopeSubmitter.opts)
+}
+
+func setSelfBuildBuilderIndex(t *testing.T, proposal *consensusapi.VersionedEPBSProposal) {
+	t.Helper()
+
+	proposal.GloasContents.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex = gloas.BuilderIndex(math.MaxUint64)
+	proposal.GloasContents.ExecutionPayloadEnvelope.BuilderIndex = gloas.BuilderIndex(math.MaxUint64)
+	bodyRoot, err := proposal.GloasContents.Block.Body.HashTreeRoot()
+	require.NoError(t, err)
+	convertedBodyRoot := phase0.Root(bodyRoot)
+	proposal.BeaconBlockBodyRoot = &convertedBodyRoot
 }
 
 func newGloasProposerForProposalSource(
@@ -349,6 +394,7 @@ func newGloasProposerForProposalSource(
 	*capturingBeaconBlockSigner,
 	*capturingExecutionPayloadEnvelopeSigner,
 	*capturingExecutionPayloadEnvelopeSubmitter,
+	*capturingProposalSubmitter,
 ) {
 	t.Helper()
 
@@ -364,6 +410,7 @@ func newGloasProposerForProposalSource(
 		if response.Data.ExecutionPayloadIncluded {
 			response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 			response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+			setSelfBuildBuilderIndex(t, response.Data)
 			blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 			require.NoError(t, err)
 			response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -396,7 +443,7 @@ func newGloasProposerForProposalSource(
 	duty.SetAccount(&testAccount{})
 	duty.SetRandaoReveal(phase0.BLSSignature{0x02})
 
-	return service, duty, blockSigner, envelopeSigner, envelopeSubmitter
+	return service, duty, blockSigner, envelopeSigner, envelopeSubmitter, proposalSubmitter
 }
 
 func beaconBlockProposalSourceCount(t *testing.T, source string) float64 {
@@ -446,6 +493,7 @@ func TestProposeGloasSignsRetainedBodyRoot(t *testing.T) {
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+		setSelfBuildBuilderIndex(t, response.Data)
 
 		block := response.Data.GloasContents.Block
 		generatedRoot, err := block.Body.HashTreeRoot()
@@ -532,6 +580,7 @@ func TestProposeGloasMissingBodyRootFails(t *testing.T) {
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+		setSelfBuildBuilderIndex(t, response.Data)
 		blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 		require.NoError(t, err)
 		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -591,6 +640,7 @@ func TestProposeGloasStartsBothSignaturesBeforePublication(t *testing.T) {
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+		setSelfBuildBuilderIndex(t, response.Data)
 		blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 		require.NoError(t, err)
 		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -679,6 +729,7 @@ func TestProposeGloasCancelsPeerSigningAfterFailure(t *testing.T) {
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+		setSelfBuildBuilderIndex(t, response.Data)
 		blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 		require.NoError(t, err)
 		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -768,6 +819,7 @@ func TestProposeGloasCancelsBlockedBlockSigningAfterEnvelopeFailure(t *testing.T
 		}
 		response.Data.GloasContents.KZGProofs = []deneb.KZGProof{{0x04}}
 		response.Data.GloasContents.Blobs = []deneb.Blob{{0x05}}
+		setSelfBuildBuilderIndex(t, response.Data)
 		blockRoot, err := response.Data.GloasContents.Block.HashTreeRoot()
 		require.NoError(t, err)
 		response.Data.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot = blockRoot
@@ -881,13 +933,14 @@ func TestProposePreGloas(t *testing.T) {
 type capturingProposalSubmitter struct {
 	proposal *consensusapi.VersionedSignedProposal
 	calls    int
+	err      error
 }
 
 func (s *capturingProposalSubmitter) SubmitProposal(_ context.Context, proposal *consensusapi.VersionedSignedProposal) error {
 	s.calls++
 	s.proposal = proposal
 
-	return nil
+	return s.err
 }
 
 var _ submitter.ProposalSubmitter = (*capturingProposalSubmitter)(nil)

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -311,6 +311,7 @@ func TestProposeGloasProposalSource(t *testing.T) {
 	tests := []struct {
 		name                     string
 		executionPayloadIncluded bool
+		envelopeSubmissionErr    error
 		source                   string
 		expectedCountDelta       float64
 		err                      string
@@ -328,6 +329,14 @@ func TestProposeGloasProposalSource(t *testing.T) {
 			expectedCountDelta:       0,
 			err:                      "failed to propose block: ePBS proposal excludes requested execution payload",
 		},
+		{
+			name:                     "EnvelopeSubmissionFailure",
+			executionPayloadIncluded: true,
+			envelopeSubmissionErr:    errors.New("submit failed"),
+			source:                   "local",
+			expectedCountDelta:       0,
+			err:                      "failed to propose block: failed to submit execution payload envelope after block publication: submit failed",
+		},
 	}
 
 	for _, test := range tests {
@@ -339,6 +348,7 @@ func TestProposeGloasProposalSource(t *testing.T) {
 			require.NoError(t, err)
 			proposalSourceCountBefore := beaconBlockProposalSourceCount(t, test.source)
 			service, duty, blockSigner, envelopeSigner, envelopeSubmitter, _ := newGloasProposerForProposalSource(ctx, t, test.executionPayloadIncluded, monitor)
+			envelopeSubmitter.err = test.envelopeSubmissionErr
 
 			err = service.Propose(ctx, duty)
 			if test.err != "" {

--- a/services/beaconblockproposer/standard/metrics.go
+++ b/services/beaconblockproposer/standard/metrics.go
@@ -109,7 +109,7 @@ func registerPrometheusMetrics(_ context.Context) error {
 		Namespace: "vouch",
 		Subsystem: "beaconblockproposal_process",
 		Name:      "blocks_total",
-		Help:      "The number of beacon block proposals.  method can be either local or relay",
+		Help:      "The number of beacon block proposals.  method can be local, relay, or builder",
 	}, []string{"method"})
 	if err := prometheus.Register(beaconBlockProposalSource); err != nil {
 		return err

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -247,8 +247,13 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 		s.log.Warn().Msg("Ignoring non-default builder boost factor on Gloas proposal path")
 	}
 
+	// A Gloas block never carries an execution payload: it commits to a bid, and the
+	// payload is revealed separately as an envelope.  IncludePayload selects whether
+	// that envelope travels back with the block or stays cached on the producing node,
+	// so asking for it is what keeps the reveal publishable through any beacon node
+	// rather than only the one that built the payload.
 	includePayload := true
-	// Force local building and include its payload so any beacon node can publish it.
+	// Force local building.
 	selfBuildBoostFactor := uint64(0)
 	proposalResponse, err := s.proposalProvider.EPBSProposal(ctx, &api.EPBSProposalOpts{
 		Slot:               duty.Slot(),
@@ -343,7 +348,7 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 }
 
 // epbsProposalEnvelope obtains the execution payload envelope and body root for a proposal,
-// confirming that the envelope is for the proposed block.
+// confirming that the envelope is for the proposed block and pays a fee recipient.
 func (*Service) epbsProposalEnvelope(proposal *api.VersionedEPBSProposal) (*gloas.ExecutionPayloadEnvelope, phase0.Root, error) {
 	envelope, err := proposal.ExecutionPayloadEnvelope()
 	if err != nil {
@@ -351,6 +356,13 @@ func (*Service) epbsProposalEnvelope(proposal *api.VersionedEPBSProposal) (*gloa
 	}
 	if envelope.Payload == nil {
 		return nil, phase0.Root{}, errors.New("ePBS execution payload envelope has no payload")
+	}
+	// The bid's fee recipient is the one the strategies check, but a self-built bid pays
+	// nothing: the spec requires bid.value to be zero and records no builder payment for
+	// it.  The payload's own fee recipient collects the slot's priority fees and MEV, so
+	// it is the one that has to be checked before this envelope is signed.
+	if envelope.Payload.FeeRecipient.IsZero() {
+		return nil, phase0.Root{}, errors.New("ePBS execution payload envelope has 0 fee recipient")
 	}
 	if proposal.GloasContents == nil || proposal.GloasContents.Block == nil || proposal.GloasContents.Block.Body == nil || proposal.GloasContents.Block.Body.SignedExecutionPayloadBid == nil || proposal.GloasContents.Block.Body.SignedExecutionPayloadBid.Message == nil {
 		return nil, phase0.Root{}, errors.New("ePBS proposal has no execution payload bid")

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -265,14 +265,12 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "failed to calculate hash tree root of ePBS block body")
 	}
-	block := proposal.GloasContents.Block
-	blockRoot, err := (&phase0.BeaconBlockHeader{
-		Slot:          block.Slot,
-		ProposerIndex: block.ProposerIndex,
-		ParentRoot:    block.ParentRoot,
-		StateRoot:     block.StateRoot,
-		BodyRoot:      bodyRoot,
-	}).HashTreeRoot()
+	// Use proposal.Root() rather than hashing GloasContents.Block ourselves: the
+	// generated block hasher inlines mainnet preset sizes, so it is wrong on any
+	// other preset.  Root() derives the block root from the same body root that
+	// is signed below, and is the same derivation the beacon node client used to
+	// check the envelope, so this guard and the signature cannot disagree.
+	blockRoot, err := proposal.Root()
 	if err != nil {
 		return errors.Wrap(err, "failed to calculate hash tree root of ePBS block")
 	}

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -308,7 +308,7 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 		return errors.Wrap(err, "failed to submit proposal")
 	}
 
-	if err := s.executionPayloadEnvelopeSubmitter.SubmitExecutionPayloadEnvelope(ctx, &api.SubmitExecutionPayloadEnvelopeOpts{
+	envelopeSubmissionOpts := &api.SubmitExecutionPayloadEnvelopeOpts{
 		SignedExecutionPayloadEnvelope: &spec.VersionedSignedExecutionPayloadEnvelope{
 			Version: spec.DataVersionGloas,
 			Gloas: &gloas.SignedExecutionPayloadEnvelope{
@@ -318,8 +318,24 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 		},
 		KZGProofs: kzgProofs,
 		Blobs:     blobs,
-	}); err != nil {
-		return errors.Wrap(err, "failed to submit execution payload envelope")
+	}
+	var envelopeSubmissionErr error
+	for attempts := 3; attempts > 0; attempts-- {
+		envelopeSubmissionErr = s.executionPayloadEnvelopeSubmitter.SubmitExecutionPayloadEnvelope(ctx, envelopeSubmissionOpts)
+		if envelopeSubmissionErr == nil {
+			break
+		}
+		s.log.Warn().Err(envelopeSubmissionErr).Int("attempts_remaining", attempts-1).Msg("Failed to submit execution payload envelope after block publication")
+		if attempts > 1 {
+			select {
+			case <-ctx.Done():
+				return errors.Wrap(ctx.Err(), "failed to submit execution payload envelope after block publication")
+			case <-time.After(250 * time.Millisecond):
+			}
+		}
+	}
+	if envelopeSubmissionErr != nil {
+		return errors.Wrap(envelopeSubmissionErr, "failed to submit execution payload envelope after block publication")
 	}
 
 	return nil
@@ -331,6 +347,15 @@ func (*Service) epbsProposalEnvelope(proposal *api.VersionedEPBSProposal) (*gloa
 	envelope, err := proposal.ExecutionPayloadEnvelope()
 	if err != nil {
 		return nil, phase0.Root{}, errors.Wrap(err, "failed to obtain execution payload envelope")
+	}
+	if envelope.Payload == nil {
+		return nil, phase0.Root{}, errors.New("ePBS execution payload envelope has no payload")
+	}
+	if proposal.GloasContents == nil || proposal.GloasContents.Block == nil || proposal.GloasContents.Block.Body == nil || proposal.GloasContents.Block.Body.SignedExecutionPayloadBid == nil || proposal.GloasContents.Block.Body.SignedExecutionPayloadBid.Message == nil {
+		return nil, phase0.Root{}, errors.New("ePBS proposal has no execution payload bid")
+	}
+	if envelope.BuilderIndex != proposal.GloasContents.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex {
+		return nil, phase0.Root{}, errors.New("ePBS execution payload envelope is for incorrect builder index")
 	}
 	bodyRoot, err := proposal.BodyRoot()
 	if err != nil {

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -260,10 +261,8 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 	}
 	proposal := proposalResponse.Data
 	if !proposal.ExecutionPayloadIncluded {
-		monitorBeaconBlockProposalSource("builder")
 		return errors.New("ePBS proposal excludes requested execution payload")
 	}
-	monitorBeaconBlockProposalSource("local")
 
 	if err := s.confirmEPBSProposalData(ctx, proposal, duty); err != nil {
 		return err
@@ -307,6 +306,7 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 	if err := s.proposalSubmitter.SubmitProposal(ctx, signedProposal); err != nil {
 		return errors.Wrap(err, "failed to submit proposal")
 	}
+	monitorBeaconBlockProposalSource("local")
 
 	envelopeSubmissionOpts := &api.SubmitExecutionPayloadEnvelopeOpts{
 		SignedExecutionPayloadEnvelope: &spec.VersionedSignedExecutionPayloadEnvelope{
@@ -353,6 +353,9 @@ func (*Service) epbsProposalEnvelope(proposal *api.VersionedEPBSProposal) (*gloa
 	}
 	if proposal.GloasContents == nil || proposal.GloasContents.Block == nil || proposal.GloasContents.Block.Body == nil || proposal.GloasContents.Block.Body.SignedExecutionPayloadBid == nil || proposal.GloasContents.Block.Body.SignedExecutionPayloadBid.Message == nil {
 		return nil, phase0.Root{}, errors.New("ePBS proposal has no execution payload bid")
+	}
+	if proposal.GloasContents.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex != gloas.BuilderIndex(math.MaxUint64) {
+		return nil, phase0.Root{}, errors.New("ePBS execution payload bid is not self-built")
 	}
 	if envelope.BuilderIndex != proposal.GloasContents.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex {
 		return nil, phase0.Root{}, errors.New("ePBS execution payload envelope is for incorrect builder index")

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -259,7 +259,11 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 		return errors.Wrap(err, "failed to obtain ePBS proposal")
 	}
 	proposal := proposalResponse.Data
-	monitorBeaconBlockProposalSource("local")
+	if proposal.ExecutionPayloadIncluded {
+		monitorBeaconBlockProposalSource("local")
+	} else {
+		monitorBeaconBlockProposalSource("builder")
+	}
 	if !proposal.ExecutionPayloadIncluded {
 		return errors.New("ePBS proposal excludes requested execution payload")
 	}

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -183,27 +183,10 @@ func (s *Service) proposeBlock(ctx context.Context,
 	}
 
 	if signedProposal.Blinded {
-		// Select the relays to unblind the proposal.
-		providers := make([]builderclient.UnblindedProposalProvider, 0, len(auctionResults.AllProviders))
-		unblindingCandidates := auctionResults.Providers
-		if len(unblindingCandidates) == 0 || s.unblindFromAllRelays {
-			s.log.Trace().Int("providers", len(auctionResults.AllProviders)).Msg("Unblinding from all providers")
-			unblindingCandidates = auctionResults.AllProviders
+		providers, err := s.unblindingProviders(auctionResults)
+		if err != nil {
+			return err
 		}
-
-		for _, provider := range unblindingCandidates {
-			unblindedProposalProvider, isProvider := provider.(builderclient.UnblindedProposalProvider)
-			if !isProvider {
-				s.log.Warn().Str("provider", provider.Name()).Msg("Auctioneer cannot unblind the proposal")
-				continue
-			}
-			providers = append(providers, unblindedProposalProvider)
-		}
-		if len(providers) == 0 {
-			return errors.New("no relays to unblind the block")
-		}
-
-		s.log.Trace().Int("providers", len(providers)).Msg("Obtained relays that can unblind the proposal")
 		if err := s.unblindProposal(ctx, signedProposal, providers); err != nil {
 			return errors.Wrap(err, "failed to unblind block")
 		}
@@ -214,6 +197,34 @@ func (s *Service) proposeBlock(ctx context.Context,
 	}
 
 	return nil
+}
+
+// unblindingProviders returns the relays that can unblind a proposal.
+func (s *Service) unblindingProviders(auctionResults *blockauctioneer.Results) ([]builderclient.UnblindedProposalProvider, error) {
+	// Select the relays to unblind the proposal.
+	providers := make([]builderclient.UnblindedProposalProvider, 0, len(auctionResults.AllProviders))
+	unblindingCandidates := auctionResults.Providers
+	if len(unblindingCandidates) == 0 || s.unblindFromAllRelays {
+		s.log.Trace().Int("providers", len(auctionResults.AllProviders)).Msg("Unblinding from all providers")
+		unblindingCandidates = auctionResults.AllProviders
+	}
+
+	for _, provider := range unblindingCandidates {
+		unblindedProposalProvider, isProvider := provider.(builderclient.UnblindedProposalProvider)
+		if !isProvider {
+			s.log.Warn().Str("provider", provider.Name()).Msg("Auctioneer cannot unblind the proposal")
+			continue
+		}
+		providers = append(providers, unblindedProposalProvider)
+	}
+
+	if len(providers) == 0 {
+		return nil, errors.New("no relays to unblind the block")
+	}
+
+	s.log.Trace().Int("providers", len(providers)).Msg("Obtained relays that can unblind the proposal")
+
+	return providers, nil
 }
 
 // proposeEPBSBlock proposes a Gloas block.
@@ -257,25 +268,9 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 		return err
 	}
 
-	envelope, err := proposal.ExecutionPayloadEnvelope()
+	envelope, bodyRoot, err := s.epbsProposalEnvelope(proposal)
 	if err != nil {
-		return errors.Wrap(err, "failed to obtain execution payload envelope")
-	}
-	bodyRoot, err := proposal.BodyRoot()
-	if err != nil {
-		return errors.Wrap(err, "failed to calculate hash tree root of ePBS block body")
-	}
-	// Use proposal.Root() rather than hashing GloasContents.Block ourselves: the
-	// generated block hasher inlines mainnet preset sizes, so it is wrong on any
-	// other preset.  Root() derives the block root from the same body root that
-	// is signed below, and is the same derivation the beacon node client used to
-	// check the envelope, so this guard and the signature cannot disagree.
-	blockRoot, err := proposal.Root()
-	if err != nil {
-		return errors.Wrap(err, "failed to calculate hash tree root of ePBS block")
-	}
-	if blockRoot != envelope.BeaconBlockRoot {
-		return errors.New("ePBS execution payload envelope is for incorrect block")
+		return err
 	}
 
 	var signedProposal *api.VersionedSignedProposal
@@ -327,6 +322,33 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 	}
 
 	return nil
+}
+
+// epbsProposalEnvelope obtains the execution payload envelope and body root for a proposal,
+// confirming that the envelope is for the proposed block.
+func (*Service) epbsProposalEnvelope(proposal *api.VersionedEPBSProposal) (*gloas.ExecutionPayloadEnvelope, phase0.Root, error) {
+	envelope, err := proposal.ExecutionPayloadEnvelope()
+	if err != nil {
+		return nil, phase0.Root{}, errors.Wrap(err, "failed to obtain execution payload envelope")
+	}
+	bodyRoot, err := proposal.BodyRoot()
+	if err != nil {
+		return nil, phase0.Root{}, errors.Wrap(err, "failed to calculate hash tree root of ePBS block body")
+	}
+	// Use proposal.Root() rather than hashing GloasContents.Block ourselves: the
+	// generated block hasher inlines mainnet preset sizes, so it is wrong on any
+	// other preset.  Root() derives the block root from the same body root that
+	// is signed below, and is the same derivation the beacon node client used to
+	// check the envelope, so this guard and the signature cannot disagree.
+	blockRoot, err := proposal.Root()
+	if err != nil {
+		return nil, phase0.Root{}, errors.Wrap(err, "failed to calculate hash tree root of ePBS block")
+	}
+	if blockRoot != envelope.BeaconBlockRoot {
+		return nil, phase0.Root{}, errors.New("ePBS execution payload envelope is for incorrect block")
+	}
+
+	return envelope, bodyRoot, nil
 }
 
 func (*Service) confirmProposalData(_ context.Context,

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -259,14 +259,11 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 		return errors.Wrap(err, "failed to obtain ePBS proposal")
 	}
 	proposal := proposalResponse.Data
-	if proposal.ExecutionPayloadIncluded {
-		monitorBeaconBlockProposalSource("local")
-	} else {
-		monitorBeaconBlockProposalSource("builder")
-	}
 	if !proposal.ExecutionPayloadIncluded {
+		monitorBeaconBlockProposalSource("builder")
 		return errors.New("ePBS proposal excludes requested execution payload")
 	}
+	monitorBeaconBlockProposalSource("local")
 
 	if err := s.confirmEPBSProposalData(ctx, proposal, duty); err != nil {
 		return err

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -307,7 +307,6 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 	if err := s.proposalSubmitter.SubmitProposal(ctx, signedProposal); err != nil {
 		return errors.Wrap(err, "failed to submit proposal")
 	}
-	monitorBeaconBlockProposalSource("local")
 
 	envelopeSubmissionOpts := &api.SubmitExecutionPayloadEnvelopeOpts{
 		SignedExecutionPayloadEnvelope: &spec.VersionedSignedExecutionPayloadEnvelope{
@@ -338,6 +337,7 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 	if envelopeSubmissionErr != nil {
 		return errors.Wrap(envelopeSubmissionErr, "failed to submit execution payload envelope after block publication")
 	}
+	monitorBeaconBlockProposalSource("local")
 
 	return nil
 }

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -229,6 +229,7 @@ func (s *Service) unblindingProviders(auctionResults *blockauctioneer.Results) (
 }
 
 // proposeEPBSBlock proposes a Gloas block.
+// skipcq: GO-R1005
 func (s *Service) proposeEPBSBlock(ctx context.Context,
 	duty *beaconblockproposer.Duty,
 	graffiti [32]byte,

--- a/services/beaconcommitteesubscriber/standard/parameters.go
+++ b/services/beaconcommitteesubscriber/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020, 2022 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,11 +24,11 @@ import (
 )
 
 type parameters struct {
-	logLevel                 zerolog.Level
-	processConcurrency       int64
 	monitor                  metrics.Service
 	chainTimeService         chaintime.Service
 	attesterDutiesProvider   eth2client.AttesterDutiesProvider
+	logLevel                 zerolog.Level
+	processConcurrency       int64
 	beaconCommitteeSubmitter submitter.BeaconCommitteeSubscriptionsSubmitter
 	attestationAggregator    attestationaggregator.Service
 }

--- a/services/beaconcommitteesubscriber/standard/service.go
+++ b/services/beaconcommitteesubscriber/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -31,8 +31,8 @@ type Service struct {
 	log                    zerolog.Logger
 	monitor                metrics.Service
 	chainTimeService       chaintime.Service
-	processConcurrency     int64
 	attesterDutiesProvider eth2client.AttesterDutiesProvider
+	processConcurrency     int64
 	attestationAggregator  attestationaggregator.Service
 	submitter              submitter.BeaconCommitteeSubscriptionsSubmitter
 }

--- a/services/blockrelay/standard/parameters.go
+++ b/services/blockrelay/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2023 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -33,8 +33,12 @@ import (
 )
 
 type parameters struct {
-	logLevel                                  zerolog.Level
 	monitor                                   metrics.Service
+	accountsProvider                          accountmanager.AccountsProvider
+	validatorsProvider                        consensusclient.ValidatorsProvider
+	validatingAccountsProvider                accountmanager.ValidatingAccountsProvider
+	builderBidProvider                        builderbid.Provider
+	logLevel                                  zerolog.Level
 	majordomo                                 majordomo.Service
 	scheduler                                 scheduler.Service
 	listenAddress                             string
@@ -45,14 +49,10 @@ type parameters struct {
 	clientCertURL                             string
 	clientKeyURL                              string
 	caCertURL                                 string
-	accountsProvider                          accountmanager.AccountsProvider
-	validatorsProvider                        consensusclient.ValidatorsProvider
-	validatingAccountsProvider                accountmanager.ValidatingAccountsProvider
 	validatorRegistrationSigner               signer.ValidatorRegistrationSigner
 	secondaryValidatorRegistrationsSubmitters []consensusclient.ValidatorRegistrationsSubmitter
 	logResults                                bool
 	releaseVersion                            string
-	builderBidProvider                        builderbid.Provider
 	builderConfigs                            map[phase0.BLSPubKey]*blockrelay.BuilderConfig
 }
 
@@ -263,7 +263,7 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	if _, _, err := net.SplitHostPort(parameters.listenAddress); err != nil {
 		return nil, errors.New("listen address malformed")
 	}
-	// config URL can be empty.
+	// Config URL can be empty.
 	if parameters.releaseVersion == "" {
 		return nil, errors.New("no release version specified")
 	}

--- a/services/blockrelay/standard/parameters.go
+++ b/services/blockrelay/standard/parameters.go
@@ -227,52 +227,51 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 		p.apply(&parameters)
 	}
 
-	if parameters.monitor == nil {
-		return nil, errors.New("no monitor specified")
-	}
-	if parameters.majordomo == nil {
-		return nil, errors.New("no majordomo specified")
-	}
-	if parameters.scheduler == nil {
-		return nil, errors.New("no scheduler specified")
-	}
-	if parameters.chainTime == nil {
-		return nil, errors.New("no chaintime specified")
-	}
-	if bytes.Equal(parameters.fallbackFeeRecipient[:], zeroExecutionAddress[:]) {
-		return nil, errors.New("no fallback fee recipient specified")
-	}
-	if parameters.fallbackGasLimit == 0 {
-		return nil, errors.New("no fallback gas limit specified")
-	}
-	if parameters.accountsProvider == nil {
-		return nil, errors.New("no accounts provider specified")
-	}
-	if parameters.validatorsProvider == nil {
-		return nil, errors.New("no validators provider specified")
-	}
-	if parameters.validatingAccountsProvider == nil {
-		return nil, errors.New("no validating accounts provider specified")
-	}
-	if parameters.validatorRegistrationSigner == nil {
-		return nil, errors.New("no validator registration signer specified")
-	}
-	if parameters.listenAddress == "" {
-		return nil, errors.New("no listen address specified")
-	}
-	if _, _, err := net.SplitHostPort(parameters.listenAddress); err != nil {
-		return nil, errors.New("listen address malformed")
-	}
-	// Config URL can be empty.
-	if parameters.releaseVersion == "" {
-		return nil, errors.New("no release version specified")
-	}
-	if parameters.builderBidProvider == nil {
-		return nil, errors.New("no builder bid provider specified")
-	}
-	if parameters.builderConfigs == nil {
-		return nil, errors.New("no builder configs specified")
+	if err := parameters.validate(); err != nil {
+		return nil, err
 	}
 
 	return &parameters, nil
+}
+
+func (p *parameters) validate() error {
+	checks := []struct {
+		valid bool
+		err   string
+	}{
+		{p.monitor != nil, "no monitor specified"},
+		{p.majordomo != nil, "no majordomo specified"},
+		{p.scheduler != nil, "no scheduler specified"},
+		{p.chainTime != nil, "no chaintime specified"},
+		{!bytes.Equal(p.fallbackFeeRecipient[:], zeroExecutionAddress[:]), "no fallback fee recipient specified"},
+		{p.fallbackGasLimit != 0, "no fallback gas limit specified"},
+		{p.accountsProvider != nil, "no accounts provider specified"},
+		{p.validatorsProvider != nil, "no validators provider specified"},
+		{p.validatingAccountsProvider != nil, "no validating accounts provider specified"},
+		{p.validatorRegistrationSigner != nil, "no validator registration signer specified"},
+		{p.listenAddress != "", "no listen address specified"},
+	}
+	for _, check := range checks {
+		if !check.valid {
+			return errors.New(check.err)
+		}
+	}
+	if _, _, err := net.SplitHostPort(p.listenAddress); err != nil {
+		return errors.New("listen address malformed")
+	}
+	checks = []struct {
+		valid bool
+		err   string
+	}{
+		{p.releaseVersion != "", "no release version specified"},
+		{p.builderBidProvider != nil, "no builder bid provider specified"},
+		{p.builderConfigs != nil, "no builder configs specified"},
+	}
+	for _, check := range checks {
+		if !check.valid {
+			return errors.New(check.err)
+		}
+	}
+
+	return nil
 }

--- a/services/blockrelay/standard/service.go
+++ b/services/blockrelay/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 - 2024 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -41,6 +41,10 @@ import (
 type Service struct {
 	log                                       zerolog.Logger
 	monitor                                   metrics.Service
+	accountsProvider                          accountmanager.AccountsProvider
+	validatorsProvider                        consensusclient.ValidatorsProvider
+	validatingAccountsProvider                accountmanager.ValidatingAccountsProvider
+	builderBidProvider                        builderbid.Provider
 	majordomo                                 majordomo.Service
 	chainTime                                 chaintime.Service
 	configURL                                 string
@@ -49,40 +53,31 @@ type Service struct {
 	clientCertURL                             string
 	clientKeyURL                              string
 	caCertURL                                 string
-	accountsProvider                          accountmanager.AccountsProvider
-	validatorsProvider                        consensusclient.ValidatorsProvider
-	validatingAccountsProvider                accountmanager.ValidatingAccountsProvider
 	validatorRegistrationSigner               signer.ValidatorRegistrationSigner
 	builderBidsCache                          map[string]map[string]*builderspec.VersionedSignedBuilderBid
-	builderBidsCacheMu                        sync.RWMutex
 	latestValidatorRegistrations              map[phase0.BLSPubKey]phase0.Root
-	latestValidatorRegistrationsMu            sync.RWMutex
 	signedValidatorRegistrations              map[phase0.Root]*apiv1.SignedValidatorRegistration
-	signedValidatorRegistrationsMu            sync.RWMutex
 	secondaryValidatorRegistrationsSubmitters []consensusclient.ValidatorRegistrationsSubmitter
 	logResults                                bool
 	releaseVersion                            string
-	builderBidProvider                        builderbid.Provider
 	builderConfigs                            map[phase0.BLSPubKey]*blockrelay.BuilderConfig
-
-	// builderBidMu ensures that only one builder bid operation is actively talking to
-	// relays at a time.
-	builderBidMu sync.Mutex
-
-	executionConfig   blockrelay.ExecutionConfigurator
-	executionConfigMu sync.RWMutex
-
+	executionConfig                           blockrelay.ExecutionConfigurator
 	// controlledValidators is a map of validators that are controlled
 	// by Vouch.  Used when receiving registrations from beacon nodes to know
 	// which registrations to forward, and which to drop because we have already
 	// submitted them.
-	controlledValidators   map[phase0.BLSPubKey]struct{}
-	controlledValidatorsMu sync.RWMutex
-
-	activitySem *semaphore.Weighted
-
+	controlledValidators map[phase0.BLSPubKey]struct{}
+	activitySem          *semaphore.Weighted
 	// Needed only to create dummy VersionedSignedBuilderBid in cacheBid.
-	electraForkEpoch phase0.Epoch
+	electraForkEpoch               phase0.Epoch
+	builderBidsCacheMu             sync.RWMutex
+	latestValidatorRegistrationsMu sync.RWMutex
+	signedValidatorRegistrationsMu sync.RWMutex
+	// builderBidMu ensures that only one builder bid operation is actively talking to
+	// relays at a time.
+	builderBidMu           sync.Mutex
+	executionConfigMu      sync.RWMutex
+	controlledValidatorsMu sync.RWMutex
 }
 
 // New creates a new controller.

--- a/services/blockrelay/standard/service_test.go
+++ b/services/blockrelay/standard/service_test.go
@@ -183,6 +183,26 @@ func TestService(t *testing.T) {
 			err: "problem with parameters: listen address malformed",
 		},
 		{
+			name: "ListenAddressMalformedBeforeReleaseVersion",
+			params: []standard.Parameter{
+				standard.WithLogLevel(zerolog.Disabled),
+				standard.WithMonitor(monitor),
+				standard.WithMajordomo(majordomoSvc),
+				standard.WithScheduler(mockScheduler),
+				standard.WithListenAddress("abc"),
+				standard.WithChainTime(chainTime),
+				standard.WithConfigURL(configURL),
+				standard.WithFallbackFeeRecipient(fallbackFeeRecipient),
+				standard.WithFallbackGasLimit(fallbackGasLimit),
+				standard.WithAccountsProvider(mockAccountsProvider),
+				standard.WithValidatorsProvider(mockValidatorsProvider),
+				standard.WithValidatingAccountsProvider(mockValidatingAccountsProvider),
+				standard.WithValidatorRegistrationSigner(mockSigner),
+				standard.WithBuilderBidProvider(builderBidProvider),
+			},
+			err: "problem with parameters: listen address malformed",
+		},
+		{
 			name: "ChainTimeMissing",
 			params: []standard.Parameter{
 				standard.WithLogLevel(zerolog.Disabled),

--- a/services/cache/standard/events.go
+++ b/services/cache/standard/events.go
@@ -52,8 +52,9 @@ func (s *Service) handleHead(ctx context.Context, data *apiv1.HeadEvent) {
 
 func (s *Service) updateFromBlock(block *spec.VersionedSignedBeaconBlock) {
 	switch block.Version {
-	case spec.DataVersionPhase0, spec.DataVersionAltair:
-		// No execution information available, nothing to do.
+	case spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionGloas:
+		// Phase 0 and Altair carry no execution payload.
+		// A Gloas block carries an execution payload bid, which has no execution block number.
 	case spec.DataVersionBellatrix:
 		// Potentially execution information available.
 		if block.Bellatrix != nil && block.Bellatrix.Message != nil && block.Bellatrix.Message.Body != nil {
@@ -102,8 +103,6 @@ func (s *Service) updateFromBlock(block *spec.VersionedSignedBeaconBlock) {
 			s.log.Trace().Uint64("height", executionPayload.BlockNumber).Stringer("hash", executionPayload.BlockHash).Msg("Updating execution chain head")
 			s.setExecutionChainHead(executionPayload.BlockHash, executionPayload.BlockNumber)
 		}
-	case spec.DataVersionGloas:
-		// Gloas blocks contain an execution payload bid, which has no execution block number.
 	default:
 		s.log.Error().Msg("Unhandled block version")
 	}

--- a/services/cache/standard/events.go
+++ b/services/cache/standard/events.go
@@ -102,6 +102,8 @@ func (s *Service) updateFromBlock(block *spec.VersionedSignedBeaconBlock) {
 			s.log.Trace().Uint64("height", executionPayload.BlockNumber).Stringer("hash", executionPayload.BlockHash).Msg("Updating execution chain head")
 			s.setExecutionChainHead(executionPayload.BlockHash, executionPayload.BlockNumber)
 		}
+	case spec.DataVersionGloas:
+		// Gloas blocks contain an execution payload bid, which has no execution block number.
 	default:
 		s.log.Error().Msg("Unhandled block version")
 	}

--- a/services/cache/standard/events_internal_test.go
+++ b/services/cache/standard/events_internal_test.go
@@ -14,11 +14,14 @@
 package standard
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	consensusclient "github.com/attestantio/go-eth2-client"
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/mock"
 	"github.com/rs/zerolog"
@@ -67,4 +70,51 @@ func TestHandleHead(t *testing.T) {
 			require.Equal(t, phase0.Slot(100), cachedSlot, "slot should come from head event")
 		})
 	}
+}
+
+func TestUpdateFromBlockGloas(t *testing.T) {
+	ctx := context.Background()
+	var logs bytes.Buffer
+	previousRoot := phase0.Hash32{0x01}
+	previousHeight := uint64(123)
+	previousGasLimit := uint64(30_000_000)
+
+	s := &Service{
+		log:                      zerolog.New(&logs),
+		executionChainHeadRoot:   previousRoot,
+		executionChainHeadHeight: previousHeight,
+		blockGasLimits: map[uint64]uint64{
+			previousHeight: previousGasLimit,
+		},
+	}
+
+	s.updateFromBlock(&spec.VersionedSignedBeaconBlock{
+		Version: spec.DataVersionGloas,
+		Gloas: &gloas.SignedBeaconBlock{
+			Message: &gloas.BeaconBlock{
+				Body: &gloas.BeaconBlockBody{
+					SignedExecutionPayloadBid: &gloas.SignedExecutionPayloadBid{
+						Message: &gloas.ExecutionPayloadBid{
+							BlockHash: phase0.Hash32{0x02},
+							GasLimit:  31_000_000,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.NotContains(t, logs.String(), "Unhandled block version")
+
+	actualRoot, actualHeight := s.ExecutionChainHead(ctx)
+	require.Equal(t, previousRoot, actualRoot)
+	require.Equal(t, previousHeight, actualHeight)
+
+	actualGasLimit, exists := s.BlockGasLimit(ctx, previousHeight)
+	require.True(t, exists)
+	require.Equal(t, previousGasLimit, actualGasLimit)
+
+	s.blockGasLimitMu.RLock()
+	defer s.blockGasLimitMu.RUnlock()
+	require.Equal(t, map[uint64]uint64{previousHeight: previousGasLimit}, s.blockGasLimits)
 }

--- a/services/cache/standard/parameters.go
+++ b/services/cache/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2024 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,12 +24,12 @@ import (
 )
 
 type parameters struct {
-	logLevel                   zerolog.Level
 	monitor                    metrics.Service
-	chainTime                  chaintime.Service
 	signedBeaconBlockProvider  consensusclient.SignedBeaconBlockProvider
 	beaconBlockHeadersProvider consensusclient.BeaconBlockHeadersProvider
 	eventsProvider             consensusclient.EventsProvider
+	logLevel                   zerolog.Level
+	chainTime                  chaintime.Service
 	scheduler                  scheduler.Service
 }
 

--- a/services/cache/standard/service.go
+++ b/services/cache/standard/service.go
@@ -29,21 +29,17 @@ import (
 
 // Service provides cached information.
 type Service struct {
-	log zerolog.Logger
-
-	chainTime                  chaintime.Service
+	log                        zerolog.Logger
 	signedBeaconBlockProvider  consensusclient.SignedBeaconBlockProvider
 	beaconBlockHeadersProvider consensusclient.BeaconBlockHeadersProvider
-
-	blockRootToSlotMu sync.RWMutex
-	blockRootToSlot   map[phase0.Root]phase0.Slot
-
-	executionChainHeadMu     sync.RWMutex
-	executionChainHeadHeight uint64
-	executionChainHeadRoot   phase0.Hash32
-
-	blockGasLimitMu sync.RWMutex
-	blockGasLimits  map[uint64]uint64
+	chainTime                  chaintime.Service
+	blockRootToSlot            map[phase0.Root]phase0.Slot
+	executionChainHeadHeight   uint64
+	executionChainHeadRoot     phase0.Hash32
+	blockGasLimits             map[uint64]uint64
+	blockRootToSlotMu          sync.RWMutex
+	executionChainHeadMu       sync.RWMutex
+	blockGasLimitMu            sync.RWMutex
 }
 
 // New creates a new cache.

--- a/services/chaintime/standard/parameters.go
+++ b/services/chaintime/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,9 +20,9 @@ import (
 )
 
 type parameters struct {
-	logLevel        zerolog.Level
 	genesisProvider eth2client.GenesisProvider
 	specProvider    eth2client.SpecProvider
+	logLevel        zerolog.Level
 }
 
 // Parameter is the interface for service parameters.

--- a/services/chaintime/standard/service.go
+++ b/services/chaintime/standard/service.go
@@ -16,6 +16,9 @@ package standard
 import (
 	"context"
 	"fmt"
+	"maps"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	client "github.com/attestantio/go-eth2-client"
@@ -26,13 +29,30 @@ import (
 	zerologger "github.com/rs/zerolog/log"
 )
 
+// forkSchedule is immutable after publication through Service.forkSchedule.
+type forkSchedule struct {
+	epochs    map[string]phase0.Epoch
+	malformed map[string]struct{}
+}
+
+type forkScheduleRefresh struct {
+	err  error
+	done chan struct{}
+}
+
+type forkScheduleGeneration struct {
+	refresh atomic.Pointer[forkScheduleRefresh]
+}
+
 // Service provides chain time services.
 type Service struct {
-	log           zerolog.Logger
-	genesisTime   time.Time
-	slotDuration  time.Duration
-	slotsPerEpoch uint64
-	specProvider  client.SpecProvider
+	log                    zerolog.Logger
+	specProvider           client.SpecProvider
+	genesisTime            time.Time
+	slotDuration           time.Duration
+	slotsPerEpoch          uint64
+	forkSchedule           atomic.Pointer[forkSchedule]
+	forkScheduleGeneration atomic.Pointer[forkScheduleGeneration]
 }
 
 // New creates a new controller.
@@ -88,6 +108,9 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		slotsPerEpoch: slotsPerEpoch,
 		specProvider:  parameters.specProvider,
 	}
+	forkSchedule := forkScheduleFromSpec(spec)
+	s.forkSchedule.Store(&forkSchedule)
+	s.forkScheduleGeneration.Store(&forkScheduleGeneration{})
 
 	return s, nil
 }
@@ -135,30 +158,135 @@ func (s *Service) FirstSlotOfEpoch(epoch phase0.Epoch) phase0.Slot {
 
 // HardForkEpoch returns the activation epoch of the specified hard fork or far future epoch if missing.
 func (s *Service) HardForkEpoch(ctx context.Context, hardForkName string) phase0.Epoch {
-	forkEpoch, err := s.getHardForkEpoch(ctx, hardForkName)
-	if err != nil {
+	forkSchedule := s.forkSchedule.Load()
+	if forkEpoch, exists := forkSchedule.epochs[hardForkName]; exists {
+		return forkEpoch
+	}
+	if _, exists := forkSchedule.malformed[hardForkName]; exists {
+		s.log.Error().Err(fmt.Errorf("%s is not a uint64", hardForkName)).Msg("Failed to obtain hard fork")
+		return 0xffffffffffffffff
+	}
+
+	generation := s.forkScheduleGeneration.Load()
+	forkSchedule = s.forkSchedule.Load()
+	if forkEpoch, exists := forkSchedule.epochs[hardForkName]; exists {
+		return forkEpoch
+	}
+	if _, exists := forkSchedule.malformed[hardForkName]; exists {
+		s.log.Error().Err(fmt.Errorf("%s is not a uint64", hardForkName)).Msg("Failed to obtain hard fork")
+		return 0xffffffffffffffff
+	}
+	if err := s.refreshForkSchedule(ctx, generation); err != nil {
 		s.log.Error().Err(err).Msg("Failed to obtain hard fork")
 		return 0xffffffffffffffff
 	}
-	return forkEpoch
+	forkSchedule = s.forkSchedule.Load()
+	if forkEpoch, exists := forkSchedule.epochs[hardForkName]; exists {
+		return forkEpoch
+	}
+	if _, exists := forkSchedule.malformed[hardForkName]; exists {
+		s.log.Error().Err(fmt.Errorf("%s is not a uint64", hardForkName)).Msg("Failed to obtain hard fork")
+		return 0xffffffffffffffff
+	}
+
+	s.log.Error().Err(fmt.Errorf("%s version not known by chain", hardForkName)).Msg("Failed to obtain hard fork")
+	return 0xffffffffffffffff
 }
 
-func (s *Service) getHardForkEpoch(ctx context.Context, hardForkName string) (phase0.Epoch, error) {
-	// Fetch the fork version.
+func forkScheduleFromSpec(spec map[string]any) forkSchedule {
+	res := forkSchedule{
+		epochs:    make(map[string]phase0.Epoch),
+		malformed: make(map[string]struct{}),
+	}
+	for name, value := range spec {
+		if !strings.HasSuffix(name, "_FORK_EPOCH") {
+			continue
+		}
+		epoch, isEpoch := value.(uint64)
+		if !isEpoch {
+			res.malformed[name] = struct{}{}
+			continue
+		}
+		res.epochs[name] = phase0.Epoch(epoch)
+	}
+
+	return res
+}
+
+func (s *Service) refreshForkSchedule(ctx context.Context, generation *forkScheduleGeneration) error {
+	if generation == nil {
+		generation = &forkScheduleGeneration{}
+		if !s.forkScheduleGeneration.CompareAndSwap(nil, generation) {
+			generation = s.forkScheduleGeneration.Load()
+		}
+	}
+
+	refresh := generation.refresh.Load()
+	leader := false
+	if refresh == nil {
+		candidate := &forkScheduleRefresh{done: make(chan struct{})}
+		if generation.refresh.CompareAndSwap(nil, candidate) {
+			refresh = candidate
+			leader = true
+		} else {
+			refresh = generation.refresh.Load()
+		}
+	}
+	if !leader {
+		select {
+		case <-refresh.done:
+			return refresh.err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	specResponse, err := s.specProvider.Spec(ctx, &api.SpecOpts{})
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to obtain spec")
+		err = errors.Wrap(err, "failed to obtain spec")
+	} else {
+		current := s.forkSchedule.Load()
+		incoming := forkScheduleFromSpec(specResponse.Data)
+		var next *forkSchedule
+		cloneCurrent := func() {
+			if next == nil {
+				next = &forkSchedule{
+					epochs:    maps.Clone(current.epochs),
+					malformed: maps.Clone(current.malformed),
+				}
+			}
+		}
+		for name, epoch := range incoming.epochs {
+			if currentEpoch, exists := current.epochs[name]; exists {
+				if currentEpoch == epoch {
+					continue
+				}
+				now := s.CurrentEpoch()
+				if currentEpoch <= now || epoch <= now {
+					continue
+				}
+			}
+			cloneCurrent()
+			next.epochs[name] = epoch
+			delete(next.malformed, name)
+		}
+		for name := range incoming.malformed {
+			if _, exists := current.epochs[name]; exists {
+				continue
+			}
+			if _, exists := current.malformed[name]; exists {
+				continue
+			}
+			cloneCurrent()
+			next.malformed[name] = struct{}{}
+		}
+		if next != nil {
+			s.forkSchedule.Store(next)
+		}
 	}
-	spec := specResponse.Data
 
-	tmp, exists := spec[hardForkName]
-	if !exists {
-		return 0, fmt.Errorf("%s version not known by chain", hardForkName)
-	}
-	epoch, isEpoch := tmp.(uint64)
-	if !isEpoch {
-		return 0, fmt.Errorf("%s is not a uint64", hardForkName)
-	}
+	refresh.err = err
+	s.forkScheduleGeneration.CompareAndSwap(generation, &forkScheduleGeneration{})
+	close(refresh.done)
 
-	return phase0.Epoch(epoch), nil
+	return err
 }

--- a/services/chaintime/standard/service.go
+++ b/services/chaintime/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -168,6 +168,7 @@ func (s *Service) HardForkEpoch(ctx context.Context, hardForkName string) phase0
 	}
 
 	generation := s.forkScheduleGeneration.Load()
+	// A concurrent refresh may have published the requested fork before we captured its generation.
 	forkSchedule = s.forkSchedule.Load()
 	if forkEpoch, exists := forkSchedule.epochs[hardForkName]; exists {
 		return forkEpoch
@@ -214,6 +215,7 @@ func forkScheduleFromSpec(spec map[string]any) forkSchedule {
 }
 
 func (s *Service) refreshForkSchedule(ctx context.Context, generation *forkScheduleGeneration) error {
+	// Each generation admits one provider request; other callers reuse its result.
 	if generation == nil {
 		generation = &forkScheduleGeneration{}
 		if !s.forkScheduleGeneration.CompareAndSwap(nil, generation) {
@@ -246,47 +248,59 @@ func (s *Service) refreshForkSchedule(ctx context.Context, generation *forkSched
 	} else {
 		current := s.forkSchedule.Load()
 		incoming := forkScheduleFromSpec(specResponse.Data)
-		var next *forkSchedule
-		cloneCurrent := func() {
-			if next == nil {
-				next = &forkSchedule{
-					epochs:    maps.Clone(current.epochs),
-					malformed: maps.Clone(current.malformed),
-				}
-			}
-		}
-		for name, epoch := range incoming.epochs {
-			if currentEpoch, exists := current.epochs[name]; exists {
-				if currentEpoch == epoch {
-					continue
-				}
-				now := s.CurrentEpoch()
-				if currentEpoch <= now || epoch <= now {
-					continue
-				}
-			}
-			cloneCurrent()
-			next.epochs[name] = epoch
-			delete(next.malformed, name)
-		}
-		for name := range incoming.malformed {
-			if _, exists := current.epochs[name]; exists {
-				continue
-			}
-			if _, exists := current.malformed[name]; exists {
-				continue
-			}
-			cloneCurrent()
-			next.malformed[name] = struct{}{}
-		}
+		next := mergeForkSchedule(current, incoming, s.CurrentEpoch())
 		if next != nil {
 			s.forkSchedule.Store(next)
 		}
 	}
 
 	refresh.err = err
+	// Advance the generation before waking waiters so a later miss can refresh again.
 	s.forkScheduleGeneration.CompareAndSwap(generation, &forkScheduleGeneration{})
 	close(refresh.done)
 
 	return err
+}
+
+func mergeForkSchedule(current *forkSchedule,
+	incoming forkSchedule,
+	currentEpoch phase0.Epoch,
+) *forkSchedule {
+	var next *forkSchedule
+	cloneCurrent := func() {
+		if next == nil {
+			next = &forkSchedule{
+				epochs:    maps.Clone(current.epochs),
+				malformed: maps.Clone(current.malformed),
+			}
+		}
+	}
+
+	for name, epoch := range incoming.epochs {
+		if existingEpoch, exists := current.epochs[name]; exists {
+			if existingEpoch == epoch {
+				continue
+			}
+			// Once either schedule activates a fork, retain the last-known-good boundary.
+			if existingEpoch <= currentEpoch || epoch <= currentEpoch {
+				continue
+			}
+		}
+		cloneCurrent()
+		next.epochs[name] = epoch
+		delete(next.malformed, name)
+	}
+
+	for name := range incoming.malformed {
+		if _, exists := current.epochs[name]; exists {
+			continue
+		}
+		if _, exists := current.malformed[name]; exists {
+			continue
+		}
+		cloneCurrent()
+		next.malformed[name] = struct{}{}
+	}
+
+	return next
 }

--- a/services/chaintime/standard/service_benchmark_test.go
+++ b/services/chaintime/standard/service_benchmark_test.go
@@ -1,0 +1,40 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+var benchmarkForkEpoch phase0.Epoch
+
+func BenchmarkHardForkEpoch(b *testing.B) {
+	ctx := context.Background()
+	specProvider := newMutableSpecProvider(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+		"GLOAS_FORK_EPOCH": uint64(1_000_000),
+	})
+	service := createMutableSpecService(b, specProvider)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkForkEpoch = service.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH")
+	}
+}

--- a/services/chaintime/standard/service_internal_test.go
+++ b/services/chaintime/standard/service_internal_test.go
@@ -1,0 +1,315 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+)
+
+type internalSpecProvider struct {
+	spec  map[string]any
+	err   error
+	calls atomic.Uint64
+}
+
+func (s *internalSpecProvider) Spec(_ context.Context, _ *api.SpecOpts) (*api.Response[map[string]any], error) {
+	s.calls.Add(1)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &api.Response[map[string]any]{Data: s.spec}, nil
+}
+
+type blockingInternalSpecProvider struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingInternalSpecProvider) Spec(_ context.Context, _ *api.SpecOpts) (*api.Response[map[string]any], error) {
+	close(s.entered)
+	<-s.release
+
+	return &api.Response[map[string]any]{Data: make(map[string]any)}, nil
+}
+
+func TestRefreshForkScheduleWaiterHonoursCancellation(t *testing.T) {
+	ctx := context.Background()
+	provider := &blockingInternalSpecProvider{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	schedule := forkSchedule{
+		epochs:    make(map[string]phase0.Epoch),
+		malformed: make(map[string]struct{}),
+	}
+	service := &Service{
+		genesisTime:   time.Now(),
+		slotDuration:  12 * time.Second,
+		slotsPerEpoch: 32,
+		specProvider:  provider,
+	}
+	service.forkSchedule.Store(&schedule)
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- service.refreshForkSchedule(ctx, nil)
+	}()
+	<-provider.entered
+	t.Cleanup(func() {
+		close(provider.release)
+		require.NoError(t, <-leaderDone)
+	})
+
+	waiterCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	waiterDone := make(chan error, 1)
+	go func() {
+		waiterDone <- service.refreshForkSchedule(waiterCtx, nil)
+	}()
+
+	select {
+	case err := <-waiterDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("canceled refresh waiter remained blocked")
+	}
+}
+
+func TestRefreshForkScheduleSharesCompletedGeneration(t *testing.T) {
+	ctx := context.Background()
+	provider := &internalSpecProvider{spec: make(map[string]any)}
+	schedule := forkSchedule{
+		epochs:    make(map[string]phase0.Epoch),
+		malformed: make(map[string]struct{}),
+	}
+	generation := &forkScheduleGeneration{}
+	service := &Service{
+		genesisTime:   time.Now(),
+		slotDuration:  12 * time.Second,
+		slotsPerEpoch: 32,
+		specProvider:  provider,
+	}
+	service.forkSchedule.Store(&schedule)
+	service.forkScheduleGeneration.Store(generation)
+
+	require.NoError(t, service.refreshForkSchedule(ctx, generation))
+	require.NoError(t, service.refreshForkSchedule(ctx, generation))
+	require.Equal(t, uint64(1), provider.calls.Load())
+}
+
+func TestRefreshForkScheduleCoalescesGeneration(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name        string
+		spec        map[string]any
+		providerErr error
+		expected    map[string]phase0.Epoch
+		err         string
+	}{
+		{
+			name:     "Missing",
+			spec:     make(map[string]any),
+			expected: make(map[string]phase0.Epoch),
+		},
+		{
+			name: "Discovery",
+			spec: map[string]any{
+				"FUTURE_FORK_EPOCH": uint64(2048),
+			},
+			expected: map[string]phase0.Epoch{
+				"FUTURE_FORK_EPOCH": 2048,
+			},
+		},
+		{
+			name:        "Failure",
+			spec:        make(map[string]any),
+			providerErr: errors.New("spec unavailable"),
+			expected:    make(map[string]phase0.Epoch),
+			err:         "failed to obtain spec: spec unavailable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &internalSpecProvider{spec: test.spec, err: test.providerErr}
+			schedule := forkSchedule{
+				epochs:    make(map[string]phase0.Epoch),
+				malformed: make(map[string]struct{}),
+			}
+			generation := &forkScheduleGeneration{}
+			service := &Service{
+				genesisTime:   time.Now(),
+				slotDuration:  12 * time.Second,
+				slotsPerEpoch: 32,
+				specProvider:  provider,
+			}
+			service.forkSchedule.Store(&schedule)
+			service.forkScheduleGeneration.Store(generation)
+
+			const readers = 16
+			results := make(chan error, readers)
+			for range readers {
+				go func() {
+					results <- service.refreshForkSchedule(ctx, generation)
+				}()
+			}
+			for range readers {
+				err := <-results
+				if test.err == "" {
+					require.NoError(t, err)
+				} else {
+					require.EqualError(t, err, test.err)
+				}
+			}
+
+			require.Equal(t, uint64(1), provider.calls.Load())
+			require.Equal(t, test.expected, service.forkSchedule.Load().epochs)
+		})
+	}
+}
+
+func TestRefreshForkSchedule(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		spec     map[string]any
+		expected map[string]phase0.Epoch
+		same     bool
+	}{
+		{
+			name: "Unchanged",
+			spec: map[string]any{
+				"GLOAS_FORK_EPOCH": uint64(2048),
+			},
+			expected: map[string]phase0.Epoch{
+				"GLOAS_FORK_EPOCH": phase0.Epoch(2048),
+			},
+			same: true,
+		},
+		{
+			name: "Omitted",
+			spec: make(map[string]any),
+			expected: map[string]phase0.Epoch{
+				"GLOAS_FORK_EPOCH": phase0.Epoch(2048),
+			},
+			same: true,
+		},
+		{
+			name: "Added",
+			spec: map[string]any{
+				"GLOAS_FORK_EPOCH":  uint64(2048),
+				"FUTURE_FORK_EPOCH": uint64(4096),
+			},
+			expected: map[string]phase0.Epoch{
+				"GLOAS_FORK_EPOCH":  phase0.Epoch(2048),
+				"FUTURE_FORK_EPOCH": phase0.Epoch(4096),
+			},
+		},
+		{
+			name: "Changed",
+			spec: map[string]any{
+				"GLOAS_FORK_EPOCH": uint64(4096),
+			},
+			expected: map[string]phase0.Epoch{
+				"GLOAS_FORK_EPOCH": phase0.Epoch(4096),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schedule := forkSchedule{
+				epochs: map[string]phase0.Epoch{
+					"GLOAS_FORK_EPOCH": phase0.Epoch(2048),
+				},
+				malformed: make(map[string]struct{}),
+			}
+			service := &Service{
+				genesisTime:   time.Now(),
+				slotDuration:  12 * time.Second,
+				slotsPerEpoch: 32,
+				specProvider:  &internalSpecProvider{spec: test.spec},
+			}
+			service.forkSchedule.Store(&schedule)
+			before := service.forkSchedule.Load()
+
+			require.NoError(t, service.refreshForkSchedule(ctx, nil))
+			after := service.forkSchedule.Load()
+			if test.same {
+				require.Same(t, before, after)
+			} else {
+				require.NotSame(t, before, after)
+			}
+			require.Equal(t, test.expected, after.epochs)
+		})
+	}
+}
+
+func TestRefreshForkScheduleRejectsActivatedForkChange(t *testing.T) {
+	ctx := context.Background()
+	schedule := forkSchedule{
+		epochs: map[string]phase0.Epoch{
+			"GLOAS_FORK_EPOCH": 1,
+		},
+		malformed: make(map[string]struct{}),
+	}
+	service := &Service{
+		genesisTime:   time.Now().Add(-100 * 32 * 12 * time.Second),
+		slotDuration:  12 * time.Second,
+		slotsPerEpoch: 32,
+		specProvider: &internalSpecProvider{spec: map[string]any{
+			"GLOAS_FORK_EPOCH": uint64(4096),
+		}},
+	}
+	service.forkSchedule.Store(&schedule)
+	before := service.forkSchedule.Load()
+
+	require.NoError(t, service.refreshForkSchedule(ctx, nil))
+	after := service.forkSchedule.Load()
+	require.Same(t, before, after)
+	require.Equal(t, phase0.Epoch(1), after.epochs["GLOAS_FORK_EPOCH"])
+}
+
+func TestRefreshForkScheduleRejectsRollback(t *testing.T) {
+	ctx := context.Background()
+	schedule := forkSchedule{
+		epochs: map[string]phase0.Epoch{
+			"GLOAS_FORK_EPOCH": 4096,
+		},
+		malformed: make(map[string]struct{}),
+	}
+	service := &Service{
+		genesisTime:   time.Now().Add(-100 * 32 * 12 * time.Second),
+		slotDuration:  12 * time.Second,
+		slotsPerEpoch: 32,
+		specProvider: &internalSpecProvider{spec: map[string]any{
+			"GLOAS_FORK_EPOCH": uint64(1),
+		}},
+	}
+	service.forkSchedule.Store(&schedule)
+	before := service.forkSchedule.Load()
+
+	require.NoError(t, service.refreshForkSchedule(ctx, nil))
+	after := service.forkSchedule.Load()
+	require.Same(t, before, after)
+	require.Equal(t, phase0.Epoch(4096), after.epochs["GLOAS_FORK_EPOCH"])
+}

--- a/services/chaintime/standard/service_test.go
+++ b/services/chaintime/standard/service_test.go
@@ -15,17 +15,87 @@ package standard_test
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/mock"
 	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/chaintime/standard"
+	testlogger "github.com/attestantio/vouch/testing/logger"
 	"github.com/rs/zerolog"
+	zerologger "github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 )
+
+type mutableSpecProvider struct {
+	mu       sync.RWMutex
+	response *api.Response[map[string]any]
+	err      error
+	calls    atomic.Uint64
+	entered  chan struct{}
+	release  chan struct{}
+}
+
+func (s *mutableSpecProvider) Spec(_ context.Context, _ *api.SpecOpts) (*api.Response[map[string]any], error) {
+	s.calls.Add(1)
+	s.mu.RLock()
+	response := s.response
+	err := s.err
+	entered := s.entered
+	release := s.release
+	s.mu.RUnlock()
+	if entered != nil {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+	}
+	if release != nil {
+		<-release
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func newMutableSpecProvider(spec map[string]any) *mutableSpecProvider {
+	return &mutableSpecProvider{
+		response: &api.Response[map[string]any]{Data: spec},
+	}
+}
+
+func (s *mutableSpecProvider) setSpec(spec map[string]any) {
+	s.mu.Lock()
+	s.response = &api.Response[map[string]any]{Data: spec}
+	s.mu.Unlock()
+}
+
+func (s *mutableSpecProvider) setError(err error) {
+	s.mu.Lock()
+	s.err = err
+	s.mu.Unlock()
+}
+
+func createMutableSpecService(t testing.TB, specProvider *mutableSpecProvider) chaintime.Service {
+	t.Helper()
+
+	service, err := standard.New(context.Background(),
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithGenesisProvider(mock.NewGenesisProvider(time.Now())),
+		standard.WithSpecProvider(specProvider),
+	)
+	require.NoError(t, err)
+
+	return service
+}
 
 func TestService(t *testing.T) {
 	genesisTime := time.Now()
@@ -226,4 +296,148 @@ func TestFirstSlotOfEpoch(t *testing.T) {
 			assert.Equal(t, test.slot, slot)
 		})
 	}
+}
+
+func TestHardForkEpochUsesConstructionSchedule(t *testing.T) {
+	ctx := context.Background()
+	specProvider := newMutableSpecProvider(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+		"GLOAS_FORK_EPOCH": uint64(2048),
+	})
+	service := createMutableSpecService(t, specProvider)
+
+	specProvider.setError(errors.New("spec unavailable"))
+
+	require.Equal(t, phase0.Epoch(2048), service.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH"))
+}
+
+func TestHardForkEpochRetainsDiscoveredFork(t *testing.T) {
+	ctx := context.Background()
+	specProvider := newMutableSpecProvider(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+	})
+	service := createMutableSpecService(t, specProvider)
+
+	specProvider.setSpec(map[string]any{
+		"SECONDS_PER_SLOT":  12 * time.Second,
+		"SLOTS_PER_EPOCH":   uint64(32),
+		"FUTURE_FORK_EPOCH": uint64(2048),
+	})
+	require.Equal(t, phase0.Epoch(2048), service.HardForkEpoch(ctx, "FUTURE_FORK_EPOCH"))
+
+	specProvider.setError(errors.New("spec unavailable"))
+	require.Equal(t, phase0.Epoch(2048), service.HardForkEpoch(ctx, "FUTURE_FORK_EPOCH"))
+}
+
+func TestHardForkEpochRecognisesMalformedConstructionValue(t *testing.T) {
+	ctx := context.Background()
+	oldLogger := zerologger.Logger
+	oldLogLevel := zerolog.GlobalLevel()
+	t.Cleanup(func() {
+		zerologger.Logger = oldLogger
+		zerolog.SetGlobalLevel(oldLogLevel)
+	})
+	logCapture := testlogger.NewLogCapture()
+	specProvider := newMutableSpecProvider(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+		"GLOAS_FORK_EPOCH": "2048",
+	})
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.TraceLevel),
+		standard.WithGenesisProvider(mock.NewGenesisProvider(time.Now())),
+		standard.WithSpecProvider(specProvider),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, phase0.Epoch(^uint64(0)), service.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH"))
+	require.Equal(t, uint64(1), specProvider.calls.Load())
+	require.True(t, logCapture.HasLog(map[string]any{
+		"error": "GLOAS_FORK_EPOCH is not a uint64",
+	}))
+}
+
+func TestHardForkEpochRetainsMalformedRefreshedValue(t *testing.T) {
+	ctx := context.Background()
+	specProvider := newMutableSpecProvider(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+	})
+	service := createMutableSpecService(t, specProvider)
+
+	specProvider.setSpec(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+		"GLOAS_FORK_EPOCH": "2048",
+	})
+	require.Equal(t, phase0.Epoch(^uint64(0)), service.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH"))
+
+	specProvider.setError(errors.New("spec unavailable"))
+	require.Equal(t, phase0.Epoch(^uint64(0)), service.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH"))
+	require.Equal(t, uint64(2), specProvider.calls.Load())
+}
+
+func TestHardForkEpochRetainsValidValueWhenRefreshIsMalformed(t *testing.T) {
+	ctx := context.Background()
+	specProvider := newMutableSpecProvider(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+		"GLOAS_FORK_EPOCH": uint64(2048),
+	})
+	service := createMutableSpecService(t, specProvider)
+
+	specProvider.setSpec(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+		"GLOAS_FORK_EPOCH": "2048",
+	})
+	require.Equal(t, phase0.Epoch(^uint64(0)), service.HardForkEpoch(ctx, "MISSING_FORK_EPOCH"))
+	require.Equal(t, phase0.Epoch(2048), service.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH"))
+	require.Equal(t, uint64(2), specProvider.calls.Load())
+}
+
+func TestHardForkEpochReturnsFarFutureWhenUnavailable(t *testing.T) {
+	ctx := context.Background()
+	specProvider := newMutableSpecProvider(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+	})
+	service := createMutableSpecService(t, specProvider)
+	specProvider.setError(errors.New("spec unavailable"))
+
+	require.Equal(t, phase0.Epoch(^uint64(0)), service.HardForkEpoch(ctx, "MISSING_FORK_EPOCH"))
+}
+
+func TestHardForkEpochReadersContinueDuringRefresh(t *testing.T) {
+	ctx := context.Background()
+	specProvider := newMutableSpecProvider(map[string]any{
+		"SECONDS_PER_SLOT": 12 * time.Second,
+		"SLOTS_PER_EPOCH":  uint64(32),
+		"GLOAS_FORK_EPOCH": uint64(2048),
+	})
+	service := createMutableSpecService(t, specProvider)
+
+	specProvider.entered = make(chan struct{}, 1)
+	specProvider.release = make(chan struct{})
+	refreshed := make(chan phase0.Epoch, 1)
+	go func() {
+		refreshed <- service.HardForkEpoch(ctx, "MISSING_FORK_EPOCH")
+	}()
+	<-specProvider.entered
+
+	known := make(chan phase0.Epoch, 1)
+	go func() {
+		known <- service.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH")
+	}()
+	select {
+	case epoch := <-known:
+		require.Equal(t, phase0.Epoch(2048), epoch)
+	case <-time.After(time.Second):
+		t.Fatal("known fork lookup blocked during refresh")
+	}
+
+	close(specProvider.release)
+	require.Equal(t, phase0.Epoch(^uint64(0)), <-refreshed)
 }

--- a/services/controller/standard/attester.go
+++ b/services/controller/standard/attester.go
@@ -107,7 +107,7 @@ func (s *Service) scheduleAttestations(ctx context.Context,
 		s.pendingAttestationsMutex.Unlock()
 
 		go func(duty *attester.Duty) {
-			jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.maxAttestationDelay)
+			jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.timingsForSlot(duty.Slot()).maxAttestationDelay)
 			if err := s.scheduler.ScheduleJob(ctx,
 				"Attest",
 				fmt.Sprintf("Attestations for slot %d", duty.Slot()),
@@ -232,7 +232,7 @@ func (s *Service) AttestAndScheduleAggregate(ctx context.Context, duty *attester
 			if err := s.scheduler.ScheduleJob(ctx,
 				"Aggregate attestations",
 				fmt.Sprintf("Beacon block attestation aggregation for slot %d committee %d", attestationData.Slot, committeeIndex),
-				s.chainTimeService.StartOfSlot(attestationData.Slot).Add(s.attestationAggregationDelay),
+				s.chainTimeService.StartOfSlot(attestationData.Slot).Add(s.timingsForSlot(attestationData.Slot).attestationAggregationDelay),
 				func(ctx context.Context) { s.attestationAggregator.Aggregate(ctx, aggregatorDuty) },
 			); err != nil {
 				// Don't return here; we want to try to set up as many aggregator jobs as possible.

--- a/services/controller/standard/attester.go
+++ b/services/controller/standard/attester.go
@@ -20,9 +20,12 @@ import (
 
 	"github.com/attestantio/go-eth2-client/api"
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/attestationaggregator"
 	"github.com/attestantio/vouch/services/attester"
+	"github.com/attestantio/vouch/services/beaconcommitteesubscriber"
+	"github.com/rs/zerolog"
 )
 
 // scheduleAttestations schedules attestations for the given epoch and validator indices.
@@ -172,6 +175,15 @@ func (s *Service) AttestAndScheduleAggregate(ctx context.Context, duty *attester
 		return
 	}
 
+	s.scheduleAttestationAggregations(ctx, log, epoch, subscriptionInfoMap, attestations)
+}
+
+func (s *Service) scheduleAttestationAggregations(ctx context.Context,
+	log zerolog.Logger,
+	epoch phase0.Epoch,
+	subscriptionInfoMap map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription,
+	attestations []*spec.VersionedAttestation,
+) {
 	for _, attestation := range attestations {
 		attestationData, err := attestation.Data()
 		if err != nil {

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -38,25 +38,25 @@ import (
 )
 
 type parameters struct {
-	logLevel                      zerolog.Level
 	monitor                       metrics.Service
 	specProvider                  eth2client.SpecProvider
 	chainTimeService              chaintime.Service
-	waitedForGenesis              bool
 	proposerDutiesProvider        eth2client.ProposerDutiesProvider
 	attesterDutiesProvider        eth2client.AttesterDutiesProvider
 	syncCommitteeDutiesProvider   eth2client.SyncCommitteeDutiesProvider
-	syncCommitteesSubscriber      synccommitteesubscriber.Service
 	validatingAccountsProvider    accountmanager.ValidatingAccountsProvider
+	eventsProvider                eth2client.EventsProvider
+	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
+	signedBeaconBlockProvider     eth2client.SignedBeaconBlockProvider
+	logLevel                      zerolog.Level
+	waitedForGenesis              bool
+	syncCommitteesSubscriber      synccommitteesubscriber.Service
 	proposalsPreparer             proposalpreparer.Service
 	scheduler                     scheduler.Service
-	eventsProvider                eth2client.EventsProvider
 	attester                      attester.Service
 	syncCommitteeMessenger        synccommitteemessenger.Service
 	syncCommitteeAggregator       synccommitteeaggregator.Service
 	beaconBlockProposer           beaconblockproposer.Service
-	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
-	signedBeaconBlockProvider     eth2client.SignedBeaconBlockProvider
 	attestationAggregator         attestationaggregator.Service
 	beaconCommitteeSubscriber     beaconcommitteesubscriber.Service
 	accountsRefresher             accountmanager.Refresher

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -435,11 +435,13 @@ func (p *parameters) setDefaultDelays(spec map[string]any, slotDuration time.Dur
 
 func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, gloasActive bool) dutyTimings {
 	if !gloasActive {
+		// The ratios are the pre-Gloas basis-point deadlines: ATTESTATION_DUE_BPS and
+		// SYNC_MESSAGE_DUE_BPS are 3333, AGGREGATE_DUE_BPS and CONTRIBUTION_DUE_BPS are 6667.
 		return dutyTimings{
-			maxAttestationDelay:           slotDuration / 3,
-			attestationAggregationDelay:   slotDuration * 2 / 3,
-			maxSyncCommitteeMessageDelay:  slotDuration / 3,
-			syncCommitteeAggregationDelay: slotDuration * 2 / 3,
+			maxAttestationDelay:           slotDuration / 3,     // 4s on a 12-second slot.
+			attestationAggregationDelay:   slotDuration * 2 / 3, // 8s on a 12-second slot.
+			maxSyncCommitteeMessageDelay:  slotDuration / 3,     // 4s on a 12-second slot.
+			syncCommitteeAggregationDelay: slotDuration * 2 / 3, // 8s on a 12-second slot.
 		}
 	}
 
@@ -449,13 +451,13 @@ func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, g
 		slotDuration = time.Duration(durationMS) * time.Millisecond
 	}
 
-	// dueBPS provides the deadline for the given spec value, in basis points of the slot duration,
-	// falling back to the supplied default if the value is not served or is out of range.
+	// dueBPS provides the deadline held in the named spec value, in basis points of the slot
+	// duration, falling back to the supplied default if the value is not served or is out of range.
+	// The name is the exact key: Gloas redefines these four deadlines under _GLOAS-suffixed keys and
+	// keeps serving the unsuffixed keys for the slots before the fork, so reading the unsuffixed key
+	// here would schedule post-fork duties to the deadlines the fork moved away from.
 	dueBPS := func(name string, fallback time.Duration) time.Duration {
-		bps, ok := spec[name+"_GLOAS"].(uint64)
-		if !ok {
-			bps, ok = spec[name].(uint64)
-		}
+		bps, ok := spec[name].(uint64)
 		if !ok || bps == 0 || bps > 10000 {
 			return fallback
 		}
@@ -463,10 +465,13 @@ func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, g
 		return slotDuration * time.Duration(bps) / 10000
 	}
 
+	// The fallbacks are the Gloas deadlines themselves: ATTESTATION_DUE_BPS_GLOAS and
+	// SYNC_MESSAGE_DUE_BPS_GLOAS are 2500, AGGREGATE_DUE_BPS_GLOAS and CONTRIBUTION_DUE_BPS_GLOAS
+	// are 5000.  A node that does not serve them still schedules to this fork's timings.
 	return dutyTimings{
-		maxAttestationDelay:           dueBPS("ATTESTATION_DUE_BPS", slotDuration/3),
-		attestationAggregationDelay:   dueBPS("AGGREGATE_DUE_BPS", slotDuration*2/3),
-		maxSyncCommitteeMessageDelay:  dueBPS("SYNC_MESSAGE_DUE_BPS", slotDuration/3),
-		syncCommitteeAggregationDelay: dueBPS("CONTRIBUTION_DUE_BPS", slotDuration*2/3),
+		maxAttestationDelay:           dueBPS("ATTESTATION_DUE_BPS_GLOAS", slotDuration/4),  // 3s on a 12-second slot.
+		attestationAggregationDelay:   dueBPS("AGGREGATE_DUE_BPS_GLOAS", slotDuration/2),    // 6s on a 12-second slot.
+		maxSyncCommitteeMessageDelay:  dueBPS("SYNC_MESSAGE_DUE_BPS_GLOAS", slotDuration/4), // 3s on a 12-second slot.
+		syncCommitteeAggregationDelay: dueBPS("CONTRIBUTION_DUE_BPS_GLOAS", slotDuration/2), // 6s on a 12-second slot.
 	}
 }

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -327,12 +327,13 @@ func parseAndCheckParameters(ctx context.Context, params ...Parameter) (*paramet
 	if err := parameters.validate(); err != nil {
 		return nil, err
 	}
-	slotDuration, err := parameters.slotDuration(ctx)
+	spec, slotDuration, err := parameters.slotDuration(ctx)
 	if err != nil {
 		return nil, err
 	}
 	// maxProposalDelay can be 0, so no check for it here.
-	parameters.setDefaultDelays(slotDuration)
+	gloasActive := parameters.chainTimeService.CurrentEpoch() >= parameters.chainTimeService.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH")
+	parameters.setDefaultDelays(spec, slotDuration, gloasActive)
 	// Sync committee duties provider/messenger/aggregator/subscriber are optional so no checks here.
 
 	return &parameters, nil
@@ -371,34 +372,69 @@ func (p *parameters) validate() error {
 	return nil
 }
 
-func (p *parameters) slotDuration(ctx context.Context) (time.Duration, error) {
+func (p *parameters) slotDuration(ctx context.Context) (map[string]any, time.Duration, error) {
 	specResponse, err := p.specProvider.Spec(ctx, &api.SpecOpts{})
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to obtain spec")
+		return nil, 0, errors.Wrap(err, "failed to obtain spec")
 	}
 	secondsPerSlot, exists := specResponse.Data["SECONDS_PER_SLOT"]
 	if !exists {
-		return 0, errors.New("SECONDS_PER_SLOT not found in spec")
+		return nil, 0, errors.New("SECONDS_PER_SLOT not found in spec")
 	}
 	slotDuration, ok := secondsPerSlot.(time.Duration)
 	if !ok {
-		return 0, errors.New("SECONDS_PER_SLOT of unexpected type")
+		return nil, 0, errors.New("SECONDS_PER_SLOT of unexpected type")
 	}
 
-	return slotDuration, nil
+	return specResponse.Data, slotDuration, nil
 }
 
-func (p *parameters) setDefaultDelays(slotDuration time.Duration) {
+func (p *parameters) setDefaultDelays(spec map[string]any, slotDuration time.Duration, gloasActive bool) {
+	attestationDue, aggregationDue, syncMessageDue, contributionDue := obtainAttestationTimings(spec, slotDuration, gloasActive)
 	if p.maxAttestationDelay == 0 {
-		p.maxAttestationDelay = slotDuration / 3
+		p.maxAttestationDelay = attestationDue
 	}
 	if p.attestationAggregationDelay == 0 {
-		p.attestationAggregationDelay = slotDuration * 2 / 3
+		p.attestationAggregationDelay = aggregationDue
 	}
 	if p.maxSyncCommitteeMessageDelay == 0 {
-		p.maxSyncCommitteeMessageDelay = slotDuration / 3
+		p.maxSyncCommitteeMessageDelay = syncMessageDue
 	}
 	if p.syncCommitteeAggregationDelay == 0 {
-		p.syncCommitteeAggregationDelay = slotDuration * 2 / 3
+		p.syncCommitteeAggregationDelay = contributionDue
 	}
+}
+
+func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, gloasActive bool) (time.Duration, time.Duration, time.Duration, time.Duration) {
+	attestationDue := slotDuration / 3
+	aggregationDue := slotDuration * 2 / 3
+	syncMessageDue := slotDuration / 3
+	contributionDue := slotDuration * 2 / 3
+	if !gloasActive {
+		return attestationDue, aggregationDue, syncMessageDue, contributionDue
+	}
+	if durationMS, ok := spec["SLOT_DURATION_MS"].(uint64); ok {
+		slotDuration = time.Duration(durationMS) * time.Millisecond
+	}
+	dueBPS := func(name string) (uint64, bool) {
+		if bps, ok := spec[name+"_GLOAS"].(uint64); ok {
+			return bps, true
+		}
+		bps, ok := spec[name].(uint64)
+		return bps, ok
+	}
+	if bps, ok := dueBPS("ATTESTATION_DUE_BPS"); ok {
+		attestationDue = slotDuration * time.Duration(bps) / 10000
+	}
+	if bps, ok := dueBPS("AGGREGATE_DUE_BPS"); ok {
+		aggregationDue = slotDuration * time.Duration(bps) / 10000
+	}
+	if bps, ok := dueBPS("SYNC_MESSAGE_DUE_BPS"); ok {
+		syncMessageDue = slotDuration * time.Duration(bps) / 10000
+	}
+	if bps, ok := dueBPS("CONTRIBUTION_DUE_BPS"); ok {
+		contributionDue = slotDuration * time.Duration(bps) / 10000
+	}
+
+	return attestationDue, aggregationDue, syncMessageDue, contributionDue
 }

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -66,6 +66,8 @@ type parameters struct {
 	attestationAggregationDelay   time.Duration
 	maxSyncCommitteeMessageDelay  time.Duration
 	syncCommitteeAggregationDelay time.Duration
+	preGloasTimings               dutyTimings
+	gloasTimings                  dutyTimings
 	verifySyncCommitteeInclusion  bool
 	fastTrackAttestations         bool
 	fastTrackSyncCommittees       bool
@@ -332,8 +334,7 @@ func parseAndCheckParameters(ctx context.Context, params ...Parameter) (*paramet
 		return nil, err
 	}
 	// maxProposalDelay can be 0, so no check for it here.
-	gloasActive := parameters.chainTimeService.CurrentEpoch() >= parameters.chainTimeService.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH")
-	parameters.setDefaultDelays(spec, slotDuration, gloasActive)
+	parameters.setDefaultDelays(spec, slotDuration)
 	// Sync committee duties provider/messenger/aggregator/subscriber are optional so no checks here.
 
 	return &parameters, nil
@@ -389,52 +390,83 @@ func (p *parameters) slotDuration(ctx context.Context) (map[string]any, time.Dur
 	return specResponse.Data, slotDuration, nil
 }
 
-func (p *parameters) setDefaultDelays(spec map[string]any, slotDuration time.Duration, gloasActive bool) {
-	attestationDue, aggregationDue, syncMessageDue, contributionDue := obtainAttestationTimings(spec, slotDuration, gloasActive)
-	if p.maxAttestationDelay == 0 {
-		p.maxAttestationDelay = attestationDue
+// dutyTimings holds the duty scheduling deadlines, as offsets in to the slot.
+type dutyTimings struct {
+	maxAttestationDelay           time.Duration
+	attestationAggregationDelay   time.Duration
+	maxSyncCommitteeMessageDelay  time.Duration
+	syncCommitteeAggregationDelay time.Duration
+}
+
+// applyOverrides replaces each deadline for which the operator supplied an explicit value.  An
+// explicit value is absolute: it applies on both sides of the Gloas fork, as documented for these
+// options.
+func (t *dutyTimings) applyOverrides(overrides dutyTimings) {
+	if overrides.maxAttestationDelay != 0 {
+		t.maxAttestationDelay = overrides.maxAttestationDelay
 	}
-	if p.attestationAggregationDelay == 0 {
-		p.attestationAggregationDelay = aggregationDue
+	if overrides.attestationAggregationDelay != 0 {
+		t.attestationAggregationDelay = overrides.attestationAggregationDelay
 	}
-	if p.maxSyncCommitteeMessageDelay == 0 {
-		p.maxSyncCommitteeMessageDelay = syncMessageDue
+	if overrides.maxSyncCommitteeMessageDelay != 0 {
+		t.maxSyncCommitteeMessageDelay = overrides.maxSyncCommitteeMessageDelay
 	}
-	if p.syncCommitteeAggregationDelay == 0 {
-		p.syncCommitteeAggregationDelay = contributionDue
+	if overrides.syncCommitteeAggregationDelay != 0 {
+		t.syncCommitteeAggregationDelay = overrides.syncCommitteeAggregationDelay
 	}
 }
 
-func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, gloasActive bool) (time.Duration, time.Duration, time.Duration, time.Duration) {
-	attestationDue := slotDuration / 3
-	aggregationDue := slotDuration * 2 / 3
-	syncMessageDue := slotDuration / 3
-	contributionDue := slotDuration * 2 / 3
-	if !gloasActive {
-		return attestationDue, aggregationDue, syncMessageDue, contributionDue
-	}
-	if durationMS, ok := spec["SLOT_DURATION_MS"].(uint64); ok {
-		slotDuration = time.Duration(durationMS) * time.Millisecond
-	}
-	dueBPS := func(name string) (uint64, bool) {
-		if bps, ok := spec[name+"_GLOAS"].(uint64); ok {
-			return bps, true
-		}
-		bps, ok := spec[name].(uint64)
-		return bps, ok
-	}
-	if bps, ok := dueBPS("ATTESTATION_DUE_BPS"); ok {
-		attestationDue = slotDuration * time.Duration(bps) / 10000
-	}
-	if bps, ok := dueBPS("AGGREGATE_DUE_BPS"); ok {
-		aggregationDue = slotDuration * time.Duration(bps) / 10000
-	}
-	if bps, ok := dueBPS("SYNC_MESSAGE_DUE_BPS"); ok {
-		syncMessageDue = slotDuration * time.Duration(bps) / 10000
-	}
-	if bps, ok := dueBPS("CONTRIBUTION_DUE_BPS"); ok {
-		contributionDue = slotDuration * time.Duration(bps) / 10000
+// setDefaultDelays derives both the pre-Gloas and the Gloas duty timings.  Both are derived here,
+// at construction, but which of them applies is decided per duty from that duty's slot; deciding it
+// here would freeze the process on whichever side of the fork it happened to start.
+func (p *parameters) setDefaultDelays(spec map[string]any, slotDuration time.Duration) {
+	overrides := dutyTimings{
+		maxAttestationDelay:           p.maxAttestationDelay,
+		attestationAggregationDelay:   p.attestationAggregationDelay,
+		maxSyncCommitteeMessageDelay:  p.maxSyncCommitteeMessageDelay,
+		syncCommitteeAggregationDelay: p.syncCommitteeAggregationDelay,
 	}
 
-	return attestationDue, aggregationDue, syncMessageDue, contributionDue
+	p.preGloasTimings = obtainAttestationTimings(spec, slotDuration, false)
+	p.preGloasTimings.applyOverrides(overrides)
+	p.gloasTimings = obtainAttestationTimings(spec, slotDuration, true)
+	p.gloasTimings.applyOverrides(overrides)
+}
+
+func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, gloasActive bool) dutyTimings {
+	if !gloasActive {
+		return dutyTimings{
+			maxAttestationDelay:           slotDuration / 3,
+			attestationAggregationDelay:   slotDuration * 2 / 3,
+			maxSyncCommitteeMessageDelay:  slotDuration / 3,
+			syncCommitteeAggregationDelay: slotDuration * 2 / 3,
+		}
+	}
+
+	// Gloas serves the slot duration in milliseconds, and it can differ from SECONDS_PER_SLOT.
+	// All Gloas-derived deadlines must be fractions of this value rather than of SECONDS_PER_SLOT.
+	if durationMS, ok := spec["SLOT_DURATION_MS"].(uint64); ok && durationMS != 0 {
+		slotDuration = time.Duration(durationMS) * time.Millisecond
+	}
+
+	// dueBPS provides the deadline for the given spec value, in basis points of the slot duration,
+	// falling back to the supplied default if the value is not served or is out of range.
+	dueBPS := func(name string, fallback time.Duration) time.Duration {
+		bps, ok := spec[name+"_GLOAS"].(uint64)
+		if !ok {
+			bps, ok = spec[name].(uint64)
+		}
+		if !ok || bps == 0 || bps > 10000 {
+			return fallback
+		}
+
+		return slotDuration * time.Duration(bps) / 10000
+	}
+
+	return dutyTimings{
+		maxAttestationDelay:           dueBPS("ATTESTATION_DUE_BPS", slotDuration/3),
+		attestationAggregationDelay:   dueBPS("AGGREGATE_DUE_BPS", slotDuration*2/3),
+		maxSyncCommitteeMessageDelay:  dueBPS("SYNC_MESSAGE_DUE_BPS", slotDuration/3),
+		syncCommitteeAggregationDelay: dueBPS("CONTRIBUTION_DUE_BPS", slotDuration*2/3),
+	}
 }

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -324,87 +324,81 @@ func parseAndCheckParameters(ctx context.Context, params ...Parameter) (*paramet
 		p.apply(&parameters)
 	}
 
-	if parameters.monitor == nil {
-		return nil, errors.New("no monitor specified")
+	if err := parameters.validate(); err != nil {
+		return nil, err
 	}
-	if parameters.specProvider == nil {
-		return nil, errors.New("no spec provider specified")
-	}
-	if parameters.chainTimeService == nil {
-		return nil, errors.New("no chain time service specified")
-	}
-	if parameters.proposerDutiesProvider == nil {
-		return nil, errors.New("no proposer duties provider specified")
-	}
-	if parameters.attesterDutiesProvider == nil {
-		return nil, errors.New("no attester duties provider specified")
-	}
-	if parameters.eventsProvider == nil {
-		return nil, errors.New("no events provider specified")
-	}
-	if parameters.validatingAccountsProvider == nil {
-		return nil, errors.New("no validating accounts provider specified")
-	}
-	if parameters.proposalsPreparer == nil {
-		return nil, errors.New("no proposals preparer specified")
-	}
-	if parameters.scheduler == nil {
-		return nil, errors.New("no scheduler service specified")
-	}
-	if parameters.attester == nil {
-		return nil, errors.New("no attester specified")
-	}
-	if parameters.beaconBlockProposer == nil {
-		return nil, errors.New("no beacon block proposer specified")
-	}
-	if parameters.beaconBlockHeadersProvider == nil {
-		return nil, errors.New("no beacon block headers provider specified")
-	}
-	if parameters.signedBeaconBlockProvider == nil {
-		return nil, errors.New("no signed beacon block provider specified")
-	}
-	if parameters.attestationAggregator == nil {
-		return nil, errors.New("no attestation aggregator specified")
-	}
-	if parameters.beaconCommitteeSubscriber == nil {
-		return nil, errors.New("no beacon committee subscriber specified")
-	}
-	if parameters.accountsRefresher == nil {
-		return nil, errors.New("no accounts refresher specified")
-	}
-	if parameters.blockToSlotSetter == nil {
-		return nil, errors.New("no block to slot setter specified")
-	}
-	if parameters.multiInstance == nil {
-		return nil, errors.New("no multi instance service specified")
-	}
-	specResponse, err := parameters.specProvider.Spec(ctx, &api.SpecOpts{})
+	slotDuration, err := parameters.slotDuration(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to obtain spec")
-	}
-	spec := specResponse.Data
-	tmp, exists := spec["SECONDS_PER_SLOT"]
-	if !exists {
-		return nil, errors.New("SECONDS_PER_SLOT not found in spec")
-	}
-	slotDuration, ok := tmp.(time.Duration)
-	if !ok {
-		return nil, errors.New("SECONDS_PER_SLOT of unexpected type")
+		return nil, err
 	}
 	// maxProposalDelay can be 0, so no check for it here.
-	if parameters.maxAttestationDelay == 0 {
-		parameters.maxAttestationDelay = slotDuration / 3
-	}
-	if parameters.attestationAggregationDelay == 0 {
-		parameters.attestationAggregationDelay = slotDuration * 2 / 3
-	}
-	if parameters.maxSyncCommitteeMessageDelay == 0 {
-		parameters.maxSyncCommitteeMessageDelay = slotDuration / 3
-	}
-	if parameters.syncCommitteeAggregationDelay == 0 {
-		parameters.syncCommitteeAggregationDelay = slotDuration * 2 / 3
-	}
+	parameters.setDefaultDelays(slotDuration)
 	// Sync committee duties provider/messenger/aggregator/subscriber are optional so no checks here.
 
 	return &parameters, nil
+}
+
+func (p *parameters) validate() error {
+	checks := []struct {
+		valid bool
+		err   string
+	}{
+		{p.monitor != nil, "no monitor specified"},
+		{p.specProvider != nil, "no spec provider specified"},
+		{p.chainTimeService != nil, "no chain time service specified"},
+		{p.proposerDutiesProvider != nil, "no proposer duties provider specified"},
+		{p.attesterDutiesProvider != nil, "no attester duties provider specified"},
+		{p.eventsProvider != nil, "no events provider specified"},
+		{p.validatingAccountsProvider != nil, "no validating accounts provider specified"},
+		{p.proposalsPreparer != nil, "no proposals preparer specified"},
+		{p.scheduler != nil, "no scheduler service specified"},
+		{p.attester != nil, "no attester specified"},
+		{p.beaconBlockProposer != nil, "no beacon block proposer specified"},
+		{p.beaconBlockHeadersProvider != nil, "no beacon block headers provider specified"},
+		{p.signedBeaconBlockProvider != nil, "no signed beacon block provider specified"},
+		{p.attestationAggregator != nil, "no attestation aggregator specified"},
+		{p.beaconCommitteeSubscriber != nil, "no beacon committee subscriber specified"},
+		{p.accountsRefresher != nil, "no accounts refresher specified"},
+		{p.blockToSlotSetter != nil, "no block to slot setter specified"},
+		{p.multiInstance != nil, "no multi instance service specified"},
+	}
+	for _, check := range checks {
+		if !check.valid {
+			return errors.New(check.err)
+		}
+	}
+
+	return nil
+}
+
+func (p *parameters) slotDuration(ctx context.Context) (time.Duration, error) {
+	specResponse, err := p.specProvider.Spec(ctx, &api.SpecOpts{})
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to obtain spec")
+	}
+	secondsPerSlot, exists := specResponse.Data["SECONDS_PER_SLOT"]
+	if !exists {
+		return 0, errors.New("SECONDS_PER_SLOT not found in spec")
+	}
+	slotDuration, ok := secondsPerSlot.(time.Duration)
+	if !ok {
+		return 0, errors.New("SECONDS_PER_SLOT of unexpected type")
+	}
+
+	return slotDuration, nil
+}
+
+func (p *parameters) setDefaultDelays(slotDuration time.Duration) {
+	if p.maxAttestationDelay == 0 {
+		p.maxAttestationDelay = slotDuration / 3
+	}
+	if p.attestationAggregationDelay == 0 {
+		p.attestationAggregationDelay = slotDuration * 2 / 3
+	}
+	if p.maxSyncCommitteeMessageDelay == 0 {
+		p.maxSyncCommitteeMessageDelay = slotDuration / 3
+	}
+	if p.syncCommitteeAggregationDelay == 0 {
+		p.syncCommitteeAggregationDelay = slotDuration * 2 / 3
+	}
 }

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -53,15 +53,17 @@ var syncCommitteePreparationEpochs = uint64(5)
 type Service struct {
 	log                           zerolog.Logger
 	monitor                       metrics.Service
-	slotDuration                  time.Duration
-	slotsPerEpoch                 uint64
-	epochsPerSyncCommitteePeriod  uint64
 	chainTimeService              chaintime.Service
-	waitedForGenesis              bool
 	proposerDutiesProvider        eth2client.ProposerDutiesProvider
 	attesterDutiesProvider        eth2client.AttesterDutiesProvider
 	syncCommitteeDutiesProvider   eth2client.SyncCommitteeDutiesProvider
 	validatingAccountsProvider    accountmanager.ValidatingAccountsProvider
+	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
+	signedBeaconBlockProvider     eth2client.SignedBeaconBlockProvider
+	slotDuration                  time.Duration
+	slotsPerEpoch                 uint64
+	epochsPerSyncCommitteePeriod  uint64
+	waitedForGenesis              bool
 	proposalsPreparer             proposalpreparer.Service
 	scheduler                     scheduler.Service
 	attester                      attester.Service
@@ -69,13 +71,10 @@ type Service struct {
 	syncCommitteeAggregator       synccommitteeaggregator.Service
 	syncCommitteesSubscriber      synccommitteesubscriber.Service
 	beaconBlockProposer           beaconblockproposer.Service
-	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
-	signedBeaconBlockProvider     eth2client.SignedBeaconBlockProvider
 	attestationAggregator         attestationaggregator.Service
 	beaconCommitteeSubscriber     beaconcommitteesubscriber.Service
 	activeValidators              int
 	subscriptionInfos             map[phase0.Epoch]map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription
-	subscriptionInfosMutex        sync.Mutex
 	accountsRefresher             accountmanager.Refresher
 	blockToSlotSetter             cache.BlockRootToSlotSetter
 	maxProposalDelay              time.Duration
@@ -88,7 +87,6 @@ type Service struct {
 	fastTrackSyncCommittees       bool
 	fastTrackGrace                time.Duration
 	multiInstance                 multiinstance.Service
-
 	// Hard fork control.
 	handlingAltair     bool
 	altairForkEpoch    phase0.Epoch
@@ -97,15 +95,14 @@ type Service struct {
 	capellaForkEpoch   phase0.Epoch
 	handlingElectra    bool
 	electraForkEpoch   phase0.Epoch
-
 	// Tracking for reorgs.
 	lastBlockRoot             phase0.Root
 	lastBlockEpoch            phase0.Epoch
 	currentDutyDependentRoot  phase0.Root
 	previousDutyDependentRoot phase0.Root
-
 	// Tracking for attestations.
 	pendingAttestations      map[phase0.Slot]bool
+	subscriptionInfosMutex   sync.Mutex
 	pendingAttestationsMutex sync.RWMutex
 }
 
@@ -273,9 +270,9 @@ func (s *Service) startTickers(ctx context.Context,
 }
 
 type epochTickerData struct {
-	mutex          sync.Mutex
 	latestEpochRan int64
 	atGenesis      bool
+	mutex          sync.Mutex
 }
 
 // startEpochTicker starts a ticker that ticks at the beginning of each epoch.

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -51,42 +51,40 @@ var syncCommitteePreparationEpochs = uint64(5)
 // It runs purely against clock events, setting up jobs for the validator's processes of block proposal, attestation
 // creation and attestation aggregation.
 type Service struct {
-	log                           zerolog.Logger
-	monitor                       metrics.Service
-	chainTimeService              chaintime.Service
-	proposerDutiesProvider        eth2client.ProposerDutiesProvider
-	attesterDutiesProvider        eth2client.AttesterDutiesProvider
-	syncCommitteeDutiesProvider   eth2client.SyncCommitteeDutiesProvider
-	validatingAccountsProvider    accountmanager.ValidatingAccountsProvider
-	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
-	signedBeaconBlockProvider     eth2client.SignedBeaconBlockProvider
-	slotDuration                  time.Duration
-	slotsPerEpoch                 uint64
-	epochsPerSyncCommitteePeriod  uint64
-	waitedForGenesis              bool
-	proposalsPreparer             proposalpreparer.Service
-	scheduler                     scheduler.Service
-	attester                      attester.Service
-	syncCommitteeMessenger        synccommitteemessenger.Service
-	syncCommitteeAggregator       synccommitteeaggregator.Service
-	syncCommitteesSubscriber      synccommitteesubscriber.Service
-	beaconBlockProposer           beaconblockproposer.Service
-	attestationAggregator         attestationaggregator.Service
-	beaconCommitteeSubscriber     beaconcommitteesubscriber.Service
-	activeValidators              int
-	subscriptionInfos             map[phase0.Epoch]map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription
-	accountsRefresher             accountmanager.Refresher
-	blockToSlotSetter             cache.BlockRootToSlotSetter
-	maxProposalDelay              time.Duration
-	maxAttestationDelay           time.Duration
-	attestationAggregationDelay   time.Duration
-	maxSyncCommitteeMessageDelay  time.Duration
-	syncCommitteeAggregationDelay time.Duration
-	verifySyncCommitteeInclusion  bool
-	fastTrackAttestations         bool
-	fastTrackSyncCommittees       bool
-	fastTrackGrace                time.Duration
-	multiInstance                 multiinstance.Service
+	log                          zerolog.Logger
+	monitor                      metrics.Service
+	chainTimeService             chaintime.Service
+	proposerDutiesProvider       eth2client.ProposerDutiesProvider
+	attesterDutiesProvider       eth2client.AttesterDutiesProvider
+	syncCommitteeDutiesProvider  eth2client.SyncCommitteeDutiesProvider
+	validatingAccountsProvider   accountmanager.ValidatingAccountsProvider
+	beaconBlockHeadersProvider   eth2client.BeaconBlockHeadersProvider
+	signedBeaconBlockProvider    eth2client.SignedBeaconBlockProvider
+	slotDuration                 time.Duration
+	slotsPerEpoch                uint64
+	epochsPerSyncCommitteePeriod uint64
+	waitedForGenesis             bool
+	proposalsPreparer            proposalpreparer.Service
+	scheduler                    scheduler.Service
+	attester                     attester.Service
+	syncCommitteeMessenger       synccommitteemessenger.Service
+	syncCommitteeAggregator      synccommitteeaggregator.Service
+	syncCommitteesSubscriber     synccommitteesubscriber.Service
+	beaconBlockProposer          beaconblockproposer.Service
+	attestationAggregator        attestationaggregator.Service
+	beaconCommitteeSubscriber    beaconcommitteesubscriber.Service
+	activeValidators             int
+	subscriptionInfos            map[phase0.Epoch]map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription
+	accountsRefresher            accountmanager.Refresher
+	blockToSlotSetter            cache.BlockRootToSlotSetter
+	maxProposalDelay             time.Duration
+	preGloasTimings              dutyTimings
+	gloasTimings                 dutyTimings
+	verifySyncCommitteeInclusion bool
+	fastTrackAttestations        bool
+	fastTrackSyncCommittees      bool
+	fastTrackGrace               time.Duration
+	multiInstance                multiinstance.Service
 	// Hard fork control.
 	handlingAltair     bool
 	altairForkEpoch    phase0.Epoch
@@ -95,6 +93,7 @@ type Service struct {
 	capellaForkEpoch   phase0.Epoch
 	handlingElectra    bool
 	electraForkEpoch   phase0.Epoch
+	gloasForkEpoch     phase0.Epoch
 	// Tracking for reorgs.
 	lastBlockRoot             phase0.Root
 	lastBlockEpoch            phase0.Epoch
@@ -131,50 +130,50 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	handlingBellatrix, bellatrixForkEpoch := bellatrixDetails(ctx, log, parameters.specProvider)
 	capellaForkEpoch := capellaDetails(ctx, log, parameters.specProvider)
 	handlingElectra, electraForkEpoch := electraDetails(ctx, log, parameters.chainTimeService)
+	gloasForkEpoch := gloasDetails(ctx, log, parameters.chainTimeService)
 
 	s := &Service{
-		log:                           log,
-		monitor:                       parameters.monitor,
-		slotDuration:                  slotDuration,
-		slotsPerEpoch:                 slotsPerEpoch,
-		epochsPerSyncCommitteePeriod:  epochsPerSyncCommitteePeriod,
-		chainTimeService:              parameters.chainTimeService,
-		proposerDutiesProvider:        parameters.proposerDutiesProvider,
-		attesterDutiesProvider:        parameters.attesterDutiesProvider,
-		syncCommitteeDutiesProvider:   parameters.syncCommitteeDutiesProvider,
-		syncCommitteesSubscriber:      parameters.syncCommitteesSubscriber,
-		validatingAccountsProvider:    parameters.validatingAccountsProvider,
-		proposalsPreparer:             parameters.proposalsPreparer,
-		scheduler:                     parameters.scheduler,
-		attester:                      parameters.attester,
-		syncCommitteeMessenger:        parameters.syncCommitteeMessenger,
-		syncCommitteeAggregator:       parameters.syncCommitteeAggregator,
-		beaconBlockProposer:           parameters.beaconBlockProposer,
-		beaconBlockHeadersProvider:    parameters.beaconBlockHeadersProvider,
-		signedBeaconBlockProvider:     parameters.signedBeaconBlockProvider,
-		attestationAggregator:         parameters.attestationAggregator,
-		beaconCommitteeSubscriber:     parameters.beaconCommitteeSubscriber,
-		accountsRefresher:             parameters.accountsRefresher,
-		blockToSlotSetter:             parameters.blockToSlotSetter,
-		maxProposalDelay:              parameters.maxProposalDelay,
-		maxAttestationDelay:           parameters.maxAttestationDelay,
-		attestationAggregationDelay:   parameters.attestationAggregationDelay,
-		maxSyncCommitteeMessageDelay:  parameters.maxSyncCommitteeMessageDelay,
-		syncCommitteeAggregationDelay: parameters.syncCommitteeAggregationDelay,
-		verifySyncCommitteeInclusion:  parameters.verifySyncCommitteeInclusion,
-		fastTrackAttestations:         parameters.fastTrackAttestations,
-		fastTrackSyncCommittees:       parameters.fastTrackSyncCommittees,
-		fastTrackGrace:                parameters.fastTrackGrace,
-		multiInstance:                 parameters.multiInstance,
-		subscriptionInfos:             make(map[phase0.Epoch]map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription),
-		handlingAltair:                handlingAltair,
-		altairForkEpoch:               altairForkEpoch,
-		handlingBellatrix:             handlingBellatrix,
-		bellatrixForkEpoch:            bellatrixForkEpoch,
-		capellaForkEpoch:              capellaForkEpoch,
-		handlingElectra:               handlingElectra,
-		electraForkEpoch:              electraForkEpoch,
-		pendingAttestations:           make(map[phase0.Slot]bool),
+		log:                          log,
+		monitor:                      parameters.monitor,
+		slotDuration:                 slotDuration,
+		slotsPerEpoch:                slotsPerEpoch,
+		epochsPerSyncCommitteePeriod: epochsPerSyncCommitteePeriod,
+		chainTimeService:             parameters.chainTimeService,
+		proposerDutiesProvider:       parameters.proposerDutiesProvider,
+		attesterDutiesProvider:       parameters.attesterDutiesProvider,
+		syncCommitteeDutiesProvider:  parameters.syncCommitteeDutiesProvider,
+		syncCommitteesSubscriber:     parameters.syncCommitteesSubscriber,
+		validatingAccountsProvider:   parameters.validatingAccountsProvider,
+		proposalsPreparer:            parameters.proposalsPreparer,
+		scheduler:                    parameters.scheduler,
+		attester:                     parameters.attester,
+		syncCommitteeMessenger:       parameters.syncCommitteeMessenger,
+		syncCommitteeAggregator:      parameters.syncCommitteeAggregator,
+		beaconBlockProposer:          parameters.beaconBlockProposer,
+		beaconBlockHeadersProvider:   parameters.beaconBlockHeadersProvider,
+		signedBeaconBlockProvider:    parameters.signedBeaconBlockProvider,
+		attestationAggregator:        parameters.attestationAggregator,
+		beaconCommitteeSubscriber:    parameters.beaconCommitteeSubscriber,
+		accountsRefresher:            parameters.accountsRefresher,
+		blockToSlotSetter:            parameters.blockToSlotSetter,
+		maxProposalDelay:             parameters.maxProposalDelay,
+		preGloasTimings:              parameters.preGloasTimings,
+		gloasTimings:                 parameters.gloasTimings,
+		verifySyncCommitteeInclusion: parameters.verifySyncCommitteeInclusion,
+		fastTrackAttestations:        parameters.fastTrackAttestations,
+		fastTrackSyncCommittees:      parameters.fastTrackSyncCommittees,
+		fastTrackGrace:               parameters.fastTrackGrace,
+		multiInstance:                parameters.multiInstance,
+		subscriptionInfos:            make(map[phase0.Epoch]map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription),
+		handlingAltair:               handlingAltair,
+		altairForkEpoch:              altairForkEpoch,
+		handlingBellatrix:            handlingBellatrix,
+		bellatrixForkEpoch:           bellatrixForkEpoch,
+		capellaForkEpoch:             capellaForkEpoch,
+		handlingElectra:              handlingElectra,
+		electraForkEpoch:             electraForkEpoch,
+		gloasForkEpoch:               gloasForkEpoch,
+		pendingAttestations:          make(map[phase0.Slot]bool),
 	}
 
 	// Subscribe to head events.  This allows us to go early for attestations if a block arrives, as well as
@@ -666,6 +665,29 @@ func altairDetails(ctx context.Context, log zerolog.Logger, specProvider eth2cli
 		log.Debug().Msg("Not handling Altair")
 	}
 	return handlingAltair, altairForkEpoch
+}
+
+func gloasDetails(ctx context.Context, log zerolog.Logger, chainTimeService chaintime.Service) phase0.Epoch {
+	// Fetch the gloas fork epoch from the fork schedule.
+	gloasForkEpoch := chainTimeService.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH")
+	if gloasForkEpoch == 0xffffffffffffffff {
+		log.Debug().Msg("Not handling Gloas")
+	} else {
+		log.Trace().Uint64("epoch", uint64(gloasForkEpoch)).Msg("Obtained Gloas fork epoch")
+	}
+
+	return gloasForkEpoch
+}
+
+// timingsForSlot provides the duty timings that apply at the given slot.  The decision is made per
+// duty rather than once at startup, because duties are scheduled up to an epoch ahead and a process
+// that starts before the fork must still schedule post-fork duties to the post-fork deadlines.
+func (s *Service) timingsForSlot(slot phase0.Slot) *dutyTimings {
+	if s.chainTimeService.SlotToEpoch(slot) >= s.gloasForkEpoch {
+		return &s.gloasTimings
+	}
+
+	return &s.preGloasTimings
 }
 
 func electraDetails(ctx context.Context, log zerolog.Logger, chainTimeService chaintime.Service) (bool, phase0.Epoch) {

--- a/services/controller/standard/synccommitteemessenger.go
+++ b/services/controller/standard/synccommitteemessenger.go
@@ -1,4 +1,4 @@
-// Copyright © 2021, 2024 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/services/controller/standard/synccommitteemessenger.go
+++ b/services/controller/standard/synccommitteemessenger.go
@@ -148,7 +148,7 @@ func (s *Service) prepareMessageSyncCommittee(ctx context.Context, duty *synccom
 	}
 
 	// At this point we can schedule the message job.
-	jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.maxSyncCommitteeMessageDelay)
+	jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.timingsForSlot(duty.Slot()).maxSyncCommitteeMessageDelay)
 	if err := s.scheduler.ScheduleJob(ctx,
 		"Generate sync committee messages",
 		fmt.Sprintf("Sync committee messages for slot %d", duty.Slot()),
@@ -193,7 +193,7 @@ func (s *Service) messageSyncCommittee(ctx context.Context, duty *synccommitteem
 		if err := s.scheduler.ScheduleJob(ctx,
 			"Aggregate sync committee messages",
 			fmt.Sprintf("Sync committee aggregation for slot %d", duty.Slot()),
-			s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.syncCommitteeAggregationDelay),
+			s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.timingsForSlot(duty.Slot()).syncCommitteeAggregationDelay),
 			func(ctx context.Context) { s.syncCommitteeAggregator.Aggregate(ctx, aggregatorDuty) },
 		); err != nil {
 			log.Error().Err(err).Msg("Failed to schedule sync committee attestation aggregation job")

--- a/services/controller/standard/timing_internal_test.go
+++ b/services/controller/standard/timing_internal_test.go
@@ -12,6 +12,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// gloasDevnet8Spec is the Glamsterdam devnet-8 configuration, as served by
+// https://beacon.glamsterdam-devnet-8.ethpandaops.io/eth/v1/config/spec.  It matches the
+// consensus-specs v1.7.0-alpha.13 mainnet configuration for every value used here.
+func gloasDevnet8Spec() map[string]any {
+	return map[string]any{
+		"SLOT_DURATION_MS":            uint64(12000),
+		"ATTESTATION_DUE_BPS":         uint64(3333),
+		"ATTESTATION_DUE_BPS_GLOAS":   uint64(2500),
+		"AGGREGATE_DUE_BPS":           uint64(6667),
+		"AGGREGATE_DUE_BPS_GLOAS":     uint64(5000),
+		"SYNC_MESSAGE_DUE_BPS":        uint64(3333),
+		"SYNC_MESSAGE_DUE_BPS_GLOAS":  uint64(2500),
+		"CONTRIBUTION_DUE_BPS":        uint64(6667),
+		"CONTRIBUTION_DUE_BPS_GLOAS":  uint64(5000),
+		"PAYLOAD_DUE_BPS":             uint64(5000),
+		"PAYLOAD_ATTESTATION_DUE_BPS": uint64(7500),
+	}
+}
+
+// TestGloasSpecConformance pins the derived deadlines to the values the Gloas specification
+// mandates, rather than to the formula the derivation itself uses.  The slot anatomy at mainnet
+// parameters is propose at 0s, attest at 3s, reveal the payload at 6s, and vote on it at 9s.
+func TestGloasSpecConformance(t *testing.T) {
+	timings := obtainAttestationTimings(gloasDevnet8Spec(), 12*time.Second, true)
+
+	require.Equal(t, 3*time.Second, timings.maxAttestationDelay)
+	require.Equal(t, 6*time.Second, timings.attestationAggregationDelay)
+	require.Equal(t, 3*time.Second, timings.maxSyncCommitteeMessageDelay)
+	require.Equal(t, 6*time.Second, timings.syncCommitteeAggregationDelay)
+}
+
+// TestObtainAttestationTimingsIgnoresPreGloasKeys confirms that the unsuffixed keys do not reach the
+// Gloas deadlines.  Devnet-7 served ATTESTATION_DUE_BPS_GLOAS but none of the other three suffixed
+// keys, so reading the unsuffixed key as a fallback scheduled aggregation at the pre-Gloas 8.0004s
+// rather than at the 6s that Gloas requires.
+func TestObtainAttestationTimingsIgnoresPreGloasKeys(t *testing.T) {
+	devnet7 := map[string]any{
+		"SLOT_DURATION_MS":          uint64(12000),
+		"ATTESTATION_DUE_BPS":       uint64(3333),
+		"ATTESTATION_DUE_BPS_GLOAS": uint64(2500),
+		"AGGREGATE_DUE_BPS":         uint64(6667),
+		"SYNC_MESSAGE_DUE_BPS":      uint64(3333),
+		"CONTRIBUTION_DUE_BPS":      uint64(6667),
+	}
+
+	timings := obtainAttestationTimings(devnet7, 12*time.Second, true)
+
+	require.Equal(t, 3*time.Second, timings.maxAttestationDelay)
+	require.Equal(t, 6*time.Second, timings.attestationAggregationDelay)
+	require.Equal(t, 3*time.Second, timings.maxSyncCommitteeMessageDelay)
+	require.Equal(t, 6*time.Second, timings.syncCommitteeAggregationDelay)
+}
+
 func TestObtainAttestationTimings(t *testing.T) {
 	slotDuration := 12 * time.Second
 
@@ -25,10 +78,8 @@ func TestObtainAttestationTimings(t *testing.T) {
 		gloasActive          bool
 	}{
 		{
-			// The plain key names are what /eth/v1/config/spec serves for values introduced at
-			// Gloas, so they are the branch exercised against a real beacon node.
 			name:                 "served values",
-			spec:                 map[string]any{"SLOT_DURATION_MS": uint64(12000), "ATTESTATION_DUE_BPS": uint64(2500), "AGGREGATE_DUE_BPS": uint64(5000), "SYNC_MESSAGE_DUE_BPS": uint64(1250), "CONTRIBUTION_DUE_BPS": uint64(8750)},
+			spec:                 map[string]any{"SLOT_DURATION_MS": uint64(12000), "ATTESTATION_DUE_BPS_GLOAS": uint64(2500), "AGGREGATE_DUE_BPS_GLOAS": uint64(5000), "SYNC_MESSAGE_DUE_BPS_GLOAS": uint64(1250), "CONTRIBUTION_DUE_BPS_GLOAS": uint64(8750)},
 			expectedAttestation:  3 * time.Second,
 			expectedAggregation:  6 * time.Second,
 			expectedSyncMessage:  1500 * time.Millisecond,
@@ -36,50 +87,45 @@ func TestObtainAttestationTimings(t *testing.T) {
 			gloasActive:          true,
 		},
 		{
-			name:                 "fork-suffixed values take precedence",
-			spec:                 map[string]any{"ATTESTATION_DUE_BPS": uint64(2500), "ATTESTATION_DUE_BPS_GLOAS": uint64(5000)},
-			expectedAttestation:  6 * time.Second,
-			expectedAggregation:  8 * time.Second,
-			expectedSyncMessage:  4 * time.Second,
-			expectedContribution: 8 * time.Second,
-			gloasActive:          true,
-		},
-		{
-			name:                 "attestation fallback",
-			spec:                 map[string]any{"AGGREGATE_DUE_BPS": uint64(7500)},
-			expectedAttestation:  4 * time.Second,
-			expectedAggregation:  9 * time.Second,
-			expectedSyncMessage:  4 * time.Second,
-			expectedContribution: 8 * time.Second,
+			// A served value that is not a whole number of milliseconds of the slot is used as-is,
+			// rather than being rounded to the nearest ratio.
+			name:                 "served values need not be round",
+			spec:                 map[string]any{"ATTESTATION_DUE_BPS_GLOAS": uint64(3333)},
+			expectedAttestation:  3999600 * time.Microsecond,
+			expectedAggregation:  6 * time.Second,
+			expectedSyncMessage:  3 * time.Second,
+			expectedContribution: 6 * time.Second,
 			gloasActive:          true,
 		},
 		{
 			name:                 "aggregation fallback",
-			spec:                 map[string]any{"ATTESTATION_DUE_BPS": uint64(2500)},
-			expectedAttestation:  3 * time.Second,
-			expectedAggregation:  8 * time.Second,
-			expectedSyncMessage:  4 * time.Second,
-			expectedContribution: 8 * time.Second,
+			spec:                 map[string]any{"ATTESTATION_DUE_BPS_GLOAS": uint64(1250)},
+			expectedAttestation:  1500 * time.Millisecond,
+			expectedAggregation:  6 * time.Second,
+			expectedSyncMessage:  3 * time.Second,
+			expectedContribution: 6 * time.Second,
 			gloasActive:          true,
 		},
 		{
+			// The fallbacks are the Gloas deadlines, not the pre-Gloas ones, so a node that serves
+			// none of the values still schedules to this fork's timings.
 			name:                 "all fallbacks",
 			spec:                 map[string]any{},
-			expectedAttestation:  4 * time.Second,
-			expectedAggregation:  8 * time.Second,
-			expectedSyncMessage:  4 * time.Second,
-			expectedContribution: 8 * time.Second,
+			expectedAttestation:  3 * time.Second,
+			expectedAggregation:  6 * time.Second,
+			expectedSyncMessage:  3 * time.Second,
+			expectedContribution: 6 * time.Second,
 			gloasActive:          true,
 		},
 		{
 			// A zero or above-range basis-point value would otherwise schedule the duty at the
 			// start of the slot, or after the slot has ended.
 			name:                 "out of range values ignored",
-			spec:                 map[string]any{"ATTESTATION_DUE_BPS": uint64(0), "AGGREGATE_DUE_BPS": uint64(10001)},
-			expectedAttestation:  4 * time.Second,
-			expectedAggregation:  8 * time.Second,
-			expectedSyncMessage:  4 * time.Second,
-			expectedContribution: 8 * time.Second,
+			spec:                 map[string]any{"ATTESTATION_DUE_BPS_GLOAS": uint64(0), "AGGREGATE_DUE_BPS_GLOAS": uint64(10001)},
+			expectedAttestation:  3 * time.Second,
+			expectedAggregation:  6 * time.Second,
+			expectedSyncMessage:  3 * time.Second,
+			expectedContribution: 6 * time.Second,
 			gloasActive:          true,
 		},
 		{
@@ -87,15 +133,15 @@ func TestObtainAttestationTimings(t *testing.T) {
 			// SECONDS_PER_SLOT, or they land after the end of a shortened slot.
 			name:                 "gloas slot duration drives fallbacks",
 			spec:                 map[string]any{"SLOT_DURATION_MS": uint64(6000)},
-			expectedAttestation:  2 * time.Second,
-			expectedAggregation:  4 * time.Second,
-			expectedSyncMessage:  2 * time.Second,
-			expectedContribution: 4 * time.Second,
+			expectedAttestation:  1500 * time.Millisecond,
+			expectedAggregation:  3 * time.Second,
+			expectedSyncMessage:  1500 * time.Millisecond,
+			expectedContribution: 3 * time.Second,
 			gloasActive:          true,
 		},
 		{
 			name:                 "pre-Gloas ignores served values",
-			spec:                 map[string]any{"SLOT_DURATION_MS": uint64(6000), "ATTESTATION_DUE_BPS": uint64(5000), "AGGREGATE_DUE_BPS": uint64(5000)},
+			spec:                 gloasDevnet8Spec(),
 			expectedAttestation:  4 * time.Second,
 			expectedAggregation:  8 * time.Second,
 			expectedSyncMessage:  4 * time.Second,
@@ -130,7 +176,7 @@ func TestObtainAttestationTimings(t *testing.T) {
 // TestSetDefaultDelaysOverrides confirms that an explicit operator value replaces the derived
 // deadline on both sides of the fork, and that an unset value leaves each side its own derivation.
 func TestSetDefaultDelaysOverrides(t *testing.T) {
-	spec := map[string]any{"SLOT_DURATION_MS": uint64(6000), "ATTESTATION_DUE_BPS": uint64(2500)}
+	spec := map[string]any{"SLOT_DURATION_MS": uint64(6000), "ATTESTATION_DUE_BPS_GLOAS": uint64(2500)}
 
 	t.Run("derived", func(t *testing.T) {
 		p := &parameters{}
@@ -144,9 +190,11 @@ func TestSetDefaultDelaysOverrides(t *testing.T) {
 		p.setDefaultDelays(spec, 12*time.Second)
 		require.Equal(t, 5*time.Second, p.preGloasTimings.maxAttestationDelay)
 		require.Equal(t, 5*time.Second, p.gloasTimings.maxAttestationDelay)
-		// Deadlines the operator did not set still follow their own side's derivation.
+		// Deadlines the operator did not set still follow their own side's derivation: two thirds
+		// of the 12-second SECONDS_PER_SLOT before the fork, and half of the 6-second
+		// SLOT_DURATION_MS after it.
 		require.Equal(t, 8*time.Second, p.preGloasTimings.attestationAggregationDelay)
-		require.Equal(t, 4*time.Second, p.gloasTimings.attestationAggregationDelay)
+		require.Equal(t, 3*time.Second, p.gloasTimings.attestationAggregationDelay)
 	})
 }
 

--- a/services/controller/standard/timing_internal_test.go
+++ b/services/controller/standard/timing_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,8 +25,10 @@ func TestObtainAttestationTimings(t *testing.T) {
 		gloasActive          bool
 	}{
 		{
+			// The plain key names are what /eth/v1/config/spec serves for values introduced at
+			// Gloas, so they are the branch exercised against a real beacon node.
 			name:                 "served values",
-			spec:                 map[string]any{"SLOT_DURATION_MS": uint64(12000), "ATTESTATION_DUE_BPS_GLOAS": uint64(2500), "AGGREGATE_DUE_BPS_GLOAS": uint64(5000), "SYNC_MESSAGE_DUE_BPS_GLOAS": uint64(1250), "CONTRIBUTION_DUE_BPS_GLOAS": uint64(8750)},
+			spec:                 map[string]any{"SLOT_DURATION_MS": uint64(12000), "ATTESTATION_DUE_BPS": uint64(2500), "AGGREGATE_DUE_BPS": uint64(5000), "SYNC_MESSAGE_DUE_BPS": uint64(1250), "CONTRIBUTION_DUE_BPS": uint64(8750)},
 			expectedAttestation:  3 * time.Second,
 			expectedAggregation:  6 * time.Second,
 			expectedSyncMessage:  1500 * time.Millisecond,
@@ -32,8 +36,17 @@ func TestObtainAttestationTimings(t *testing.T) {
 			gloasActive:          true,
 		},
 		{
+			name:                 "fork-suffixed values take precedence",
+			spec:                 map[string]any{"ATTESTATION_DUE_BPS": uint64(2500), "ATTESTATION_DUE_BPS_GLOAS": uint64(5000)},
+			expectedAttestation:  6 * time.Second,
+			expectedAggregation:  8 * time.Second,
+			expectedSyncMessage:  4 * time.Second,
+			expectedContribution: 8 * time.Second,
+			gloasActive:          true,
+		},
+		{
 			name:                 "attestation fallback",
-			spec:                 map[string]any{"AGGREGATE_DUE_BPS_GLOAS": uint64(7500)},
+			spec:                 map[string]any{"AGGREGATE_DUE_BPS": uint64(7500)},
 			expectedAttestation:  4 * time.Second,
 			expectedAggregation:  9 * time.Second,
 			expectedSyncMessage:  4 * time.Second,
@@ -42,7 +55,7 @@ func TestObtainAttestationTimings(t *testing.T) {
 		},
 		{
 			name:                 "aggregation fallback",
-			spec:                 map[string]any{"ATTESTATION_DUE_BPS_GLOAS": uint64(2500)},
+			spec:                 map[string]any{"ATTESTATION_DUE_BPS": uint64(2500)},
 			expectedAttestation:  3 * time.Second,
 			expectedAggregation:  8 * time.Second,
 			expectedSyncMessage:  4 * time.Second,
@@ -59,8 +72,42 @@ func TestObtainAttestationTimings(t *testing.T) {
 			gloasActive:          true,
 		},
 		{
+			// A zero or above-range basis-point value would otherwise schedule the duty at the
+			// start of the slot, or after the slot has ended.
+			name:                 "out of range values ignored",
+			spec:                 map[string]any{"ATTESTATION_DUE_BPS": uint64(0), "AGGREGATE_DUE_BPS": uint64(10001)},
+			expectedAttestation:  4 * time.Second,
+			expectedAggregation:  8 * time.Second,
+			expectedSyncMessage:  4 * time.Second,
+			expectedContribution: 8 * time.Second,
+			gloasActive:          true,
+		},
+		{
+			// Fallback deadlines must be fractions of the Gloas slot duration, not of
+			// SECONDS_PER_SLOT, or they land after the end of a shortened slot.
+			name:                 "gloas slot duration drives fallbacks",
+			spec:                 map[string]any{"SLOT_DURATION_MS": uint64(6000)},
+			expectedAttestation:  2 * time.Second,
+			expectedAggregation:  4 * time.Second,
+			expectedSyncMessage:  2 * time.Second,
+			expectedContribution: 4 * time.Second,
+			gloasActive:          true,
+		},
+		{
 			name:                 "pre-Gloas ignores served values",
-			spec:                 map[string]any{"SLOT_DURATION_MS_GLOAS": uint64(6000), "ATTESTATION_DUE_BPS_GLOAS": uint64(5000), "AGGREGATE_DUE_BPS_GLOAS": uint64(5000)},
+			spec:                 map[string]any{"SLOT_DURATION_MS": uint64(6000), "ATTESTATION_DUE_BPS": uint64(5000), "AGGREGATE_DUE_BPS": uint64(5000)},
+			expectedAttestation:  4 * time.Second,
+			expectedAggregation:  8 * time.Second,
+			expectedSyncMessage:  4 * time.Second,
+			expectedContribution: 8 * time.Second,
+			gloasActive:          false,
+		},
+		{
+			// The pre-Gloas derivation must reproduce the 4s/8s that main.go previously supplied
+			// as hardcoded viper defaults, so that defaulting those options to 0 (and thereby
+			// letting the derivation run) leaves a 12-second chain unchanged.
+			name:                 "pre-Gloas derivation reproduces the former hardcoded defaults",
+			spec:                 map[string]any{},
 			expectedAttestation:  4 * time.Second,
 			expectedAggregation:  8 * time.Second,
 			expectedSyncMessage:  4 * time.Second,
@@ -71,11 +118,90 @@ func TestObtainAttestationTimings(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			attestation, aggregation, syncMessage, contribution := obtainAttestationTimings(test.spec, slotDuration, test.gloasActive)
-			require.Equal(t, test.expectedAttestation, attestation)
-			require.Equal(t, test.expectedAggregation, aggregation)
-			require.Equal(t, test.expectedSyncMessage, syncMessage)
-			require.Equal(t, test.expectedContribution, contribution)
+			timings := obtainAttestationTimings(test.spec, slotDuration, test.gloasActive)
+			require.Equal(t, test.expectedAttestation, timings.maxAttestationDelay)
+			require.Equal(t, test.expectedAggregation, timings.attestationAggregationDelay)
+			require.Equal(t, test.expectedSyncMessage, timings.maxSyncCommitteeMessageDelay)
+			require.Equal(t, test.expectedContribution, timings.syncCommitteeAggregationDelay)
 		})
 	}
+}
+
+// TestSetDefaultDelaysOverrides confirms that an explicit operator value replaces the derived
+// deadline on both sides of the fork, and that an unset value leaves each side its own derivation.
+func TestSetDefaultDelaysOverrides(t *testing.T) {
+	spec := map[string]any{"SLOT_DURATION_MS": uint64(6000), "ATTESTATION_DUE_BPS": uint64(2500)}
+
+	t.Run("derived", func(t *testing.T) {
+		p := &parameters{}
+		p.setDefaultDelays(spec, 12*time.Second)
+		require.Equal(t, 4*time.Second, p.preGloasTimings.maxAttestationDelay)
+		require.Equal(t, 1500*time.Millisecond, p.gloasTimings.maxAttestationDelay)
+	})
+
+	t.Run("override applies to both sides", func(t *testing.T) {
+		p := &parameters{maxAttestationDelay: 5 * time.Second}
+		p.setDefaultDelays(spec, 12*time.Second)
+		require.Equal(t, 5*time.Second, p.preGloasTimings.maxAttestationDelay)
+		require.Equal(t, 5*time.Second, p.gloasTimings.maxAttestationDelay)
+		// Deadlines the operator did not set still follow their own side's derivation.
+		require.Equal(t, 8*time.Second, p.preGloasTimings.attestationAggregationDelay)
+		require.Equal(t, 4*time.Second, p.gloasTimings.attestationAggregationDelay)
+	})
+}
+
+// slotEpochChainTime resolves slots to epochs with a fixed number of slots per epoch.  The duty
+// timing selector uses only SlotToEpoch, so the remaining methods are left unimplemented.
+type slotEpochChainTime struct {
+	chaintime.Service
+	slotsPerEpoch uint64
+}
+
+func (c *slotEpochChainTime) SlotToEpoch(slot phase0.Slot) phase0.Epoch {
+	return phase0.Epoch(uint64(slot) / c.slotsPerEpoch)
+}
+
+// TestTimingsForSlot confirms that the deadline set follows the duty's own slot.  Duties are
+// scheduled up to an epoch ahead, so a process running before the fork schedules duties on both
+// sides of it and must not apply the deadlines of the epoch it happens to be in.
+func TestTimingsForSlot(t *testing.T) {
+	const slotsPerEpoch = 32
+	const gloasForkEpoch = 5
+
+	s := &Service{
+		chainTimeService: &slotEpochChainTime{slotsPerEpoch: slotsPerEpoch},
+		gloasForkEpoch:   gloasForkEpoch,
+		preGloasTimings:  dutyTimings{maxAttestationDelay: 4 * time.Second},
+		gloasTimings:     dutyTimings{maxAttestationDelay: 3 * time.Second},
+	}
+
+	tests := []struct {
+		name     string
+		slot     phase0.Slot
+		expected time.Duration
+	}{
+		{name: "well before the fork", slot: 0, expected: 4 * time.Second},
+		{name: "last slot before the fork", slot: slotsPerEpoch*gloasForkEpoch - 1, expected: 4 * time.Second},
+		{name: "first slot of the fork", slot: slotsPerEpoch * gloasForkEpoch, expected: 3 * time.Second},
+		{name: "well after the fork", slot: slotsPerEpoch * (gloasForkEpoch + 10), expected: 3 * time.Second},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, s.timingsForSlot(test.slot).maxAttestationDelay)
+		})
+	}
+}
+
+// TestTimingsForSlotWithoutGloas confirms that a chain whose spec does not carry GLOAS_FORK_EPOCH,
+// for which HardForkEpoch returns the far future epoch, stays on the pre-Gloas deadlines.
+func TestTimingsForSlotWithoutGloas(t *testing.T) {
+	s := &Service{
+		chainTimeService: &slotEpochChainTime{slotsPerEpoch: 32},
+		gloasForkEpoch:   0xffffffffffffffff,
+		preGloasTimings:  dutyTimings{maxAttestationDelay: 4 * time.Second},
+		gloasTimings:     dutyTimings{maxAttestationDelay: 3 * time.Second},
+	}
+
+	require.Equal(t, 4*time.Second, s.timingsForSlot(0).maxAttestationDelay)
+	require.Equal(t, 4*time.Second, s.timingsForSlot(1<<40).maxAttestationDelay)
 }

--- a/services/controller/standard/timing_internal_test.go
+++ b/services/controller/standard/timing_internal_test.go
@@ -1,0 +1,81 @@
+// Copyright © 2020 - 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package standard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestObtainAttestationTimings(t *testing.T) {
+	slotDuration := 12 * time.Second
+
+	tests := []struct {
+		name                 string
+		spec                 map[string]any
+		expectedAttestation  time.Duration
+		expectedAggregation  time.Duration
+		expectedSyncMessage  time.Duration
+		expectedContribution time.Duration
+		gloasActive          bool
+	}{
+		{
+			name:                 "served values",
+			spec:                 map[string]any{"SLOT_DURATION_MS": uint64(12000), "ATTESTATION_DUE_BPS_GLOAS": uint64(2500), "AGGREGATE_DUE_BPS_GLOAS": uint64(5000), "SYNC_MESSAGE_DUE_BPS_GLOAS": uint64(1250), "CONTRIBUTION_DUE_BPS_GLOAS": uint64(8750)},
+			expectedAttestation:  3 * time.Second,
+			expectedAggregation:  6 * time.Second,
+			expectedSyncMessage:  1500 * time.Millisecond,
+			expectedContribution: 10500 * time.Millisecond,
+			gloasActive:          true,
+		},
+		{
+			name:                 "attestation fallback",
+			spec:                 map[string]any{"AGGREGATE_DUE_BPS_GLOAS": uint64(7500)},
+			expectedAttestation:  4 * time.Second,
+			expectedAggregation:  9 * time.Second,
+			expectedSyncMessage:  4 * time.Second,
+			expectedContribution: 8 * time.Second,
+			gloasActive:          true,
+		},
+		{
+			name:                 "aggregation fallback",
+			spec:                 map[string]any{"ATTESTATION_DUE_BPS_GLOAS": uint64(2500)},
+			expectedAttestation:  3 * time.Second,
+			expectedAggregation:  8 * time.Second,
+			expectedSyncMessage:  4 * time.Second,
+			expectedContribution: 8 * time.Second,
+			gloasActive:          true,
+		},
+		{
+			name:                 "all fallbacks",
+			spec:                 map[string]any{},
+			expectedAttestation:  4 * time.Second,
+			expectedAggregation:  8 * time.Second,
+			expectedSyncMessage:  4 * time.Second,
+			expectedContribution: 8 * time.Second,
+			gloasActive:          true,
+		},
+		{
+			name:                 "pre-Gloas ignores served values",
+			spec:                 map[string]any{"SLOT_DURATION_MS_GLOAS": uint64(6000), "ATTESTATION_DUE_BPS_GLOAS": uint64(5000), "AGGREGATE_DUE_BPS_GLOAS": uint64(5000)},
+			expectedAttestation:  4 * time.Second,
+			expectedAggregation:  8 * time.Second,
+			expectedSyncMessage:  4 * time.Second,
+			expectedContribution: 8 * time.Second,
+			gloasActive:          false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			attestation, aggregation, syncMessage, contribution := obtainAttestationTimings(test.spec, slotDuration, test.gloasActive)
+			require.Equal(t, test.expectedAttestation, attestation)
+			require.Equal(t, test.expectedAggregation, aggregation)
+			require.Equal(t, test.expectedSyncMessage, syncMessage)
+			require.Equal(t, test.expectedContribution, contribution)
+		})
+	}
+}

--- a/services/metrics/prometheus/service.go
+++ b/services/metrics/prometheus/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2023 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -36,7 +36,7 @@ type Service struct {
 	strategyOperationTimer   *prometheus.HistogramVec
 }
 
-// module-wide log.
+// Module-wide log.
 var log zerolog.Logger
 
 // New creates a new prometheus metrics service.

--- a/services/multiinstance/always/parameters.go
+++ b/services/multiinstance/always/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,8 +21,8 @@ import (
 )
 
 type parameters struct {
-	logLevel zerolog.Level
 	monitor  metrics.Service
+	logLevel zerolog.Level
 }
 
 // Parameter is the interface for service parameters.

--- a/services/multiinstance/staticdelay/parameters.go
+++ b/services/multiinstance/staticdelay/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2024, 2025 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -25,11 +25,11 @@ import (
 )
 
 type parameters struct {
-	logLevel                   zerolog.Level
 	monitor                    metrics.Service
 	specProvider               consensusclient.SpecProvider
 	attestationPoolProvider    consensusclient.AttestationPoolProvider
 	beaconBlockHeadersProvider consensusclient.BeaconBlockHeadersProvider
+	logLevel                   zerolog.Level
 	chainTime                  chaintime.Service
 	attesterDelay              time.Duration
 	proposerDelay              time.Duration

--- a/services/proposalpreparer/standard/parameters.go
+++ b/services/proposalpreparer/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2024 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -26,12 +26,12 @@ import (
 )
 
 type parameters struct {
-	logLevel                       zerolog.Level
 	monitor                        metrics.Service
 	chainTimeService               chaintime.Service
 	validatingAccountsProvider     accountmanager.ValidatingAccountsProvider
-	proposalPreparationsSubmitters []eth2client.ProposalPreparationsSubmitter
 	executionConfigProvider        blockrelay.ExecutionConfigProvider
+	logLevel                       zerolog.Level
+	proposalPreparationsSubmitters []eth2client.ProposalPreparationsSubmitter
 }
 
 // Parameter is the interface for service parameters.

--- a/services/proposalpreparer/standard/service.go
+++ b/services/proposalpreparer/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2024 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -30,8 +30,8 @@ type Service struct {
 	log                            zerolog.Logger
 	chainTimeService               chaintime.Service
 	validatingAccountsProvider     accountmanager.ValidatingAccountsProvider
-	proposalPreparationsSubmitters []eth2client.ProposalPreparationsSubmitter
 	executionConfigProvider        blockrelay.ExecutionConfigProvider
+	proposalPreparationsSubmitters []eth2client.ProposalPreparationsSubmitter
 }
 
 // New creates a new proposal preparer.

--- a/services/scheduler/advanced/parameters.go
+++ b/services/scheduler/advanced/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22,8 +22,8 @@ import (
 )
 
 type parameters struct {
-	logLevel zerolog.Level
 	monitor  metrics.Service
+	logLevel zerolog.Level
 }
 
 // Parameter is the interface for service parameters.

--- a/services/scheduler/advanced/service.go
+++ b/services/scheduler/advanced/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2021, 2024 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -29,11 +29,11 @@ import (
 
 // job contains control points for a job.
 type job struct {
-	// stateLock is required for active or finalised.
-	stateLock deadlock.Mutex
 	active    atomic.Bool
 	finalised atomic.Bool
 	periodic  bool
+	// stateLock is required for active or finalised.
+	stateLock deadlock.Mutex
 	cancelCh  chan struct{}
 	runCh     chan struct{}
 }

--- a/services/signer/standard/parameters.go
+++ b/services/signer/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22,11 +22,11 @@ import (
 )
 
 type parameters struct {
-	logLevel       zerolog.Level
 	monitor        metrics.SignerMonitor
-	clientMonitor  metrics.ClientMonitor
 	specProvider   eth2client.SpecProvider
 	domainProvider eth2client.DomainProvider
+	logLevel       zerolog.Level
+	clientMonitor  metrics.ClientMonitor
 }
 
 // Parameter is the interface for service parameters.

--- a/services/signer/standard/service.go
+++ b/services/signer/standard/service.go
@@ -102,30 +102,11 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 
 	// The following are optional.
-	var syncCommitteeDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_SYNC_COMMITTEE"); err == nil {
-		syncCommitteeDomainType = &tmp
-	}
-
-	var syncCommitteeSelectionProofDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF"); err == nil {
-		syncCommitteeSelectionProofDomainType = &tmp
-	}
-
-	var contributionAndProofDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_CONTRIBUTION_AND_PROOF"); err == nil {
-		contributionAndProofDomainType = &tmp
-	}
-
-	var applicationBuilderDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_APPLICATION_BUILDER"); err == nil {
-		applicationBuilderDomainType = &tmp
-	}
-
-	var blobSidecarDomainType *phase0.DomainType
-	if tmp, err := domainType(spec, "DOMAIN_BLOB_SIDECAR"); err == nil {
-		blobSidecarDomainType = &tmp
-	}
+	syncCommitteeDomainType := optionalDomainType(spec, "DOMAIN_SYNC_COMMITTEE")
+	syncCommitteeSelectionProofDomainType := optionalDomainType(spec, "DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF")
+	contributionAndProofDomainType := optionalDomainType(spec, "DOMAIN_CONTRIBUTION_AND_PROOF")
+	applicationBuilderDomainType := optionalDomainType(spec, "DOMAIN_APPLICATION_BUILDER")
+	blobSidecarDomainType := optionalDomainType(spec, "DOMAIN_BLOB_SIDECAR")
 
 	var beaconBuilderDomainType *phase0.DomainType
 	if tmp, err := domainType(spec, "DOMAIN_BEACON_BUILDER"); err == nil {
@@ -165,4 +146,14 @@ func domainType(spec map[string]interface{}, input string) (phase0.DomainType, e
 		return phase0.DomainType{}, fmt.Errorf("%v of unexpected type", input)
 	}
 	return domainType, nil
+}
+
+// optionalDomainType returns the domain type if present in the spec, otherwise nil.
+func optionalDomainType(spec map[string]interface{}, input string) *phase0.DomainType {
+	tmp, err := domainType(spec, input)
+	if err != nil {
+		return nil
+	}
+
+	return &tmp
 }

--- a/services/signer/standard/service.go
+++ b/services/signer/standard/service.go
@@ -45,7 +45,7 @@ type Service struct {
 	beaconBuilderDomainType               *phase0.DomainType
 }
 
-// module-wide log.
+// Module-wide log.
 var log zerolog.Logger
 
 // New creates a new dirk account manager.

--- a/services/signer/standard/service_test.go
+++ b/services/signer/standard/service_test.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/mock"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/services/signer/standard"
@@ -24,6 +26,21 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+type minimalSpecProvider struct{}
+
+func (*minimalSpecProvider) Spec(_ context.Context, _ *api.SpecOpts) (*api.Response[map[string]any], error) {
+	return &api.Response[map[string]any]{
+		Data: map[string]any{
+			"SLOTS_PER_EPOCH":            uint64(32),
+			"DOMAIN_BEACON_ATTESTER":     phase0.DomainType{0x01},
+			"DOMAIN_BEACON_PROPOSER":     phase0.DomainType{0x02},
+			"DOMAIN_RANDAO":              phase0.DomainType{0x03},
+			"DOMAIN_SELECTION_PROOF":     phase0.DomainType{0x04},
+			"DOMAIN_AGGREGATE_AND_PROOF": phase0.DomainType{0x05},
+		},
+	}, nil
+}
 
 func TestService(t *testing.T) {
 	specProvider := mock.NewSpecProvider()
@@ -104,4 +121,16 @@ func TestService(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServiceWithOptionalDomainsAbsent(t *testing.T) {
+	service, err := standard.New(context.Background(),
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithClientMonitor(nullmetrics.New()),
+		standard.WithSpecProvider(&minimalSpecProvider{}),
+		standard.WithDomainProvider(mock.NewDomainProvider()),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, service)
 }

--- a/services/submitter/immediate/submitexecutionpayloadenvelope.go
+++ b/services/submitter/immediate/submitexecutionpayloadenvelope.go
@@ -20,10 +20,14 @@ import (
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
 )
 
 // SubmitExecutionPayloadEnvelope submits a signed execution payload envelope.
 func (s *Service) SubmitExecutionPayloadEnvelope(ctx context.Context, opts *api.SubmitExecutionPayloadEnvelopeOpts) error {
+	ctx, span := otel.Tracer("attestantio.vouch.services.submitter.immediate").Start(ctx, "SubmitExecutionPayloadEnvelope")
+	defer span.End()
+
 	if opts == nil {
 		return errors.New("no execution payload envelope supplied")
 	}

--- a/services/submitter/immediate/submitexecutionpayloadenvelope_test.go
+++ b/services/submitter/immediate/submitexecutionpayloadenvelope_test.go
@@ -23,10 +23,22 @@ import (
 	"github.com/attestantio/vouch/services/submitter/immediate"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestSubmitExecutionPayloadEnvelope(t *testing.T) {
 	ctx := context.Background()
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracerProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		require.NoError(t, tracerProvider.Shutdown(ctx))
+	})
 	capture := &capturingExecutionPayloadEnvelopeSubmitter{}
 	service, err := immediate.New(ctx,
 		immediate.WithLogLevel(zerolog.Disabled),
@@ -45,13 +57,26 @@ func TestSubmitExecutionPayloadEnvelope(t *testing.T) {
 	opts := &api.SubmitExecutionPayloadEnvelopeOpts{}
 	require.NoError(t, service.SubmitExecutionPayloadEnvelope(ctx, opts))
 	require.Same(t, opts, capture.opts)
+
+	var envelopeSubmissionSpan sdktrace.ReadOnlySpan
+	for _, span := range spanRecorder.Ended() {
+		if span.Name() == "SubmitExecutionPayloadEnvelope" {
+			envelopeSubmissionSpan = span
+			break
+		}
+	}
+	require.NotNil(t, envelopeSubmissionSpan, "submission should create an execution payload envelope span")
+	require.Equal(t, "attestantio.vouch.services.submitter.immediate", envelopeSubmissionSpan.InstrumentationScope().Name)
+	require.Equal(t, envelopeSubmissionSpan.SpanContext(), trace.SpanFromContext(capture.ctx).SpanContext())
 }
 
 type capturingExecutionPayloadEnvelopeSubmitter struct {
+	ctx  context.Context
 	opts *api.SubmitExecutionPayloadEnvelopeOpts
 }
 
-func (s *capturingExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(_ context.Context, opts *api.SubmitExecutionPayloadEnvelopeOpts) error {
+func (s *capturingExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(ctx context.Context, opts *api.SubmitExecutionPayloadEnvelopeOpts) error {
+	s.ctx = ctx
 	s.opts = opts
 	return nil
 }

--- a/services/synccommitteeaggregator/standard/parameters.go
+++ b/services/synccommitteeaggregator/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -25,13 +25,13 @@ import (
 )
 
 type parameters struct {
-	logLevel                            zerolog.Level
 	monitor                             metrics.Service
 	specProvider                        eth2client.SpecProvider
 	beaconBlockRootProvider             eth2client.BeaconBlockRootProvider
-	contributionAndProofSigner          signer.ContributionAndProofSigner
 	validatingAccountsProvider          accountmanager.ValidatingAccountsProvider
 	syncCommitteeContributionProvider   eth2client.SyncCommitteeContributionProvider
+	logLevel                            zerolog.Level
+	contributionAndProofSigner          signer.ContributionAndProofSigner
 	syncCommitteeContributionsSubmitter submitter.SyncCommitteeContributionsSubmitter
 	chainTime                           chaintime.Service
 }

--- a/services/synccommitteeaggregator/standard/service.go
+++ b/services/synccommitteeaggregator/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2021, 2024 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -39,18 +39,18 @@ import (
 type Service struct {
 	log                                  zerolog.Logger
 	monitor                              metrics.Service
+	beaconBlockRootProvider              eth2client.BeaconBlockRootProvider
+	validatingAccountsProvider           accountmanager.ValidatingAccountsProvider
+	syncCommitteeContributionProvider    eth2client.SyncCommitteeContributionProvider
 	slotsPerEpoch                        uint64
 	syncCommitteeSize                    uint64
 	syncCommitteeSubnetCount             uint64
 	targetAggregatorsPerSyncSubcommittee uint64
-	beaconBlockRootProvider              eth2client.BeaconBlockRootProvider
 	contributionAndProofSigner           signer.ContributionAndProofSigner
-	validatingAccountsProvider           accountmanager.ValidatingAccountsProvider
-	syncCommitteeContributionProvider    eth2client.SyncCommitteeContributionProvider
 	syncCommitteeContributionsSubmitter  eth2client.SyncCommitteeContributionsSubmitter
 	beaconBlockRoots                     map[phase0.Slot]phase0.Root
-	beaconBlockRootsMu                   sync.Mutex
 	chainTime                            chaintime.Service
+	beaconBlockRootsMu                   sync.Mutex
 }
 
 // New creates a new sync committee aggregator.

--- a/services/synccommitteemessenger/standard/parameters.go
+++ b/services/synccommitteemessenger/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -27,15 +27,15 @@ import (
 )
 
 type parameters struct {
-	logLevel                            zerolog.Level
-	processConcurrency                  int64
 	monitor                             metrics.Service
 	chainTimeService                    chaintime.Service
-	syncCommitteeAggregator             synccommitteeaggregator.Service
 	specProvider                        eth2client.SpecProvider
 	beaconBlockRootProvider             eth2client.BeaconBlockRootProvider
-	syncCommitteeMessagesSubmitter      submitter.SyncCommitteeMessagesSubmitter
 	validatingAccountsProvider          accountmanager.ValidatingAccountsProvider
+	logLevel                            zerolog.Level
+	processConcurrency                  int64
+	syncCommitteeAggregator             synccommitteeaggregator.Service
+	syncCommitteeMessagesSubmitter      submitter.SyncCommitteeMessagesSubmitter
 	syncCommitteeRootSigner             signer.SyncCommitteeRootSigner
 	syncCommitteeSelectionSigner        signer.SyncCommitteeSelectionSigner
 	syncCommitteeSubscriptionsSubmitter submitter.SyncCommitteeSubscriptionsSubmitter

--- a/services/synccommitteemessenger/standard/service.go
+++ b/services/synccommitteemessenger/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2021, 2024 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -48,15 +48,15 @@ const (
 type Service struct {
 	log                               zerolog.Logger
 	monitor                           metrics.Service
+	chainTimeService                  chaintime.Service
+	validatingAccountsProvider        accountmanager.ValidatingAccountsProvider
+	beaconBlockRootProvider           eth2client.BeaconBlockRootProvider
 	processConcurrency                int64
 	slotsPerEpoch                     uint64
 	syncCommitteeSize                 uint64
 	syncCommitteeSubnetCount          uint64
 	targetAggregatorsPerSyncCommittee uint64
-	chainTimeService                  chaintime.Service
 	syncCommitteeAggregator           synccommitteeaggregator.Service
-	validatingAccountsProvider        accountmanager.ValidatingAccountsProvider
-	beaconBlockRootProvider           eth2client.BeaconBlockRootProvider
 	syncCommitteeMessagesSubmitter    submitter.SyncCommitteeMessagesSubmitter
 	syncCommitteeSelectionSigner      signer.SyncCommitteeSelectionSigner
 	syncCommitteeRootSigner           signer.SyncCommitteeRootSigner

--- a/services/synccommitteesubscriber/standard/parameters.go
+++ b/services/synccommitteesubscriber/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Attestant Limited.
+// Copyright © 2021 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22,8 +22,8 @@ import (
 )
 
 type parameters struct {
-	logLevel               zerolog.Level
 	monitor                metrics.Service
+	logLevel               zerolog.Level
 	syncCommitteeSubmitter submitter.SyncCommitteeSubscriptionsSubmitter
 }
 

--- a/services/validatorsmanager/standard/parameters.go
+++ b/services/validatorsmanager/standard/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,10 +23,10 @@ import (
 )
 
 type parameters struct {
-	logLevel           zerolog.Level
 	monitor            metrics.ValidatorsManagerMonitor
-	clientMonitor      metrics.ClientMonitor
 	validatorsProvider eth2client.ValidatorsProvider
+	logLevel           zerolog.Level
+	clientMonitor      metrics.ClientMonitor
 	farFutureEpoch     phase0.Epoch
 }
 

--- a/services/validatorsmanager/standard/service.go
+++ b/services/validatorsmanager/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020, 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -27,16 +27,15 @@ import (
 
 // Service is the manager for validators.
 type Service struct {
-	log                zerolog.Logger
-	monitor            metrics.ValidatorsManagerMonitor
-	clientMonitor      metrics.ClientMonitor
-	validatorsProvider eth2client.ValidatorsProvider
-	farFutureEpoch     phase0.Epoch
-
-	validatorsMutex        sync.RWMutex
+	log                    zerolog.Logger
+	monitor                metrics.ValidatorsManagerMonitor
+	validatorsProvider     eth2client.ValidatorsProvider
+	clientMonitor          metrics.ClientMonitor
+	farFutureEpoch         phase0.Epoch
 	validatorsByIndex      map[phase0.ValidatorIndex]*phase0.Validator
 	validatorsByPubKey     map[phase0.BLSPubKey]*phase0.Validator
 	validatorPubKeyToIndex map[phase0.BLSPubKey]phase0.ValidatorIndex
+	validatorsMutex        sync.RWMutex
 }
 
 // New creates a new validator provider.

--- a/strategies/attestationdata/combinedmajority/parameters.go
+++ b/strategies/attestationdata/combinedmajority/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Attestant Limited.
+// Copyright © 2025 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package majority is a strategy that obtains attestation from multiple
+// Package majority is a strategy that obtains attestation from multiple
 // nodes and selects the best one.
 package combinedmajority
 

--- a/strategies/attestationdata/majority/parameters.go
+++ b/strategies/attestationdata/majority/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Attestant Limited.
+// Copyright © 2023 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package majority is a strategy that obtains attestation from multiple
+// Package majority is a strategy that obtains attestation from multiple
 // nodes and selects the best one.
 package majority
 

--- a/strategies/beaconblockproposal/best/beaconblockproposal.go
+++ b/strategies/beaconblockproposal/best/beaconblockproposal.go
@@ -87,7 +87,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 				Int("errored", errored).
 				Int("timed_out", timedOut).
 				Msg("Response received")
-			bestProposal, bestProvider = considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
+			bestProposal, bestProvider = s.considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
 		case err := <-errCh:
 			errored++
 			log.Debug().
@@ -129,7 +129,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 				Int("errored", errored).
 				Int("timed_out", timedOut).
 				Msg("Response received")
-			bestProposal, bestProvider = considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
+			bestProposal, bestProvider = s.considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
 		case err := <-errCh:
 			errored++
 			log.Debug().
@@ -173,7 +173,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 
 // considerEPBSProposal updates the best proposal seen so far, ignoring proposals that lack a
 // requested execution payload.
-func considerEPBSProposal(opts *api.EPBSProposalOpts,
+func (s *Service) considerEPBSProposal(opts *api.EPBSProposalOpts,
 	response *beaconBlockEPBSResponse,
 	bestProposal *api.VersionedEPBSProposal,
 	bestProvider string,
@@ -185,11 +185,28 @@ func considerEPBSProposal(opts *api.EPBSProposalOpts,
 		return bestProposal, bestProvider
 	}
 
-	if bestProposal == nil || response.proposal.Value().Cmp(bestProposal.Value()) > 0 {
+	if bestProposal == nil || s.scoreEPBSProposal(response.proposal).Cmp(s.scoreEPBSProposal(bestProposal)) > 0 {
 		return response.proposal, response.provider
 	}
 
 	return bestProposal, bestProvider
+}
+
+func (s *Service) scoreEPBSProposal(proposal *api.VersionedEPBSProposal) *big.Rat {
+	score := new(big.Rat).SetInt(proposal.Value())
+	if proposal.ConsensusValue == nil && proposal.ExecutionValue == nil {
+		s.log.Warn().Msg("ePBS proposal has no value headers; scoring execution payload gas only")
+	}
+	if proposal.ExecutionPayloadIncluded && proposal.GloasContents != nil && proposal.GloasContents.ExecutionPayloadEnvelope != nil && proposal.GloasContents.ExecutionPayloadEnvelope.Payload != nil {
+		payload := proposal.GloasContents.ExecutionPayloadEnvelope.Payload
+		if factor := new(big.Rat).SetFloat64(s.executionPayloadFactor); factor != nil {
+			gasUsed := new(big.Int).SetUint64(payload.GasUsed)
+			gasUsed.Add(gasUsed, new(big.Int).SetUint64(payload.BlobGasUsed))
+			score.Add(score, new(big.Rat).Mul(new(big.Rat).SetInt(gasUsed), factor))
+		}
+	}
+
+	return score
 }
 
 type beaconBlockEPBSResponse struct {
@@ -319,7 +336,8 @@ func (s *Service) Proposal(ctx context.Context,
 	errCh := make(chan *beaconBlockError, requests)
 	// Kick off the requests.
 	for name, provider := range s.proposalProviders {
-		providerGraffiti := opts.Graffiti[:]
+		providerOpts := *opts
+		providerGraffiti := providerOpts.Graffiti[:]
 		if bytes.Contains(providerGraffiti, []byte("{{CLIENT}}")) {
 			if nodeClientProvider, isProvider := provider.(eth2client.NodeClientProvider); isProvider {
 				nodeClientResponse, err := nodeClientProvider.NodeClient(ctx)
@@ -331,16 +349,12 @@ func (s *Service) Proposal(ctx context.Context,
 				if len(providerGraffiti) > 32 {
 					providerGraffiti = providerGraffiti[0:32]
 				}
-				// Replace entire opts structure so the mutated graffiti does not leak to other providers.
-				opts = &api.ProposalOpts{
-					Slot:                   opts.Slot,
-					RandaoReveal:           opts.RandaoReveal,
-					Graffiti:               [32]byte(providerGraffiti),
-					SkipRandaoVerification: opts.SkipRandaoVerification,
-				}
+				var graffiti [32]byte
+				copy(graffiti[:], providerGraffiti)
+				providerOpts.Graffiti = graffiti
 			}
 		}
-		go s.beaconBlockProposal(ctx, started, name, provider, respCh, errCh, opts)
+		go s.beaconBlockProposal(ctx, started, name, provider, respCh, errCh, &providerOpts)
 	}
 
 	// Wait for all responses (or context done).

--- a/strategies/beaconblockproposal/best/beaconblockproposal.go
+++ b/strategies/beaconblockproposal/best/beaconblockproposal.go
@@ -206,6 +206,11 @@ func (s *Service) epbsProposal(ctx context.Context,
 	opts *api.EPBSProposalOpts,
 	log zerolog.Logger,
 ) {
+	ctx, span := otel.Tracer("attestantio.vouch.strategies.beaconblockproposal.best").Start(ctx, "ePBSBeaconBlockProposal", trace.WithAttributes(
+		attribute.String("provider", name),
+	))
+	defer span.End()
+
 	providerGraffiti := opts.Graffiti[:]
 	if bytes.Contains(providerGraffiti, []byte("{{CLIENT}}")) {
 		if nodeClientProvider, isProvider := provider.(eth2client.NodeClientProvider); isProvider {

--- a/strategies/beaconblockproposal/best/beaconblockproposal.go
+++ b/strategies/beaconblockproposal/best/beaconblockproposal.go
@@ -87,7 +87,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 				Int("errored", errored).
 				Int("timed_out", timedOut).
 				Msg("Response received")
-			bestProposal, bestProvider = s.considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
+			bestProposal, bestProvider = considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
 		case err := <-errCh:
 			errored++
 			log.Debug().
@@ -129,7 +129,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 				Int("errored", errored).
 				Int("timed_out", timedOut).
 				Msg("Response received")
-			bestProposal, bestProvider = s.considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
+			bestProposal, bestProvider = considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
 		case err := <-errCh:
 			errored++
 			log.Debug().
@@ -173,7 +173,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 
 // considerEPBSProposal updates the best proposal seen so far, ignoring proposals that lack a
 // requested execution payload.
-func (s *Service) considerEPBSProposal(opts *api.EPBSProposalOpts,
+func considerEPBSProposal(opts *api.EPBSProposalOpts,
 	response *beaconBlockEPBSResponse,
 	bestProposal *api.VersionedEPBSProposal,
 	bestProvider string,

--- a/strategies/beaconblockproposal/best/beaconblockproposal.go
+++ b/strategies/beaconblockproposal/best/beaconblockproposal.go
@@ -87,14 +87,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 				Int("errored", errored).
 				Int("timed_out", timedOut).
 				Msg("Response received")
-			if opts.IncludePayload != nil && *opts.IncludePayload && !response.proposal.ExecutionPayloadIncluded {
-				log.Warn().Str("provider", response.provider).Msg("Discarding ePBS proposal without requested execution payload")
-				continue
-			}
-			if bestProposal == nil || response.proposal.Value().Cmp(bestProposal.Value()) > 0 {
-				bestProposal = response.proposal
-				bestProvider = response.provider
-			}
+			bestProposal, bestProvider = considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
 		case err := <-errCh:
 			errored++
 			log.Debug().
@@ -136,14 +129,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 				Int("errored", errored).
 				Int("timed_out", timedOut).
 				Msg("Response received")
-			if opts.IncludePayload != nil && *opts.IncludePayload && !response.proposal.ExecutionPayloadIncluded {
-				log.Warn().Str("provider", response.provider).Msg("Discarding ePBS proposal without requested execution payload")
-				continue
-			}
-			if bestProposal == nil || response.proposal.Value().Cmp(bestProposal.Value()) > 0 {
-				bestProposal = response.proposal
-				bestProvider = response.provider
-			}
+			bestProposal, bestProvider = considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
 		case err := <-errCh:
 			errored++
 			log.Debug().
@@ -183,6 +169,27 @@ func (s *Service) EPBSProposal(ctx context.Context,
 		Data:     bestProposal,
 		Metadata: make(map[string]any),
 	}, nil
+}
+
+// considerEPBSProposal updates the best proposal seen so far, ignoring proposals that lack a
+// requested execution payload.
+func considerEPBSProposal(opts *api.EPBSProposalOpts,
+	response *beaconBlockEPBSResponse,
+	bestProposal *api.VersionedEPBSProposal,
+	bestProvider string,
+	log zerolog.Logger,
+) (*api.VersionedEPBSProposal, string) {
+	if opts.IncludePayload != nil && *opts.IncludePayload && !response.proposal.ExecutionPayloadIncluded {
+		log.Warn().Str("provider", response.provider).Msg("Discarding ePBS proposal without requested execution payload")
+
+		return bestProposal, bestProvider
+	}
+
+	if bestProposal == nil || response.proposal.Value().Cmp(bestProposal.Value()) > 0 {
+		return response.proposal, response.provider
+	}
+
+	return bestProposal, bestProvider
 }
 
 type beaconBlockEPBSResponse struct {
@@ -237,41 +244,45 @@ func (s *Service) epbsProposal(ctx context.Context,
 		return
 	}
 
-	if proposalResponse.Data != nil && proposalResponse.Data.Version == spec.DataVersionGloas {
-		block := proposalResponse.Data.Gloas
-		if proposalResponse.Data.ExecutionPayloadIncluded {
-			if proposalResponse.Data.GloasContents == nil {
-				errCh <- &beaconBlockError{
-					provider: name,
-					err:      errors.New("beacon node returned malformed ePBS proposal"),
-				}
-
-				return
-			}
-			block = proposalResponse.Data.GloasContents.Block
+	if err := validateEPBSProposal(proposalResponse.Data); err != nil {
+		errCh <- &beaconBlockError{
+			provider: name,
+			err:      err,
 		}
-		if block == nil || block.Body == nil || block.Body.SignedExecutionPayloadBid == nil || block.Body.SignedExecutionPayloadBid.Message == nil {
-			errCh <- &beaconBlockError{
-				provider: name,
-				err:      errors.New("beacon node returned malformed ePBS proposal"),
-			}
 
-			return
-		}
-		if block.Body.SignedExecutionPayloadBid.Message.FeeRecipient.IsZero() {
-			errCh <- &beaconBlockError{
-				provider: name,
-				err:      errors.New("beacon block obtained with 0 fee recipient"),
-			}
-
-			return
-		}
+		return
 	}
 
 	respCh <- &beaconBlockEPBSResponse{
 		provider: name,
 		proposal: proposalResponse.Data,
 	}
+}
+
+// validateEPBSProposal confirms that an ePBS proposal is structurally sound and pays a fee recipient.
+// The caller must have already excluded a nil proposal.
+func validateEPBSProposal(proposal *api.VersionedEPBSProposal) error {
+	if proposal.Version != spec.DataVersionGloas {
+		return nil
+	}
+
+	block := proposal.Gloas
+	if proposal.ExecutionPayloadIncluded {
+		if proposal.GloasContents == nil {
+			return errors.New("beacon node returned malformed ePBS proposal")
+		}
+		block = proposal.GloasContents.Block
+	}
+
+	if block == nil || block.Body == nil || block.Body.SignedExecutionPayloadBid == nil || block.Body.SignedExecutionPayloadBid.Message == nil {
+		return errors.New("beacon node returned malformed ePBS proposal")
+	}
+
+	if block.Body.SignedExecutionPayloadBid.Message.FeeRecipient.IsZero() {
+		return errors.New("beacon block obtained with 0 fee recipient")
+	}
+
+	return nil
 }
 
 // Proposal provides the best beacon block proposal from a number of beacon nodes.

--- a/strategies/beaconblockproposal/best/beaconblockproposal.go
+++ b/strategies/beaconblockproposal/best/beaconblockproposal.go
@@ -185,28 +185,11 @@ func (s *Service) considerEPBSProposal(opts *api.EPBSProposalOpts,
 		return bestProposal, bestProvider
 	}
 
-	if bestProposal == nil || s.scoreEPBSProposal(response.proposal).Cmp(s.scoreEPBSProposal(bestProposal)) > 0 {
+	if bestProposal == nil || response.proposal.Value().Cmp(bestProposal.Value()) > 0 {
 		return response.proposal, response.provider
 	}
 
 	return bestProposal, bestProvider
-}
-
-func (s *Service) scoreEPBSProposal(proposal *api.VersionedEPBSProposal) *big.Rat {
-	score := new(big.Rat).SetInt(proposal.Value())
-	if proposal.ConsensusValue == nil && proposal.ExecutionValue == nil {
-		s.log.Warn().Msg("ePBS proposal has no value headers; scoring execution payload gas only")
-	}
-	if proposal.ExecutionPayloadIncluded && proposal.GloasContents != nil && proposal.GloasContents.ExecutionPayloadEnvelope != nil && proposal.GloasContents.ExecutionPayloadEnvelope.Payload != nil {
-		payload := proposal.GloasContents.ExecutionPayloadEnvelope.Payload
-		if factor := new(big.Rat).SetFloat64(s.executionPayloadFactor); factor != nil {
-			gasUsed := new(big.Int).SetUint64(payload.GasUsed)
-			gasUsed.Add(gasUsed, new(big.Int).SetUint64(payload.BlobGasUsed))
-			score.Add(score, new(big.Rat).Mul(new(big.Rat).SetInt(gasUsed), factor))
-		}
-	}
-
-	return score
 }
 
 type beaconBlockEPBSResponse struct {

--- a/strategies/beaconblockproposal/best/beaconblockproposal_test.go
+++ b/strategies/beaconblockproposal/best/beaconblockproposal_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/attestantio/vouch/services/cache"
 	mockcache "github.com/attestantio/vouch/services/cache/mock"
 	standardchaintime "github.com/attestantio/vouch/services/chaintime/standard"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/strategies/beaconblockproposal/best"
 	"github.com/attestantio/vouch/testing/logger"
 	"github.com/rs/zerolog"
@@ -187,4 +188,49 @@ func TestProposal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProposalExpandsShortClientGraffiti(t *testing.T) {
+	ctx := context.Background()
+	specProvider := mock.NewSpecProvider()
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisProvider(mock.NewGenesisProvider(time.Now())),
+		standardchaintime.WithSpecProvider(specProvider),
+	)
+	require.NoError(t, err)
+	cacheSvc := mockcache.New(map[phase0.Root]phase0.Slot{})
+	provider := &clientGraffitiEPBSProposalProvider{
+		client:   "prysm",
+		graffiti: make(chan [32]byte, 1),
+	}
+	secondProvider := &clientGraffitiEPBSProposalProvider{
+		client:   "nimbus",
+		graffiti: make(chan [32]byte, 1),
+	}
+	service, err := best.New(ctx,
+		best.WithLogLevel(zerolog.Disabled),
+		best.WithClientMonitor(nullmetrics.New()),
+		best.WithProcessConcurrency(2),
+		best.WithChainTimeService(chainTime),
+		best.WithSpecProvider(specProvider),
+		best.WithProposalProviders(map[string]beaconblockproposer.ProposalDataProvider{
+			"prysm":  provider,
+			"nimbus": secondProvider,
+		}),
+		best.WithTimeout(time.Second),
+		best.WithBlockRootToSlotCache(cacheSvc.(cache.BlockRootToSlotProvider)),
+	)
+	require.NoError(t, err)
+	var graffiti [32]byte
+	copy(graffiti[:], "configured {{CLIENT}}")
+
+	_, err = service.Proposal(ctx, &api.ProposalOpts{Slot: 1, Graffiti: graffiti})
+	require.NoError(t, err)
+	var expected [32]byte
+	copy(expected[:], "configured prysm")
+	require.Equal(t, expected, <-provider.graffiti)
+	var secondExpected [32]byte
+	copy(secondExpected[:], "configured nimbus")
+	require.Equal(t, secondExpected, <-secondProvider.graffiti)
 }

--- a/strategies/beaconblockproposal/best/epbsproposal_test.go
+++ b/strategies/beaconblockproposal/best/epbsproposal_test.go
@@ -35,7 +35,6 @@ import (
 	standardchaintime "github.com/attestantio/vouch/services/chaintime/standard"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/strategies/beaconblockproposal/best"
-	"github.com/attestantio/vouch/testing/logger"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -244,9 +243,8 @@ func TestEPBSProposalRejectsZeroFeeRecipientWithoutPayload(t *testing.T) {
 	require.Same(t, validCandidate, response.Data)
 }
 
-func TestEPBSProposalWeightsExecutionPayloadGas(t *testing.T) {
+func TestEPBSProposalDoesNotWeightExecutionPayloadGas(t *testing.T) {
 	ctx := context.Background()
-	capture := logger.NewLogCapture()
 	specProvider := mock.NewSpecProvider()
 	chainTime, err := standardchaintime.New(ctx,
 		standardchaintime.WithLogLevel(zerolog.Disabled),
@@ -279,8 +277,7 @@ func TestEPBSProposalWeightsExecutionPayloadGas(t *testing.T) {
 
 	response, err := service.EPBSProposal(ctx, &api.EPBSProposalOpts{})
 	require.NoError(t, err)
-	require.Same(t, executionCandidate, response.Data)
-	capture.AssertHasEntry(t, "ePBS proposal has no value headers; scoring execution payload gas only")
+	require.Same(t, consensusCandidate, response.Data)
 }
 
 func TestEPBSProposalComparesLargeValuesExactly(t *testing.T) {

--- a/strategies/beaconblockproposal/best/epbsproposal_test.go
+++ b/strategies/beaconblockproposal/best/epbsproposal_test.go
@@ -37,10 +37,21 @@ import (
 	"github.com/attestantio/vouch/strategies/beaconblockproposal/best"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestEPBSProposal(t *testing.T) {
 	ctx := context.Background()
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	previousTracerProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracerProvider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousTracerProvider)
+		require.NoError(t, tracerProvider.Shutdown(ctx))
+	})
 	specProvider := mock.NewSpecProvider()
 	chainTime, err := standardchaintime.New(ctx,
 		standardchaintime.WithLogLevel(zerolog.Disabled),
@@ -58,6 +69,7 @@ func TestEPBSProposal(t *testing.T) {
 		best.WithSpecProvider(specProvider),
 		best.WithProposalProviders(map[string]beaconblockproposer.ProposalDataProvider{
 			"one": &testEPBSProposalProvider{proposal: testGloasProposal(1, bellatrix.ExecutionAddress{0x01})},
+			"two": &testEPBSProposalProvider{proposal: testGloasProposal(1, bellatrix.ExecutionAddress{0x02})},
 		}),
 		best.WithTimeout(time.Second),
 		best.WithBlockRootToSlotCache(cacheSvc.(cache.BlockRootToSlotProvider)),
@@ -70,6 +82,27 @@ func TestEPBSProposal(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	require.NotNil(t, response.Data)
+
+	var epbsProposalSpan sdktrace.ReadOnlySpan
+	providerSpans := make(map[string]sdktrace.ReadOnlySpan)
+	for _, span := range spanRecorder.Ended() {
+		switch span.Name() {
+		case "EPBSProposal":
+			epbsProposalSpan = span
+		case "ePBSBeaconBlockProposal":
+			for _, attribute := range span.Attributes() {
+				if string(attribute.Key) == "provider" {
+					providerSpans[attribute.Value.AsString()] = span
+				}
+			}
+		}
+	}
+	require.NotNil(t, epbsProposalSpan)
+	for _, provider := range []string{"one", "two"} {
+		span, exists := providerSpans[provider]
+		require.True(t, exists, "provider %q should create a span", provider)
+		require.Equal(t, epbsProposalSpan.SpanContext(), span.Parent())
+	}
 }
 
 func TestEPBSProposalReturnsIncludedCandidateAtSoftTimeout(t *testing.T) {

--- a/strategies/beaconblockproposal/best/epbsproposal_test.go
+++ b/strategies/beaconblockproposal/best/epbsproposal_test.go
@@ -642,7 +642,7 @@ func (p *waitingClientGraffitiEPBSProposalProvider) NodeClient(
 
 var _ eth2client.NodeClientProvider = (*waitingClientGraffitiEPBSProposalProvider)(nil)
 
-func (p *testEPBSProposalProvider) Proposal(_ context.Context, _ *api.ProposalOpts) (*api.Response[*api.VersionedProposal], error) {
+func (*testEPBSProposalProvider) Proposal(_ context.Context, _ *api.ProposalOpts) (*api.Response[*api.VersionedProposal], error) {
 	return nil, nil
 }
 

--- a/strategies/beaconblockproposal/best/epbsproposal_test.go
+++ b/strategies/beaconblockproposal/best/epbsproposal_test.go
@@ -35,6 +35,7 @@ import (
 	standardchaintime "github.com/attestantio/vouch/services/chaintime/standard"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/strategies/beaconblockproposal/best"
+	"github.com/attestantio/vouch/testing/logger"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -241,6 +242,80 @@ func TestEPBSProposalRejectsZeroFeeRecipientWithoutPayload(t *testing.T) {
 	response, err := service.EPBSProposal(ctx, &api.EPBSProposalOpts{})
 	require.NoError(t, err)
 	require.Same(t, validCandidate, response.Data)
+}
+
+func TestEPBSProposalWeightsExecutionPayloadGas(t *testing.T) {
+	ctx := context.Background()
+	capture := logger.NewLogCapture()
+	specProvider := mock.NewSpecProvider()
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisProvider(mock.NewGenesisProvider(time.Now())),
+		standardchaintime.WithSpecProvider(specProvider),
+	)
+	require.NoError(t, err)
+	cacheSvc := mockcache.New(map[phase0.Root]phase0.Slot{})
+	consensusCandidate := testGloasProposal(2, bellatrix.ExecutionAddress{0x01})
+	executionCandidate := testGloasProposal(0, bellatrix.ExecutionAddress{0x02})
+	executionCandidate.ConsensusValue = nil
+	executionCandidate.GloasContents.ExecutionPayloadEnvelope = &gloas.ExecutionPayloadEnvelope{
+		Payload: &gloas.ExecutionPayload{GasUsed: 3},
+	}
+	service, err := best.New(ctx,
+		best.WithLogLevel(zerolog.WarnLevel),
+		best.WithClientMonitor(nullmetrics.New()),
+		best.WithProcessConcurrency(2),
+		best.WithChainTimeService(chainTime),
+		best.WithSpecProvider(specProvider),
+		best.WithProposalProviders(map[string]beaconblockproposer.ProposalDataProvider{
+			"consensus": &testEPBSProposalProvider{proposal: consensusCandidate},
+			"execution": &testEPBSProposalProvider{proposal: executionCandidate},
+		}),
+		best.WithTimeout(time.Second),
+		best.WithBlockRootToSlotCache(cacheSvc.(cache.BlockRootToSlotProvider)),
+		best.WithExecutionPayloadFactor(1),
+	)
+	require.NoError(t, err)
+
+	response, err := service.EPBSProposal(ctx, &api.EPBSProposalOpts{})
+	require.NoError(t, err)
+	require.Same(t, executionCandidate, response.Data)
+	capture.AssertHasEntry(t, "ePBS proposal has no value headers; scoring execution payload gas only")
+}
+
+func TestEPBSProposalComparesLargeValuesExactly(t *testing.T) {
+	ctx := context.Background()
+	specProvider := mock.NewSpecProvider()
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisProvider(mock.NewGenesisProvider(time.Now())),
+		standardchaintime.WithSpecProvider(specProvider),
+	)
+	require.NoError(t, err)
+	cacheSvc := mockcache.New(map[phase0.Root]phase0.Slot{})
+	base := new(big.Int).Lsh(big.NewInt(1), 54)
+	lowerValueCandidate := testGloasProposal(0, bellatrix.ExecutionAddress{0x01})
+	lowerValueCandidate.ConsensusValue = new(big.Int).Add(base, big.NewInt(1))
+	higherValueCandidate := testGloasProposal(0, bellatrix.ExecutionAddress{0x02})
+	higherValueCandidate.ConsensusValue = new(big.Int).Add(base, big.NewInt(2))
+	service, err := best.New(ctx,
+		best.WithLogLevel(zerolog.Disabled),
+		best.WithClientMonitor(nullmetrics.New()),
+		best.WithProcessConcurrency(2),
+		best.WithChainTimeService(chainTime),
+		best.WithSpecProvider(specProvider),
+		best.WithProposalProviders(map[string]beaconblockproposer.ProposalDataProvider{
+			"lower":  &testEPBSProposalProvider{proposal: lowerValueCandidate},
+			"higher": &testEPBSProposalProvider{proposal: higherValueCandidate, delay: 10 * time.Millisecond},
+		}),
+		best.WithTimeout(time.Second),
+		best.WithBlockRootToSlotCache(cacheSvc.(cache.BlockRootToSlotProvider)),
+	)
+	require.NoError(t, err)
+
+	response, err := service.EPBSProposal(ctx, &api.EPBSProposalOpts{})
+	require.NoError(t, err)
+	require.Same(t, higherValueCandidate, response.Data)
 }
 
 func TestEPBSProposalRejectsNilData(t *testing.T) {
@@ -568,6 +643,7 @@ func TestEPBSProposalStartsProvidersWhileGraffitiClientLookupIsSlow(t *testing.T
 type testEPBSProposalProvider struct {
 	proposal            *api.VersionedEPBSProposal
 	err                 error
+	delay               time.Duration
 	waitForCancellation bool
 }
 
@@ -577,11 +653,12 @@ type clientGraffitiEPBSProposalProvider struct {
 	graffiti      chan [32]byte
 }
 
-func (*clientGraffitiEPBSProposalProvider) Proposal(
-	_ context.Context,
-	_ *api.ProposalOpts,
+func (p *clientGraffitiEPBSProposalProvider) Proposal(ctx context.Context,
+	opts *api.ProposalOpts,
 ) (*api.Response[*api.VersionedProposal], error) {
-	return nil, nil
+	p.graffiti <- opts.Graffiti
+
+	return mock.NewProposalProvider().Proposal(ctx, opts)
 }
 
 func (p *clientGraffitiEPBSProposalProvider) EPBSProposal(
@@ -685,6 +762,9 @@ func (p *testEPBSProposalProvider) EPBSProposal(ctx context.Context,
 	*api.Response[*api.VersionedEPBSProposal],
 	error,
 ) {
+	if p.delay != 0 {
+		time.Sleep(p.delay)
+	}
 	if p.waitForCancellation {
 		<-ctx.Done()
 		return nil, ctx.Err()

--- a/strategies/beaconblockproposal/best/parameters.go
+++ b/strategies/beaconblockproposal/best/parameters.go
@@ -29,11 +29,11 @@ import (
 )
 
 type parameters struct {
+	specProvider           eth2client.SpecProvider
 	logLevel               zerolog.Level
 	clientMonitor          metrics.ClientMonitor
 	processConcurrency     int64
 	chainTime              chaintime.Service
-	specProvider           eth2client.SpecProvider
 	proposalProviders      map[string]beaconblockproposer.ProposalDataProvider
 	timeout                time.Duration
 	blockRootToSlotCache   cache.BlockRootToSlotProvider

--- a/strategies/beaconblockproposal/first/epbsproposal_test.go
+++ b/strategies/beaconblockproposal/first/epbsproposal_test.go
@@ -257,7 +257,7 @@ type epbsProposalProvider struct {
 	nilResponse bool
 }
 
-func (p *epbsProposalProvider) Proposal(_ context.Context, _ *api.ProposalOpts) (*api.Response[*api.VersionedProposal], error) {
+func (*epbsProposalProvider) Proposal(_ context.Context, _ *api.ProposalOpts) (*api.Response[*api.VersionedProposal], error) {
 	return nil, nil
 }
 

--- a/strategies/beaconblockproposal/first/service.go
+++ b/strategies/beaconblockproposal/first/service.go
@@ -55,32 +55,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 
 	proposalCh := make(chan *api.VersionedEPBSProposal, len(s.proposalProviders))
 	for name, provider := range s.proposalProviders {
-		go func(ctx context.Context, name string, provider beaconblockproposer.ProposalDataProvider, ch chan *api.VersionedEPBSProposal) {
-			log := s.log.With().Str("provider", name).Uint64("slot", uint64(opts.Slot)).Logger()
-
-			started := time.Now()
-			proposalResponse, err := provider.EPBSProposal(ctx, opts)
-			s.clientMonitor.ClientOperation(name, "ePBS beacon block proposal", err == nil, time.Since(started))
-			if err != nil {
-				if !errors.Is(err, context.Canceled) {
-					log.Debug().Err(err).Msg("Failed to obtain ePBS beacon block proposal")
-				}
-
-				return
-			}
-			if proposalResponse == nil {
-				log.Warn().Msg("Discarding empty ePBS proposal response")
-
-				return
-			}
-			proposal := proposalResponse.Data
-			log.Trace().Dur("elapsed", time.Since(started)).Msg("Obtained ePBS beacon block proposal")
-
-			select {
-			case ch <- proposal:
-			case <-ctx.Done():
-			}
-		}(ctx, name, provider, proposalCh)
+		go s.fetchEPBSProposal(ctx, name, provider, opts, proposalCh)
 	}
 
 	for {
@@ -90,39 +65,90 @@ func (s *Service) EPBSProposal(ctx context.Context,
 			s.log.Debug().Msg("Failed to obtain ePBS beacon block proposal before timeout")
 			return nil, errors.New("failed to obtain ePBS beacon block proposal before timeout")
 		case proposal := <-proposalCh:
-			if proposal == nil {
-				s.log.Warn().Msg("Discarding empty ePBS proposal")
+			if !s.acceptableEPBSProposal(proposal, opts.IncludePayload) {
 				continue
-			}
-			if opts.IncludePayload != nil && *opts.IncludePayload && !proposal.ExecutionPayloadIncluded {
-				s.log.Warn().Msg("Discarding ePBS proposal without requested execution payload")
-				continue
-			}
-			if proposal.Version == spec.DataVersionGloas {
-				block := proposal.Gloas
-				if proposal.ExecutionPayloadIncluded {
-					if proposal.GloasContents == nil {
-						s.log.Warn().Msg("Discarding malformed ePBS proposal")
-						continue
-					}
-					block = proposal.GloasContents.Block
-				}
-				if block == nil || block.Body == nil || block.Body.SignedExecutionPayloadBid == nil || block.Body.SignedExecutionPayloadBid.Message == nil {
-					s.log.Warn().Msg("Discarding malformed ePBS proposal")
-					continue
-				}
-				if block.Body.SignedExecutionPayloadBid.Message.FeeRecipient.IsZero() {
-					s.log.Warn().Msg("Discarding ePBS proposal with 0 fee recipient")
-					continue
-				}
 			}
 			cancel()
+
 			return &api.Response[*api.VersionedEPBSProposal]{
 				Data:     proposal,
 				Metadata: make(map[string]any),
 			}, nil
 		}
 	}
+}
+
+// fetchEPBSProposal obtains an ePBS beacon block proposal from a single provider, recording the
+// operation with the client monitor, and sends the result to ch unless ctx is done first.
+func (s *Service) fetchEPBSProposal(ctx context.Context,
+	name string,
+	provider beaconblockproposer.ProposalDataProvider,
+	opts *api.EPBSProposalOpts,
+	ch chan *api.VersionedEPBSProposal,
+) {
+	log := s.log.With().Str("provider", name).Uint64("slot", uint64(opts.Slot)).Logger()
+
+	started := time.Now()
+	proposalResponse, err := provider.EPBSProposal(ctx, opts)
+	s.clientMonitor.ClientOperation(name, "ePBS beacon block proposal", err == nil, time.Since(started))
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			log.Debug().Err(err).Msg("Failed to obtain ePBS beacon block proposal")
+		}
+
+		return
+	}
+	if proposalResponse == nil {
+		log.Warn().Msg("Discarding empty ePBS proposal response")
+
+		return
+	}
+	proposal := proposalResponse.Data
+	log.Trace().Dur("elapsed", time.Since(started)).Msg("Obtained ePBS beacon block proposal")
+
+	select {
+	case ch <- proposal:
+	case <-ctx.Done():
+	}
+}
+
+// acceptableEPBSProposal reports whether proposal is usable, discarding and logging it if it is
+// nil, lacks a requested execution payload, or (for Gloas) is structurally malformed or pays a
+// zero fee recipient.
+func (s *Service) acceptableEPBSProposal(proposal *api.VersionedEPBSProposal, includePayload *bool) bool {
+	if proposal == nil {
+		s.log.Warn().Msg("Discarding empty ePBS proposal")
+
+		return false
+	}
+	if includePayload != nil && *includePayload && !proposal.ExecutionPayloadIncluded {
+		s.log.Warn().Msg("Discarding ePBS proposal without requested execution payload")
+
+		return false
+	}
+	if proposal.Version == spec.DataVersionGloas {
+		block := proposal.Gloas
+		if proposal.ExecutionPayloadIncluded {
+			if proposal.GloasContents == nil {
+				s.log.Warn().Msg("Discarding malformed ePBS proposal")
+
+				return false
+			}
+			block = proposal.GloasContents.Block
+		}
+		if block == nil || block.Body == nil || block.Body.SignedExecutionPayloadBid == nil || block.Body.SignedExecutionPayloadBid.Message == nil {
+			s.log.Warn().Msg("Discarding malformed ePBS proposal")
+
+			return false
+		}
+		if block.Body.SignedExecutionPayloadBid.Message.FeeRecipient.IsZero() {
+			s.log.Warn().Msg("Discarding ePBS proposal with 0 fee recipient")
+
+			return false
+		}
+	}
+
+	return true
 }
 
 // New creates a new beacon block proposal strategy.

--- a/strategies/builderbid/best/parameters.go
+++ b/strategies/builderbid/best/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Attestant Limited.
+// Copyright © 2023 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package deadline is a strategy that obtains builder bids from multiple
+// Package deadline is a strategy that obtains builder bids from multiple
 // relays repeatedly up to the supplied deadline into a slot.
 package best
 
@@ -28,11 +28,11 @@ import (
 )
 
 type parameters struct {
-	logLevel              zerolog.Level
 	monitor               metrics.Service
 	specProvider          consensusclient.SpecProvider
 	domainProvider        consensusclient.DomainProvider
 	blockGasLimitProvider cache.BlockGasLimitProvider
+	logLevel              zerolog.Level
 	chainTime             chaintime.Service
 	timeout               time.Duration
 	releaseVersion        string

--- a/strategies/builderbid/best/service.go
+++ b/strategies/builderbid/best/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Attestant Limited.
+// Copyright © 2023 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -33,13 +33,13 @@ import (
 type Service struct {
 	log                      zerolog.Logger
 	monitor                  metrics.Service
-	chainTime                chaintime.Service
 	blockGasLimitProvider    cache.BlockGasLimitProvider
+	chainTime                chaintime.Service
 	timeout                  time.Duration
 	releaseVersion           string
 	relayPubkeys             map[phase0.BLSPubKey]*e2types.BLSPublicKey
-	relayPubkeysMu           sync.RWMutex
 	applicationBuilderDomain phase0.Domain
+	relayPubkeysMu           sync.RWMutex
 }
 
 // New creates a new builder bid strategy.

--- a/strategies/builderbid/deadline/metrics.go
+++ b/strategies/builderbid/deadline/metrics.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -131,6 +131,6 @@ func monitorBidDelta(provider string, delta *big.Int, pctDelta float64) {
 	ethDelta := new(big.Int).Div(delta, weiToETH)
 	bidDelta.WithLabelValues(provider).Observe(float64(ethDelta.Uint64()))
 
-	// move pct delta from percentage to decimal.
+	// Move pct delta from percentage to decimal.
 	bidPctDelta.WithLabelValues(provider).Observe(pctDelta)
 }

--- a/strategies/builderbid/deadline/parameters.go
+++ b/strategies/builderbid/deadline/parameters.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package deadline is a strategy that obtains builder bids from multiple
+// Package deadline is a strategy that obtains builder bids from multiple
 // relays repeatedly up to the supplied deadline into a slot.
 package deadline
 
@@ -28,11 +28,11 @@ import (
 )
 
 type parameters struct {
-	logLevel              zerolog.Level
 	monitor               metrics.Service
 	specProvider          consensusclient.SpecProvider
 	domainProvider        consensusclient.DomainProvider
 	blockGasLimitProvider cache.BlockGasLimitProvider
+	logLevel              zerolog.Level
 	chainTime             chaintime.Service
 	deadline              time.Duration
 	bidGap                time.Duration

--- a/strategies/builderbid/deadline/service.go
+++ b/strategies/builderbid/deadline/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Attestant Limited.
+// Copyright © 2024 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -33,14 +33,14 @@ import (
 type Service struct {
 	log                      zerolog.Logger
 	monitor                  metrics.Service
-	chainTime                chaintime.Service
 	blockGasLimitProvider    cache.BlockGasLimitProvider
+	chainTime                chaintime.Service
 	deadline                 time.Duration
 	bidGap                   time.Duration
 	releaseVersion           string
 	relayPubkeys             map[phase0.BLSPubKey]*e2types.BLSPublicKey
-	relayPubkeysMu           sync.RWMutex
 	applicationBuilderDomain phase0.Domain
+	relayPubkeysMu           sync.RWMutex
 }
 
 // New creates a new builder bid strategy.

--- a/testing/logger/capture.go
+++ b/testing/logger/capture.go
@@ -15,6 +15,7 @@ package logger
 
 import (
 	"encoding/json"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -87,45 +88,32 @@ func (c *LogCapture) HasLog(fields map[string]any) bool {
 
 // hasField returns true if the entry has a matching field.
 func (*LogCapture) hasField(entry map[string]any, key string, value any) bool {
-	for entryKey, entryValue := range entry {
-		if entryKey != key {
-			continue
-		}
-		switch v := value.(type) {
-		case bool:
-			return entryValue == v
-		case string:
-			return entryValue == value.(string)
-		case int:
-			return int(entryValue.(float64)) == v
-		case int8:
-			return int8(entryValue.(float64)) == v
-		case int16:
-			return int16(entryValue.(float64)) == v
-		case int32:
-			return int32(entryValue.(float64)) == v
-		case int64:
-			return int64(entryValue.(float64)) == v
-		case uint:
-			return uint(entryValue.(float64)) == v
-		case uint8:
-			return uint8(entryValue.(float64)) == v
-		case uint16:
-			return uint16(entryValue.(float64)) == v
-		case uint32:
-			return uint32(entryValue.(float64)) == v
-		case uint64:
-			return uint64(entryValue.(float64)) == v
-		case float32:
-			return float32(entryValue.(float64)) == v
-		case float64:
-			return entryValue.(float64) == v
-		default:
-			panic("unhandled type")
-		}
+	entryValue, exists := entry[key]
+	if !exists {
+		return false
 	}
 
-	return false
+	return fieldsMatch(entryValue, value)
+}
+
+func fieldsMatch(entryValue any, value any) bool {
+	expected := reflect.ValueOf(value)
+	if expected.CanInt() {
+		return int64(entryValue.(float64)) == expected.Int()
+	}
+	if expected.CanUint() {
+		return uint64(entryValue.(float64)) == expected.Uint()
+	}
+	if expected.CanFloat() {
+		return entryValue.(float64) == expected.Float()
+	}
+
+	switch value.(type) {
+	case bool, string:
+		return entryValue == value
+	default:
+		panic("unhandled type")
+	}
 }
 
 // Entries returns all captures log entries.

--- a/testing/logger/capture.go
+++ b/testing/logger/capture.go
@@ -1,4 +1,4 @@
-// Copyright © 2022, 2025 Attestant Limited.
+// Copyright © 2022 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,8 +24,8 @@ import (
 
 // LogCapture allows testing code to query log output.
 type LogCapture struct {
-	mu      sync.Mutex
 	entries []map[string]any
+	mu      sync.Mutex
 }
 
 // Write captures an individual log message.

--- a/testing/logger/capture_test.go
+++ b/testing/logger/capture_test.go
@@ -1,0 +1,58 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasLog(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields map[string]any
+		match  bool
+	}{
+		{
+			name: "MatchingTypedFields",
+			fields: map[string]any{
+				"active": true,
+				"count":  uint64(2),
+				"name":   "vouch",
+			},
+			match: true,
+		},
+		{
+			name: "MismatchedField",
+			fields: map[string]any{
+				"count": uint64(3),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capture := &LogCapture{
+				entries: []map[string]any{{
+					"active": true,
+					"count":  float64(2),
+					"name":   "vouch",
+				}},
+			}
+
+			require.Equal(t, test.match, capture.HasLog(test.fields))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- derive post-Gloas duty deadlines from the beacon node's served timing values
- default the four duty-delay options to `0` so the derivation is actually reachable
- select the pre-Gloas or Gloas deadlines per duty, from that duty's slot
- retain legacy timing for pre-Gloas networks and individually missing values
- read the `_GLOAS`-suffixed deadlines after the fork, and fall back to the Gloas values

## The bug: the derived deadlines were unreachable

The controller derives its duty deadlines from the chain specification, but only when the
corresponding option is unset:

```go
if p.maxAttestationDelay == 0 {
    p.maxAttestationDelay = attestationDue
}
```

`main.go` made that condition permanently false. It declared hardcoded defaults and then passed
them unconditionally:

```go
viper.SetDefault("controller.max-attestation-delay", 4*time.Second)
viper.SetDefault("controller.attestation-aggregation-delay", 8*time.Second)
// ...
standardcontroller.WithMaxAttestationDelay(viper.GetDuration("controller.max-attestation-delay")),
```

Because viper always yields a non-zero duration, the fallback never ran and every spec-derived
deadline was computed and discarded. The four values were fixed at 4s/8s/4s/8s for the lifetime of
the process regardless of what the chain served — so a beacon node serving `ATTESTATION_DUE_BPS`, or
a `SLOT_DURATION_MS` shorter than `SECONDS_PER_SLOT`, had no effect.

This was not Gloas-specific. Any chain whose slot is shorter than 12 seconds — the minimal preset
used by local devnets — already received deadlines derived from a 12-second slot, putting the 8s
aggregation deadline after the end of a 6s slot.

## The bug: the fork decision was frozen at startup

The choice between pre-Gloas and Gloas deadlines was made once, during construction:

```go
gloasActive := parameters.chainTimeService.CurrentEpoch() >= parameters.chainTimeService.HardForkEpoch(ctx, "GLOAS_FORK_EPOCH")
```

`HardForkEpoch` is a constant and is fine to read once, but `CurrentEpoch()` is not. Freezing the
comparison gives the result a shelf life of one epoch while the process runs for months, so a vouch
started before `GLOAS_FORK_EPOCH` would keep the pre-Gloas deadlines for its entire lifetime.

This had no observable effect while the derived values were being discarded. Making the derivation
reachable arms it, so the two must be fixed together.

## The fix

**Reachability.** Default the four options to `0`, the sentinel the controller already treats as
"derive from the chain specification". This is behaviour-preserving on mainnet: the pre-Gloas
derivation is `slotDuration/3` and `slotDuration*2/3`, which on a 12-second slot yields exactly the
4s and 8s that were previously hardcoded — those constants were the derivation, written out by hand.
A dedicated test case pins that equivalence so the two cannot drift apart silently.

**Fork selection.** Both deadline sets are derived at construction and stored; which one applies is
decided per duty from that duty's slot:

```go
func (s *Service) timingsForSlot(slot phase0.Slot) *dutyTimings {
    if s.chainTimeService.SlotToEpoch(slot) >= s.gloasForkEpoch {
        return &s.gloasTimings
    }

    return &s.preGloasTimings
}
```

Keying on the duty's slot rather than on the current epoch matters at the boundary: duties are
scheduled up to an epoch ahead, so during the epoch before the fork the controller is scheduling
duties *for* the fork epoch. A predicate on `CurrentEpoch()` would hand those post-fork duties the
pre-fork deadlines. This mirrors the existing fork gate in the proposer, which compares
`SlotToEpoch(duty.Slot())` against the fork epoch for the same reason.

Both sets are immutable after construction, so the selector needs no synchronisation — the four
delay fields were previously written once before the scheduling goroutines start, and that property
is preserved.

`gloasForkEpoch` is obtained through `gloasDetails`, following the existing `electraDetails` and
`bellatrixDetails` precedent: a chain that does not carry `GLOAS_FORK_EPOCH` yields the far-future
sentinel, the comparison is never true, and the pre-Gloas deadlines apply forever. Vouch starts and
logs rather than refusing, as it does for every other fork.

**Operator overrides** keep their existing meaning and are applied to both sets: an explicit value is
absolute and applies on both sides of the fork. `docs/configuration.md` documents this, and notes
that an explicit value valid today can schedule duties past the end of the slot on a future fork.

## The bug: the Gloas deadlines fell back to the pre-Gloas ones

The Gloas derivation looked up the `_GLOAS`-suffixed key, then the unsuffixed key, then a ratio:

```go
bps, ok := spec[name+"_GLOAS"].(uint64)
if !ok {
    bps, ok = spec[name].(uint64)
}
```

Both fallbacks are the deadlines Gloas moves away from. The unsuffixed keys hold the *pre-Gloas*
values and keep being served after the fork, and the ratios were `slotDuration/3` and
`slotDuration*2/3`, which are the pre-Gloas `3333` and `6667` basis points. So a node that served an
incomplete set produced post-fork duties on pre-fork timings — the same defect this PR exists to fix,
reintroduced one level down.

Against `glamsterdam-devnet-7`, which serves `ATTESTATION_DUE_BPS_GLOAS` but none of the other three
suffixed keys, that meant:

| Duty | Produced | Gloas requires |
| --- | --- | --- |
| Attestation | 3s | 3s |
| Aggregate | 8.0004s | 6s |
| Sync committee message | 3.9996s | 3s |
| Sync committee contribution | 8.0004s | 6s |

An 8.0004s aggregation lands after the 6s payload reveal, in a slot whose anatomy is propose at 0s,
attest at 3s, reveal at 6s, and vote on the payload at 9s.

**The fix.** The Gloas arm reads the exact `_GLOAS` key and no longer falls through to the unsuffixed
one, and its fallbacks are the Gloas values — a quarter and a half of the slot, being `2500` and
`5000` basis points. That matches the convention the payload deadlines already use.

`glamsterdam-devnet-8` serves all six suffixed keys and was therefore already correct; what changes
is the behaviour of every node that does not.

## Also in this change

- Fallback deadlines are now fractions of the Gloas slot duration rather than of `SECONDS_PER_SLOT`.
  Previously the ratio defaults were computed *before* the `SLOT_DURATION_MS` override was read, so a
  node serving `SLOT_DURATION_MS=6000` without the `*_DUE_BPS` values produced an 8-second deadline
  inside a 6-second slot.
- Served basis-point values are range-checked. `ATTESTATION_DUE_BPS: 0` previously produced a
  slot-start deadline (attesting before a block can arrive) and a value above 10000 produced a
  deadline past the end of the slot, both silently. Out-of-range values now fall back to the ratio
  default.
- The timing tests take their expected values from the specification rather than from the formula
  the derivation itself uses. `TestGloasSpecConformance` pins them to the configuration served by
  `beacon.glamsterdam-devnet-8.ethpandaops.io`, and a devnet-7 case covers the partial key set. The
  previous table derived every expectation from the same arithmetic as the code, so it could only
  demonstrate that the code agreed with itself.
- `createElectraAttestations` guarded its validator-index lookup with `len(validatorIndices) < i`, an
  off-by-one that panics when `i == len(validatorIndices)`. It now matches the correct
  `i >= len(validatorIndices)` form.
- `scheduleAttestationAggregations` is split out of the attester scheduling path. This is a pure
  extraction with no behaviour change, keeping the enclosing function within the complexity limit
  now that the aggregation deadline is looked up per slot.
- The copyright range on `services/controller/standard/synccommitteemessenger.go` is refreshed, as
  the custom lint requires for a file this change modifies.

## Known limitation

`services/chaintime/standard` derives its slot duration solely from `SECONDS_PER_SLOT` and does not
read `SLOT_DURATION_MS`. Every deadline here is applied as an offset from `StartOfSlot(slot)`, so on
a chain where the two values diverge the slot boundaries themselves would be wrong and correct
in-slot offsets would not be sufficient. That is out of scope here and needs resolving before any
network ships a Gloas slot duration that differs from `SECONDS_PER_SLOT`.

Relatedly, `SECONDS_PER_SLOT` has been dropped from the devnet-8 `config.yaml` and from
`configs/mainnet.yaml` at `v1.7.0-alpha.13`. Live nodes still serve it through
`/eth/v1/config/spec`, and vouch reads only that key — `parameters.slotDuration` returns an error
without it, so vouch would refuse to start against a node that stopped serving it. That is a
fork-independent dependency on a compatibility alias and is not addressed here.

One residual restart requirement remains, shared with every other fork vouch handles: a beacon node
that begins serving `GLOAS_FORK_EPOCH` only after vouch has started requires a vouch restart, because
the fork schedule is read once at construction and the spec is cached for the life of the process.

## Reviewer note

Most of the diff in `services/controller/standard/service.go` is gofmt realignment: removing
`syncCommitteeAggregationDelay`, the longest field name in the `Service` struct, shifts the
alignment column for every other field. Reviewing that file with `git show -w` reduces it to the 30
inserted and 8 deleted lines that actually change behaviour.

## Validation

- `go build ./...` — clean.
- `gosilent test ./...` — 989 tests, all pass.
- `./custom-gcl run --max-issues-per-linter=0 --max-same-issues=0` — 14 issues, all pre-existing and
  outside the changed lines.


