### PR TITLE
Add payload timeliness committee duty flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ gloas:
   - convert gloas aggregate attestations and signed aggregate-and-proof containers for aggregation and submission, rejecting a missing gloas arm before signing
   - derive the four controller duty deadlines from the chain specification, choosing the pre-gloas or gloas deadline per duty from that duty's slot and retaining the legacy timing for pre-gloas networks
   - default controller.max-attestation-delay, controller.attestation-aggregation-delay, controller.max-sync-committee-message-delay and controller.sync-committee-aggregation-delay to 0; the hardcoded defaults made the spec-derived deadlines unreachable
+  - add the payload timeliness committee duty: fetch PTC duties for the epoch, group each slot's validators into one job scheduled inside the gloas payload timing window, and vote on whether the slot's execution payload was revealed on time
+  - submit versioned payload attestations through the immediate, multinode and null submitters, batching signatures for validators that share a slot
   - update go-eth2-client to a gloas pseudo-version
   - satisfy the attgo struct field order and comment capitalisation rules across services and strategies
 

--- a/main.go
+++ b/main.go
@@ -63,6 +63,8 @@ import (
 	"github.com/attestantio/vouch/services/multiinstance"
 	alwaysmultiinstance "github.com/attestantio/vouch/services/multiinstance/always"
 	staticdelaymultiinstance "github.com/attestantio/vouch/services/multiinstance/staticdelay"
+	"github.com/attestantio/vouch/services/payloadattester"
+	standardpayloadattester "github.com/attestantio/vouch/services/payloadattester/standard"
 	"github.com/attestantio/vouch/services/proposalpreparer"
 	standardproposalpreparer "github.com/attestantio/vouch/services/proposalpreparer/standard"
 	"github.com/attestantio/vouch/services/scheduler"
@@ -373,6 +375,11 @@ func startServices(ctx context.Context,
 		return nil, nil, errors.Wrap(err, "failed to select submitter")
 	}
 
+	payloadAttester, err := startPayloadAttester(ctx, monitor, eth2Client, signerSvc, submitter)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to start payload attester")
+	}
+
 	blockRelay, err := startBlockRelay(ctx, majordomo, monitor, eth2Client, schedulerSvc, chainTime, accountManager, signerSvc, cacheSvc)
 	if err != nil {
 		return nil, nil, err
@@ -433,6 +440,7 @@ func startServices(ctx context.Context,
 		syncCommitteeSubscriber,
 		beaconBlockHeaderProvider,
 		multiInstance,
+		payloadAttester,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -460,6 +468,7 @@ func initController(ctx context.Context,
 	syncCommitteeSubscriber synccommitteesubscriber.Service,
 	beaconBlockHeaderProvider eth2client.BeaconBlockHeadersProvider,
 	multiInstance multiinstance.Service,
+	payloadAttester payloadattester.Service,
 ) (
 	*standardcontroller.Service,
 	error,
@@ -471,7 +480,7 @@ func initController(ctx context.Context,
 	}
 
 	log.Trace().Msg("Starting controller")
-	controller, err := standardcontroller.New(ctx,
+	controllerParams := []standardcontroller.Parameter{
 		standardcontroller.WithLogLevel(util.LogLevel("controller")),
 		standardcontroller.WithMonitor(monitor),
 		standardcontroller.WithSpecProvider(eth2Client.(eth2client.SpecProvider)),
@@ -505,7 +514,14 @@ func initController(ctx context.Context,
 		standardcontroller.WithFastTrackSyncCommittees(viper.GetBool("controller.fast-track.sync-committees")),
 		standardcontroller.WithFastTrackGrace(viper.GetDuration("controller.fast-track.grace")),
 		standardcontroller.WithMultiInstance(multiInstance),
-	)
+	}
+	if ptcDutiesProvider, ok := eth2Client.(eth2client.PTCDutiesProvider); ok && payloadAttester != nil {
+		controllerParams = append(controllerParams,
+			standardcontroller.WithPTCDutiesProvider(ptcDutiesProvider),
+			standardcontroller.WithPayloadAttester(payloadAttester),
+		)
+	}
+	controller, err := standardcontroller.New(ctx, controllerParams...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start controller service")
 	}
@@ -1636,10 +1652,10 @@ func selectSubmitterStrategy(ctx context.Context, monitor metrics.Service, eth2C
 	switch viper.GetString("submitter.style") {
 	case "multinode", "all":
 		log.Info().Msg("Starting multinode submitter strategy")
-		submitter, err = startMultinodeSubmitter(ctx, monitor)
+		submitter, err = startMultinodeSubmitter(ctx, monitor, eth2Client)
 	default:
 		log.Info().Msg("Starting standard submitter strategy")
-		submitter, err = immediatesubmitter.New(ctx,
+		params := []immediatesubmitter.Parameter{
 			immediatesubmitter.WithLogLevel(util.LogLevel("submitter.immediate")),
 			immediatesubmitter.WithClientMonitor(monitor.(metrics.ClientMonitor)),
 			immediatesubmitter.WithProposalSubmitter(eth2Client.(eth2client.ProposalSubmitter)),
@@ -1651,12 +1667,53 @@ func selectSubmitterStrategy(ctx context.Context, monitor metrics.Service, eth2C
 			immediatesubmitter.WithBeaconCommitteeSubscriptionsSubmitter(eth2Client.(eth2client.BeaconCommitteeSubscriptionsSubmitter)),
 			immediatesubmitter.WithAggregateAttestationsSubmitter(eth2Client.(eth2client.AggregateAttestationsSubmitter)),
 			immediatesubmitter.WithProposalPreparationsSubmitter(eth2Client.(eth2client.ProposalPreparationsSubmitter)),
-		)
+		}
+		if payloadAttestationMessagesSubmitter, ok := eth2Client.(eth2client.PayloadAttestationMessagesSubmitter); ok {
+			params = append(params, immediatesubmitter.WithPayloadAttestationMessagesSubmitter(payloadAttestationMessagesSubmitter))
+		}
+		submitter, err = immediatesubmitter.New(ctx, params...)
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start submitter service")
 	}
 	return submitter, nil
+}
+
+// startPayloadAttester starts the payload attester when all of its post-Gloas capabilities are
+// available.  Older beacon nodes do not expose these capabilities, so the service remains
+// disabled without making startup fail.
+func startPayloadAttester(ctx context.Context,
+	monitor metrics.Service,
+	eth2Client eth2client.Service,
+	signerSvc signer.Service,
+	submitterStrategy submitter.Service,
+) (payloadattester.Service, error) {
+	payloadAttestationDataProvider, ok := eth2Client.(eth2client.PayloadAttestationDataProvider)
+	if !ok {
+		return nil, nil
+	}
+	payloadAttestationDataSigner, ok := signerSvc.(signer.PayloadAttestationDataSigner)
+	if !ok {
+		return nil, nil
+	}
+	payloadAttestationMessagesSubmitter, ok := submitterStrategy.(submitter.PayloadAttestationMessagesSubmitter)
+	if !ok {
+		return nil, nil
+	}
+
+	log.Trace().Msg("Starting payload attester")
+	service, err := standardpayloadattester.New(ctx,
+		standardpayloadattester.WithLogLevel(util.LogLevel("payloadattester")),
+		standardpayloadattester.WithMonitor(monitor),
+		standardpayloadattester.WithPayloadAttestationDataProvider(payloadAttestationDataProvider),
+		standardpayloadattester.WithPayloadAttestationDataSigner(payloadAttestationDataSigner),
+		standardpayloadattester.WithPayloadAttestationMessagesSubmitter(payloadAttestationMessagesSubmitter),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start standard payload attester service")
+	}
+
+	return service, nil
 }
 
 func genericAddressToClientMapper[T any](ctx context.Context, monitor metrics.Service, path, description string) (map[string]T, error) {
@@ -1677,6 +1734,7 @@ func genericAddressToClientMapper[T any](ctx context.Context, monitor metrics.Se
 
 func startMultinodeSubmitter(ctx context.Context,
 	monitor metrics.Service,
+	eth2Client eth2client.Service,
 ) (
 	submitter.Service,
 	error,
@@ -1743,7 +1801,17 @@ func startMultinodeSubmitter(ctx context.Context,
 		return nil, err
 	}
 
-	submitterService, err := multinodesubmitter.New(ctx,
+	var payloadAttestationMessagesSubmitters map[string]submitter.PayloadAttestationMessagesSubmitter
+	if _, ok := eth2Client.(eth2client.PayloadAttestationMessagesSubmitter); ok {
+		payloadAttestationMessagesSubmitters, err = genericAddressToClientMapper[submitter.PayloadAttestationMessagesSubmitter](ctx, monitor,
+			"submitter.payloadattestation.multinode",
+			"payload attestation message submitter strategy")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	params := []multinodesubmitter.Parameter{
 		multinodesubmitter.WithClientMonitor(monitor.(metrics.ClientMonitor)),
 		multinodesubmitter.WithProcessConcurrency(util.ProcessConcurrency("submitter.multinode")),
 		multinodesubmitter.WithLogLevel(util.LogLevel("submitter.multinode")),
@@ -1757,7 +1825,11 @@ func startMultinodeSubmitter(ctx context.Context,
 		multinodesubmitter.WithAggregateAttestationsSubmitters(aggregateAttestationSubmitters),
 		multinodesubmitter.WithBeaconCommitteeSubscriptionsSubmitters(beaconCommitteeSubscriptionsSubmitters),
 		multinodesubmitter.WithProposalPreparationsSubmitters(proposalPreparationSubmitters),
-	)
+	}
+	if payloadAttestationMessagesSubmitters != nil {
+		params = append(params, multinodesubmitter.WithPayloadAttestationMessagesSubmitters(payloadAttestationMessagesSubmitters))
+	}
+	submitterService, err := multinodesubmitter.New(ctx, params...)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -1679,9 +1679,10 @@ func selectSubmitterStrategy(ctx context.Context, monitor metrics.Service, eth2C
 	return submitter, nil
 }
 
-// startPayloadAttester starts the payload attester when all of its post-Gloas capabilities are
-// available.  Older beacon nodes do not expose these capabilities, so the service remains
-// disabled without making startup fail.
+// startPayloadAttester starts the payload attester when the consensus client, signer and submitter
+// all provide their side of the payload attestation flow.  Anything missing leaves the service
+// disabled rather than making startup fail.  Whether the network is at Gloas is not decided here:
+// the controller schedules no payload attestation duty before GLOAS_FORK_EPOCH.
 func startPayloadAttester(ctx context.Context,
 	monitor metrics.Service,
 	eth2Client eth2client.Service,

--- a/services/beaconblockproposer/standard/gloas_test.go
+++ b/services/beaconblockproposer/standard/gloas_test.go
@@ -65,7 +65,9 @@ func TestProposeGloas(t *testing.T) {
 		envelopeZeroFeeRecipient   bool
 		executionPayloadBidMissing bool
 		envelopeSignerErr          error
+		proposalSubmitterErr       error
 		envelopeSubmitterErr       error
+		cancelEnvelopeSubmission   bool
 		forkEpochAtConstruction    phase0.Epoch
 		forkEpochAtUse             phase0.Epoch
 		updateForkEpochAtUse       bool
@@ -142,10 +144,23 @@ func TestProposeGloas(t *testing.T) {
 			err:                      "failed to propose block: failed to sign execution payload envelope: envelope signing failed",
 		},
 		{
+			name:                     "ProposalSubmissionFailure",
+			executionPayloadIncluded: true,
+			proposalSubmitterErr:     errors.New("proposal submission failed"),
+			err:                      "failed to propose block: failed to submit proposal: proposal submission failed",
+		},
+		{
 			name:                     "EnvelopeSubmissionFailure",
 			executionPayloadIncluded: true,
 			envelopeSubmitterErr:     errors.New("envelope submission failed"),
 			err:                      "failed to propose block: failed to submit execution payload envelope after block publication: envelope submission failed",
+		},
+		{
+			name:                     "CanceledEnvelopeSubmissionBackoff",
+			executionPayloadIncluded: true,
+			envelopeSubmitterErr:     errors.New("envelope submission failed"),
+			cancelEnvelopeSubmission: true,
+			err:                      "failed to propose block: failed to submit execution payload envelope after block publication: context canceled",
 		},
 	}
 
@@ -203,13 +218,14 @@ func TestProposeGloas(t *testing.T) {
 				return response, err
 			}
 
-			proposalSubmitter := &capturingProposalSubmitter{}
+			proposalSubmitter := &capturingProposalSubmitter{err: test.proposalSubmitterErr}
 			signer := mocksigner.New()
 			signature := phase0.BLSSignature{0x01}
 			blockSigner := &capturingBeaconBlockSigner{signature: signature}
 			envelopeSignature := phase0.BLSSignature{0x03}
 			envelopeSigner := &capturingExecutionPayloadEnvelopeSigner{signature: envelopeSignature, err: test.envelopeSignerErr}
 			envelopeSubmitter := &capturingExecutionPayloadEnvelopeSubmitter{err: test.envelopeSubmitterErr}
+			proposeCtx := ctx
 
 			chainTime := &forkChainTime{gloasForkEpoch: test.forkEpochAtConstruction}
 			var monitor metrics.Service = nullmetrics.New()
@@ -224,9 +240,19 @@ func TestProposeGloas(t *testing.T) {
 				standard.WithRANDAORevealSigner(signer),
 				standard.WithBeaconBlockSigner(blockSigner),
 				standard.WithExecutionPayloadEnvelopeSigner(envelopeSigner),
-				standard.WithExecutionPayloadEnvelopeSubmitter(envelopeSubmitter),
 				standard.WithBlobSidecarSigner(signer),
 				standard.WithBuilderBoostFactor(test.builderBoostFactor),
+			}
+			if test.cancelEnvelopeSubmission {
+				var cancel context.CancelFunc
+				proposeCtx, cancel = context.WithCancel(ctx)
+				defer cancel()
+				params = append(params, standard.WithExecutionPayloadEnvelopeSubmitter(&cancelingExecutionPayloadEnvelopeSubmitter{
+					cancel: cancel,
+					err:    test.envelopeSubmitterErr,
+				}))
+			} else {
+				params = append(params, standard.WithExecutionPayloadEnvelopeSubmitter(envelopeSubmitter))
 			}
 			if test.blockAuctioneer {
 				cacheService := mockcache.New(map[phase0.Root]phase0.Slot{})
@@ -245,7 +271,7 @@ func TestProposeGloas(t *testing.T) {
 			duty.SetAccount(&testAccount{})
 			duty.SetRandaoReveal(phase0.BLSSignature{0x02})
 
-			err = service.Propose(ctx, duty)
+			err = service.Propose(proposeCtx, duty)
 			if test.builderBoostFactor != 0 {
 				capture.AssertHasEntry(t, "Ignoring non-default builder boost factor on Gloas proposal path")
 			}
@@ -259,13 +285,53 @@ func TestProposeGloas(t *testing.T) {
 			require.Equal(t, uint64(0), *epbsOpts.BuilderBoostFactor)
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
-				if test.envelopeSubmitterErr == nil {
-					require.Nil(t, proposalSubmitter.proposal)
-					require.Zero(t, proposalSubmitter.calls)
-				} else {
+				if test.proposalSubmitterErr != nil {
+					beaconBlockRoot := responseProposal.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot.String()
+					require.True(t, hasProposalSubmissionCompletedAt(capture, "Failed to submit ePBS beacon block proposal", beaconBlockRoot))
+					require.NotNil(t, proposalSubmitter.proposal)
+					require.Equal(t, 1, proposalSubmitter.calls)
+					require.Nil(t, envelopeSubmitter.opts)
+				}
+				if test.name == "EnvelopeSubmissionFailure" {
+					beaconBlockRoot := responseProposal.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot.String()
+					for attempt := uint64(1); attempt <= 3; attempt++ {
+						require.True(t, capture.HasLog(map[string]any{
+							"message":           "Submitting execution payload envelope",
+							"beacon_block_root": beaconBlockRoot,
+							"attempt":           attempt,
+						}))
+						require.True(t, capture.HasLog(map[string]any{
+							"message":                       "Execution payload envelope submission attempt completed",
+							"beacon_block_root":             beaconBlockRoot,
+							"attempt":                       attempt,
+							"envelope_submission_succeeded": false,
+							"error":                         "envelope submission failed",
+						}))
+					}
+					require.True(t, capture.HasLog(map[string]any{
+						"message":                       "Execution payload envelope submission completed",
+						"beacon_block_root":             beaconBlockRoot,
+						"envelope_submission_succeeded": false,
+					}))
+				}
+				if test.cancelEnvelopeSubmission {
+					beaconBlockRoot := responseProposal.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot.String()
+					require.True(t, capture.HasLog(map[string]any{
+						"message":                       "Execution payload envelope submission completed",
+						"beacon_block_root":             beaconBlockRoot,
+						"status":                        "failed",
+						"envelope_submission_succeeded": false,
+					}))
+				}
+				if test.cancelEnvelopeSubmission {
+					require.Zero(t, envelopeSubmitter.calls)
+				} else if test.envelopeSubmitterErr != nil {
 					require.NotNil(t, proposalSubmitter.proposal)
 					require.Equal(t, 1, proposalSubmitter.calls)
 					require.Equal(t, 3, envelopeSubmitter.calls)
+				} else if test.proposalSubmitterErr == nil {
+					require.Nil(t, proposalSubmitter.proposal)
+					require.Zero(t, proposalSubmitter.calls)
 				}
 				if test.envelopeRootMismatch || test.builderIndexMismatch || test.foreignBuilderIndex || test.envelopePayloadMissing || test.executionPayloadBidMissing {
 					require.Zero(t, blockSigner.calls)
@@ -311,9 +377,57 @@ func TestProposeGloas(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, directBlockRoot, headerRoot)
 				require.Equal(t, phase0.Root(bodyRoot), blockSigner.bodyRoot)
+				if test.name == "PayloadIncluded" {
+					beaconBlockRoot := responseProposal.GloasContents.ExecutionPayloadEnvelope.BeaconBlockRoot.String()
+					require.True(t, capture.HasLog(map[string]any{
+						"message":           "Submitted ePBS beacon block proposal",
+						"beacon_block_root": beaconBlockRoot,
+					}))
+					require.True(t, hasProposalSubmissionCompletedAt(capture, "Submitted ePBS beacon block proposal", beaconBlockRoot))
+					require.True(t, capture.HasLog(map[string]any{
+						"message":           "Submitting execution payload envelope",
+						"beacon_block_root": beaconBlockRoot,
+						"attempt":           uint64(1),
+					}))
+					require.True(t, capture.HasLog(map[string]any{
+						"message":                       "Execution payload envelope submission attempt completed",
+						"beacon_block_root":             beaconBlockRoot,
+						"attempt":                       uint64(1),
+						"envelope_submission_succeeded": true,
+					}))
+					require.True(t, capture.HasLog(map[string]any{
+						"message":                       "Execution payload envelope submission completed",
+						"beacon_block_root":             beaconBlockRoot,
+						"envelope_submission_succeeded": true,
+					}))
+				}
 			}
 		})
 	}
+}
+
+func hasProposalSubmissionCompletedAt(capture *logger.LogCapture, message string, beaconBlockRoot string) bool {
+	for _, entry := range capture.Entries() {
+		if entry["message"] != message || entry["beacon_block_root"] != beaconBlockRoot {
+			continue
+		}
+		if _, exists := entry["proposal_submission_completed_at"]; exists {
+			return true
+		}
+	}
+
+	return false
+}
+
+type cancelingExecutionPayloadEnvelopeSubmitter struct {
+	cancel context.CancelFunc
+	err    error
+}
+
+func (s *cancelingExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(_ context.Context, _ *consensusapi.SubmitExecutionPayloadEnvelopeOpts) error {
+	s.cancel()
+
+	return s.err
 }
 
 func TestProposeGloasProposalSource(t *testing.T) {

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -278,6 +278,7 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 	if err != nil {
 		return err
 	}
+	log := s.log.With().Str("beacon_block_root", envelope.BeaconBlockRoot.String()).Logger()
 
 	var signedProposal *api.VersionedSignedProposal
 	var signature phase0.BLSSignature
@@ -310,8 +311,11 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 	}
 
 	if err := s.proposalSubmitter.SubmitProposal(ctx, signedProposal); err != nil {
+		log.Warn().Err(err).Time("proposal_submission_completed_at", time.Now()).Msg("Failed to submit ePBS beacon block proposal")
+
 		return errors.Wrap(err, "failed to submit proposal")
 	}
+	log.Trace().Time("proposal_submission_completed_at", time.Now()).Msg("Submitted ePBS beacon block proposal")
 
 	envelopeSubmissionOpts := &api.SubmitExecutionPayloadEnvelopeOpts{
 		SignedExecutionPayloadEnvelope: &spec.VersionedSignedExecutionPayloadEnvelope{
@@ -325,19 +329,30 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 		Blobs:     blobs,
 	}
 	var envelopeSubmissionErr error
-	for attempts := 3; attempts > 0; attempts-- {
+	for attempt := 1; attempt <= 3; attempt++ {
+		log.Trace().Int("attempt", attempt).Msg("Submitting execution payload envelope")
 		envelopeSubmissionErr = s.executionPayloadEnvelopeSubmitter.SubmitExecutionPayloadEnvelope(ctx, envelopeSubmissionOpts)
 		if envelopeSubmissionErr == nil {
+			log.Trace().Int("attempt", attempt).Bool("envelope_submission_succeeded", true).Msg("Execution payload envelope submission attempt completed")
+
 			break
 		}
-		s.log.Warn().Err(envelopeSubmissionErr).Int("attempts_remaining", attempts-1).Msg("Failed to submit execution payload envelope after block publication")
-		if attempts > 1 {
+		log.Warn().Err(envelopeSubmissionErr).Int("attempt", attempt).Bool("envelope_submission_succeeded", false).Msg("Execution payload envelope submission attempt completed")
+		log.Warn().Err(envelopeSubmissionErr).Int("attempts_remaining", 3-attempt).Msg("Failed to submit execution payload envelope after block publication")
+		if attempt < 3 {
 			select {
 			case <-ctx.Done():
+				log.Warn().Err(ctx.Err()).Str("status", "failed").Bool("envelope_submission_succeeded", false).Msg("Execution payload envelope submission completed")
+
 				return errors.Wrap(ctx.Err(), "failed to submit execution payload envelope after block publication")
 			case <-time.After(250 * time.Millisecond):
 			}
 		}
+	}
+	if envelopeSubmissionErr == nil {
+		log.Trace().Bool("envelope_submission_succeeded", true).Msg("Execution payload envelope submission completed")
+	} else {
+		log.Warn().Err(envelopeSubmissionErr).Bool("envelope_submission_succeeded", false).Msg("Execution payload envelope submission completed")
 	}
 	if envelopeSubmissionErr != nil {
 		return errors.Wrap(envelopeSubmissionErr, "failed to submit execution payload envelope after block publication")

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -43,6 +43,7 @@ import (
 	"github.com/attestantio/vouch/services/beaconblockproposer"
 	"github.com/attestantio/vouch/util"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
@@ -328,38 +329,66 @@ func (s *Service) proposeEPBSBlock(ctx context.Context,
 		KZGProofs: kzgProofs,
 		Blobs:     blobs,
 	}
-	var envelopeSubmissionErr error
-	for attempt := 1; attempt <= 3; attempt++ {
-		log.Trace().Int("attempt", attempt).Msg("Submitting execution payload envelope")
-		envelopeSubmissionErr = s.executionPayloadEnvelopeSubmitter.SubmitExecutionPayloadEnvelope(ctx, envelopeSubmissionOpts)
-		if envelopeSubmissionErr == nil {
-			log.Trace().Int("attempt", attempt).Bool("envelope_submission_succeeded", true).Msg("Execution payload envelope submission attempt completed")
-
-			break
-		}
-		log.Warn().Err(envelopeSubmissionErr).Int("attempt", attempt).Bool("envelope_submission_succeeded", false).Msg("Execution payload envelope submission attempt completed")
-		log.Warn().Err(envelopeSubmissionErr).Int("attempts_remaining", 3-attempt).Msg("Failed to submit execution payload envelope after block publication")
-		if attempt < 3 {
-			select {
-			case <-ctx.Done():
-				log.Warn().Err(ctx.Err()).Str("status", "failed").Bool("envelope_submission_succeeded", false).Msg("Execution payload envelope submission completed")
-
-				return errors.Wrap(ctx.Err(), "failed to submit execution payload envelope after block publication")
-			case <-time.After(250 * time.Millisecond):
-			}
-		}
-	}
-	if envelopeSubmissionErr == nil {
-		log.Trace().Bool("envelope_submission_succeeded", true).Msg("Execution payload envelope submission completed")
-	} else {
-		log.Warn().Err(envelopeSubmissionErr).Bool("envelope_submission_succeeded", false).Msg("Execution payload envelope submission completed")
-	}
-	if envelopeSubmissionErr != nil {
-		return errors.Wrap(envelopeSubmissionErr, "failed to submit execution payload envelope after block publication")
+	if err := s.submitExecutionPayloadEnvelope(ctx, log, envelopeSubmissionOpts); err != nil {
+		return err
 	}
 	monitorBeaconBlockProposalSource("local")
 
 	return nil
+}
+
+const (
+	// envelopeSubmissionAttempts is the number of times envelope submission is attempted.  The
+	// envelope cannot be submitted by anyone else, so a failure is retried rather than abandoned.
+	envelopeSubmissionAttempts = 3
+	// envelopeSubmissionRetryInterval is the delay between envelope submission attempts.
+	envelopeSubmissionRetryInterval = 250 * time.Millisecond
+)
+
+// submitExecutionPayloadEnvelope submits the execution payload envelope of a published block.
+// It emits exactly one terminal record on every path out, so an envelope whose submission has
+// started always has a recorded outcome.
+func (s *Service) submitExecutionPayloadEnvelope(ctx context.Context,
+	log zerolog.Logger,
+	opts *api.SubmitExecutionPayloadEnvelopeOpts,
+) error {
+	err := s.attemptExecutionPayloadEnvelopeSubmission(ctx, log, opts)
+	if err != nil {
+		log.Warn().Err(err).Str("status", "failed").Bool("envelope_submission_succeeded", false).Msg("Execution payload envelope submission completed")
+
+		return errors.Wrap(err, "failed to submit execution payload envelope after block publication")
+	}
+	log.Trace().Bool("envelope_submission_succeeded", true).Msg("Execution payload envelope submission completed")
+
+	return nil
+}
+
+// attemptExecutionPayloadEnvelopeSubmission submits the envelope, retrying on failure.  It returns
+// the final attempt's error, or the context error if the context is cancelled while backing off.
+func (s *Service) attemptExecutionPayloadEnvelopeSubmission(ctx context.Context,
+	log zerolog.Logger,
+	opts *api.SubmitExecutionPayloadEnvelopeOpts,
+) error {
+	var err error
+	for attempt := 1; attempt <= envelopeSubmissionAttempts; attempt++ {
+		if attempt > 1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(envelopeSubmissionRetryInterval):
+			}
+		}
+		log.Trace().Int("attempt", attempt).Msg("Submitting execution payload envelope")
+		err = s.executionPayloadEnvelopeSubmitter.SubmitExecutionPayloadEnvelope(ctx, opts)
+		if err == nil {
+			log.Trace().Int("attempt", attempt).Bool("envelope_submission_succeeded", true).Msg("Execution payload envelope submission attempt completed")
+
+			return nil
+		}
+		log.Warn().Err(err).Int("attempt", attempt).Int("attempts_remaining", envelopeSubmissionAttempts-attempt).Bool("envelope_submission_succeeded", false).Msg("Execution payload envelope submission attempt completed")
+	}
+
+	return err
 }
 
 // epbsProposalEnvelope obtains the execution payload envelope and body root for a proposal,

--- a/services/controller/standard/events.go
+++ b/services/controller/standard/events.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 - 2024 Attestant Limited.
+// Copyright © 2020 - 2026 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/services/controller/standard/events.go
+++ b/services/controller/standard/events.go
@@ -178,6 +178,8 @@ func (s *Service) handlePreviousDependentRootChanged(ctx context.Context) {
 
 	// We need to refresh the attester duties for this epoch.
 	s.refreshAttesterDutiesForEpoch(ctx, s.chainTimeService.CurrentEpoch())
+	// The payload timeliness committee is derived from the same epoch state.
+	s.refreshPayloadAttestationDutiesForEpoch(ctx, s.chainTimeService.CurrentEpoch())
 }
 
 // handleCurrentDependentRootChanged handles the situation where the current
@@ -194,6 +196,8 @@ func (s *Service) handleCurrentDependentRootChanged(ctx context.Context) {
 	}
 	// We need to refresh the attester duties for the next epoch.
 	go s.refreshAttesterDutiesForEpoch(ctx, s.chainTimeService.CurrentEpoch()+1)
+	// The payload timeliness committee for the next epoch uses the current dependent root.
+	go s.refreshPayloadAttestationDutiesForEpoch(ctx, s.chainTimeService.CurrentEpoch()+1)
 }
 
 func (s *Service) refreshProposerDutiesForEpoch(ctx context.Context, epoch phase0.Epoch) {

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -506,10 +506,10 @@ func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, g
 	// SYNC_MESSAGE_DUE_BPS_GLOAS are 2500, AGGREGATE_DUE_BPS_GLOAS and CONTRIBUTION_DUE_BPS_GLOAS
 	// are 5000.  A node that does not serve them still schedules to this fork's timings.
 	return dutyTimings{
-		maxAttestationDelay:           dueBPS(spec, "ATTESTATION_DUE_BPS_GLOAS", slotDuration, slotDuration/4),
-		attestationAggregationDelay:   dueBPS(spec, "AGGREGATE_DUE_BPS_GLOAS", slotDuration, slotDuration/2),
-		maxSyncCommitteeMessageDelay:  dueBPS(spec, "SYNC_MESSAGE_DUE_BPS_GLOAS", slotDuration, slotDuration/4),
-		syncCommitteeAggregationDelay: dueBPS(spec, "CONTRIBUTION_DUE_BPS_GLOAS", slotDuration, slotDuration/2),
+		maxAttestationDelay:           dueBPS(spec, "ATTESTATION_DUE_BPS_GLOAS", slotDuration, slotDuration/4),  // 3s on a 12-second slot.
+		attestationAggregationDelay:   dueBPS(spec, "AGGREGATE_DUE_BPS_GLOAS", slotDuration, slotDuration/2),    // 6s on a 12-second slot.
+		maxSyncCommitteeMessageDelay:  dueBPS(spec, "SYNC_MESSAGE_DUE_BPS_GLOAS", slotDuration, slotDuration/4), // 3s on a 12-second slot.
+		syncCommitteeAggregationDelay: dueBPS(spec, "CONTRIBUTION_DUE_BPS_GLOAS", slotDuration, slotDuration/2), // 6s on a 12-second slot.
 	}
 }
 

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -69,7 +69,6 @@ type parameters struct {
 	attestationAggregationDelay   time.Duration
 	maxSyncCommitteeMessageDelay  time.Duration
 	syncCommitteeAggregationDelay time.Duration
-	payloadDueDelay               time.Duration
 	payloadAttestationDelay       time.Duration
 	preGloasTimings               dutyTimings
 	gloasTimings                  dutyTimings
@@ -416,13 +415,6 @@ func WithPayloadAttestationDelay(delay time.Duration) Parameter {
 	})
 }
 
-// WithPayloadDueDelay sets the delay before starting payload attestation work.
-func WithPayloadDueDelay(delay time.Duration) Parameter {
-	return parameterFunc(func(p *parameters) {
-		p.payloadDueDelay = delay
-	})
-}
-
 // dutyTimings holds the duty scheduling deadlines, as offsets in to the slot.
 type dutyTimings struct {
 	maxAttestationDelay           time.Duration
@@ -465,12 +457,8 @@ func (p *parameters) setDefaultDelays(spec map[string]any, slotDuration time.Dur
 	p.gloasTimings = obtainAttestationTimings(spec, slotDuration, true)
 	p.gloasTimings.applyOverrides(overrides)
 
-	payloadDue, payloadAttestationDue := obtainPayloadTimings(spec, slotDuration)
-	if p.payloadDueDelay == 0 {
-		p.payloadDueDelay = payloadDue
-	}
 	if p.payloadAttestationDelay == 0 {
-		p.payloadAttestationDelay = payloadAttestationDue
+		p.payloadAttestationDelay = obtainPayloadAttestationTiming(spec, slotDuration)
 	}
 }
 
@@ -490,7 +478,7 @@ func gloasSlotDuration(spec map[string]any, slotDuration time.Duration) time.Dur
 // the exact key.  Gloas redefines the attestation and sync committee deadlines under
 // _GLOAS-suffixed keys and keeps serving the unsuffixed keys for the slots before the fork, so
 // reading the unsuffixed key after the fork would schedule duties to the deadlines it moved away
-// from; the payload deadlines are new in Gloas and have no suffixed form.
+// from; the payload attestation deadline is new in Gloas and has no suffixed form.
 func dueBPS(spec map[string]any, name string, slotDuration, fallback time.Duration) time.Duration {
 	bps, ok := spec[name].(uint64)
 	if !ok || bps == 0 || bps > 10000 {
@@ -525,11 +513,10 @@ func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, g
 	}
 }
 
-// obtainPayloadTimings provides the payload and payload attestation deadlines.  Both duties exist
-// only after Gloas, so both always follow the Gloas slot duration.
-func obtainPayloadTimings(spec map[string]any, slotDuration time.Duration) (time.Duration, time.Duration) {
+// obtainPayloadAttestationTiming provides the payload attestation deadline.  The duty exists only
+// after Gloas, so it always follows the Gloas slot duration.
+func obtainPayloadAttestationTiming(spec map[string]any, slotDuration time.Duration) time.Duration {
 	slotDuration = gloasSlotDuration(spec, slotDuration)
 
-	return dueBPS(spec, "PAYLOAD_DUE_BPS", slotDuration, slotDuration/2),
-		dueBPS(spec, "PAYLOAD_ATTESTATION_DUE_BPS", slotDuration, slotDuration*3/4)
+	return dueBPS(spec, "PAYLOAD_ATTESTATION_DUE_BPS", slotDuration, slotDuration*3/4)
 }

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -45,6 +45,7 @@ type parameters struct {
 	proposerDutiesProvider        eth2client.ProposerDutiesProvider
 	attesterDutiesProvider        eth2client.AttesterDutiesProvider
 	syncCommitteeDutiesProvider   eth2client.SyncCommitteeDutiesProvider
+	ptcDutiesProvider             eth2client.PTCDutiesProvider
 	validatingAccountsProvider    accountmanager.ValidatingAccountsProvider
 	eventsProvider                eth2client.EventsProvider
 	beaconBlockHeadersProvider    eth2client.BeaconBlockHeadersProvider
@@ -55,10 +56,9 @@ type parameters struct {
 	proposalsPreparer             proposalpreparer.Service
 	scheduler                     scheduler.Service
 	attester                      attester.Service
-	ptcDutiesProvider             eth2client.PTCDutiesProvider
-	payloadAttester               payloadattester.Service
 	syncCommitteeMessenger        synccommitteemessenger.Service
 	syncCommitteeAggregator       synccommitteeaggregator.Service
+	payloadAttester               payloadattester.Service
 	beaconBlockProposer           beaconblockproposer.Service
 	attestationAggregator         attestationaggregator.Service
 	beaconCommitteeSubscriber     beaconcommitteesubscriber.Service

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -28,6 +28,7 @@ import (
 	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/metrics"
 	"github.com/attestantio/vouch/services/multiinstance"
+	"github.com/attestantio/vouch/services/payloadattester"
 	"github.com/attestantio/vouch/services/proposalpreparer"
 	"github.com/attestantio/vouch/services/scheduler"
 	"github.com/attestantio/vouch/services/synccommitteeaggregator"
@@ -54,6 +55,8 @@ type parameters struct {
 	proposalsPreparer             proposalpreparer.Service
 	scheduler                     scheduler.Service
 	attester                      attester.Service
+	ptcDutiesProvider             eth2client.PTCDutiesProvider
+	payloadAttester               payloadattester.Service
 	syncCommitteeMessenger        synccommitteemessenger.Service
 	syncCommitteeAggregator       synccommitteeaggregator.Service
 	beaconBlockProposer           beaconblockproposer.Service
@@ -66,6 +69,8 @@ type parameters struct {
 	attestationAggregationDelay   time.Duration
 	maxSyncCommitteeMessageDelay  time.Duration
 	syncCommitteeAggregationDelay time.Duration
+	payloadDueDelay               time.Duration
+	payloadAttestationDelay       time.Duration
 	preGloasTimings               dutyTimings
 	gloasTimings                  dutyTimings
 	verifySyncCommitteeInclusion  bool
@@ -390,6 +395,34 @@ func (p *parameters) slotDuration(ctx context.Context) (map[string]any, time.Dur
 	return specResponse.Data, slotDuration, nil
 }
 
+// WithPTCDutiesProvider sets the payload timeliness committee duties provider.
+func WithPTCDutiesProvider(provider eth2client.PTCDutiesProvider) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.ptcDutiesProvider = provider
+	})
+}
+
+// WithPayloadAttester sets the payload attester service.
+func WithPayloadAttester(attester payloadattester.Service) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.payloadAttester = attester
+	})
+}
+
+// WithPayloadAttestationDelay sets the delay before submitting payload attestations.
+func WithPayloadAttestationDelay(delay time.Duration) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.payloadAttestationDelay = delay
+	})
+}
+
+// WithPayloadDueDelay sets the delay before starting payload attestation work.
+func WithPayloadDueDelay(delay time.Duration) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.payloadDueDelay = delay
+	})
+}
+
 // dutyTimings holds the duty scheduling deadlines, as offsets in to the slot.
 type dutyTimings struct {
 	maxAttestationDelay           time.Duration
@@ -431,6 +464,40 @@ func (p *parameters) setDefaultDelays(spec map[string]any, slotDuration time.Dur
 	p.preGloasTimings.applyOverrides(overrides)
 	p.gloasTimings = obtainAttestationTimings(spec, slotDuration, true)
 	p.gloasTimings.applyOverrides(overrides)
+
+	payloadDue, payloadAttestationDue := obtainPayloadTimings(spec, slotDuration)
+	if p.payloadDueDelay == 0 {
+		p.payloadDueDelay = payloadDue
+	}
+	if p.payloadAttestationDelay == 0 {
+		p.payloadAttestationDelay = payloadAttestationDue
+	}
+}
+
+// gloasSlotDuration provides the slot duration in effect after Gloas.  Gloas serves this in
+// milliseconds, and it can differ from SECONDS_PER_SLOT, so every Gloas-derived deadline must be a
+// fraction of this value rather than of SECONDS_PER_SLOT.
+func gloasSlotDuration(spec map[string]any, slotDuration time.Duration) time.Duration {
+	if durationMS, ok := spec["SLOT_DURATION_MS"].(uint64); ok && durationMS != 0 {
+		return time.Duration(durationMS) * time.Millisecond
+	}
+
+	return slotDuration
+}
+
+// dueBPS provides the deadline held in the named spec value, in basis points of the slot duration,
+// falling back to the supplied default if the value is not served or is out of range.  The name is
+// the exact key.  Gloas redefines the attestation and sync committee deadlines under
+// _GLOAS-suffixed keys and keeps serving the unsuffixed keys for the slots before the fork, so
+// reading the unsuffixed key after the fork would schedule duties to the deadlines it moved away
+// from; the payload deadlines are new in Gloas and have no suffixed form.
+func dueBPS(spec map[string]any, name string, slotDuration, fallback time.Duration) time.Duration {
+	bps, ok := spec[name].(uint64)
+	if !ok || bps == 0 || bps > 10000 {
+		return fallback
+	}
+
+	return slotDuration * time.Duration(bps) / 10000
 }
 
 func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, gloasActive bool) dutyTimings {
@@ -445,33 +512,24 @@ func obtainAttestationTimings(spec map[string]any, slotDuration time.Duration, g
 		}
 	}
 
-	// Gloas serves the slot duration in milliseconds, and it can differ from SECONDS_PER_SLOT.
-	// All Gloas-derived deadlines must be fractions of this value rather than of SECONDS_PER_SLOT.
-	if durationMS, ok := spec["SLOT_DURATION_MS"].(uint64); ok && durationMS != 0 {
-		slotDuration = time.Duration(durationMS) * time.Millisecond
-	}
-
-	// dueBPS provides the deadline held in the named spec value, in basis points of the slot
-	// duration, falling back to the supplied default if the value is not served or is out of range.
-	// The name is the exact key: Gloas redefines these four deadlines under _GLOAS-suffixed keys and
-	// keeps serving the unsuffixed keys for the slots before the fork, so reading the unsuffixed key
-	// here would schedule post-fork duties to the deadlines the fork moved away from.
-	dueBPS := func(name string, fallback time.Duration) time.Duration {
-		bps, ok := spec[name].(uint64)
-		if !ok || bps == 0 || bps > 10000 {
-			return fallback
-		}
-
-		return slotDuration * time.Duration(bps) / 10000
-	}
+	slotDuration = gloasSlotDuration(spec, slotDuration)
 
 	// The fallbacks are the Gloas deadlines themselves: ATTESTATION_DUE_BPS_GLOAS and
 	// SYNC_MESSAGE_DUE_BPS_GLOAS are 2500, AGGREGATE_DUE_BPS_GLOAS and CONTRIBUTION_DUE_BPS_GLOAS
 	// are 5000.  A node that does not serve them still schedules to this fork's timings.
 	return dutyTimings{
-		maxAttestationDelay:           dueBPS("ATTESTATION_DUE_BPS_GLOAS", slotDuration/4),  // 3s on a 12-second slot.
-		attestationAggregationDelay:   dueBPS("AGGREGATE_DUE_BPS_GLOAS", slotDuration/2),    // 6s on a 12-second slot.
-		maxSyncCommitteeMessageDelay:  dueBPS("SYNC_MESSAGE_DUE_BPS_GLOAS", slotDuration/4), // 3s on a 12-second slot.
-		syncCommitteeAggregationDelay: dueBPS("CONTRIBUTION_DUE_BPS_GLOAS", slotDuration/2), // 6s on a 12-second slot.
+		maxAttestationDelay:           dueBPS(spec, "ATTESTATION_DUE_BPS_GLOAS", slotDuration, slotDuration/4),
+		attestationAggregationDelay:   dueBPS(spec, "AGGREGATE_DUE_BPS_GLOAS", slotDuration, slotDuration/2),
+		maxSyncCommitteeMessageDelay:  dueBPS(spec, "SYNC_MESSAGE_DUE_BPS_GLOAS", slotDuration, slotDuration/4),
+		syncCommitteeAggregationDelay: dueBPS(spec, "CONTRIBUTION_DUE_BPS_GLOAS", slotDuration, slotDuration/2),
 	}
+}
+
+// obtainPayloadTimings provides the payload and payload attestation deadlines.  Both duties exist
+// only after Gloas, so both always follow the Gloas slot duration.
+func obtainPayloadTimings(spec map[string]any, slotDuration time.Duration) (time.Duration, time.Duration) {
+	slotDuration = gloasSlotDuration(spec, slotDuration)
+
+	return dueBPS(spec, "PAYLOAD_DUE_BPS", slotDuration, slotDuration/2),
+		dueBPS(spec, "PAYLOAD_ATTESTATION_DUE_BPS", slotDuration, slotDuration*3/4)
 }

--- a/services/controller/standard/ptc.go
+++ b/services/controller/standard/ptc.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/api"
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -24,6 +25,13 @@ import (
 	"github.com/attestantio/vouch/services/payloadattester"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
 )
+
+// payloadAttestationGrace is added to the payload attestation deadline before the vote is cast.  A
+// beacon node does not serve payload attestation data it does not yet consider final, and one whose
+// clock trails ours has not reached the deadline when we do, so firing exactly on the deadline can
+// return nothing at all.  This covers that skew and still leaves the rest of the slot for the vote
+// to propagate.
+const payloadAttestationGrace = 250 * time.Millisecond
 
 // payloadAttestationJobName provides the scheduler job name for a slot's payload attestations.
 func payloadAttestationJobName(slot phase0.Slot) string {
@@ -127,6 +135,7 @@ func payloadAttestationDuties(data []*apiv1.PTCDuty,
 	return dutiesBySlot, indices
 }
 
+//nolint:godox // The TODO below is tracked as follow-up work, not left as a loose end.
 func (s *Service) schedulePayloadAttestation(ctx context.Context,
 	duty *payloadattester.Duty,
 	accounts map[phase0.ValidatorIndex]e2wtypes.Account,
@@ -140,8 +149,15 @@ func (s *Service) schedulePayloadAttestation(ctx context.Context,
 		duty.SetAccount(index, account)
 	}
 
-	jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadDueDelay)
-	deadline := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadAttestationDelay)
+	// TODO: take the payload-available event once go-eth2-client exposes the SSE topic.
+	// The vote would then be cast as soon as the beacon node reports the payload available, keeping
+	// this deadline as the backstop.  Prysm's validator waits on that event or this deadline,
+	// whichever comes first, which votes earlier in the common case without ever asking before the
+	// answer is final.
+	jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadAttestationDelay).Add(payloadAttestationGrace)
+	// The vote is cast at the attestation deadline, so its context runs to the end of the slot:
+	// bounding it at that deadline would cut off the signing and submission the vote depends on.
+	deadline := s.chainTimeService.StartOfSlot(duty.Slot() + 1)
 	if err := s.scheduler.ScheduleJob(ctx,
 		"Payload attestation",
 		payloadAttestationJobName(duty.Slot()),

--- a/services/controller/standard/ptc.go
+++ b/services/controller/standard/ptc.go
@@ -16,7 +16,7 @@ package standard
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/attestantio/go-eth2-client/api"
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -25,16 +25,25 @@ import (
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
 )
 
+// payloadAttestationJobName provides the scheduler job name for a slot's payload attestations.
+func payloadAttestationJobName(slot phase0.Slot) string {
+	return fmt.Sprintf("Payload attestations for slot %d", slot)
+}
+
 // schedulePayloadAttestations schedules payload attestation duties.
 func (s *Service) schedulePayloadAttestations(ctx context.Context,
 	epoch phase0.Epoch,
 	validatorIndices []phase0.ValidatorIndex,
 	notCurrentSlot bool,
 ) {
-	if !s.canSchedulePayloadAttestations(validatorIndices) {
+	if !s.canSchedulePayloadAttestations(epoch, validatorIndices) {
 		return
 	}
-	if epoch > s.chainTimeService.CurrentEpoch() && s.payloadAttestationsAlreadyScheduled(ctx, epoch) {
+	// The epoch is scheduled from whichever of the epoch ticker and the following epoch's
+	// preparation reaches it first, so check every epoch rather than only future ones: without
+	// this the ticker refetches the duties the preparation already scheduled and then fails to
+	// schedule every one of their jobs.
+	if s.payloadAttestationsAlreadyScheduled(ctx, epoch) {
 		s.log.Trace().Uint64("epoch", uint64(epoch)).Msg("Payload attestation duties already scheduled")
 		return
 	}
@@ -69,19 +78,23 @@ func (s *Service) schedulePayloadAttestations(ctx context.Context,
 	for slot := range dutiesBySlot {
 		slots = append(slots, slot)
 	}
-	sort.Slice(slots, func(i, j int) bool { return slots[i] < slots[j] })
+	slices.Sort(slots)
 	for _, slot := range slots {
 		s.schedulePayloadAttestation(ctx, dutiesBySlot[slot], accounts)
 	}
 }
 
-func (s *Service) canSchedulePayloadAttestations(validatorIndices []phase0.ValidatorIndex) bool {
-	return len(validatorIndices) > 0 && s.ptcDutiesProvider != nil && s.payloadAttester != nil && s.chainTimeService.CurrentEpoch() >= s.gloasForkEpoch
+// canSchedulePayloadAttestations reports whether the duties for the given epoch can be scheduled.
+// The fork test is on the epoch being scheduled rather than on the current one: the epoch after the
+// fork epoch is prepared from the epoch before it, where the current epoch is still pre-Gloas, so
+// testing the current epoch would drop the first Gloas epoch's duties.
+func (s *Service) canSchedulePayloadAttestations(epoch phase0.Epoch, validatorIndices []phase0.ValidatorIndex) bool {
+	return len(validatorIndices) > 0 && s.ptcDutiesProvider != nil && s.payloadAttester != nil && epoch >= s.gloasForkEpoch
 }
 
 func (s *Service) payloadAttestationsAlreadyScheduled(ctx context.Context, epoch phase0.Epoch) bool {
 	for slot := s.chainTimeService.FirstSlotOfEpoch(epoch); slot < s.chainTimeService.FirstSlotOfEpoch(epoch+1); slot++ {
-		if s.scheduler.JobExists(ctx, fmt.Sprintf("Payload attestations for slot %d", slot)) {
+		if s.scheduler.JobExists(ctx, payloadAttestationJobName(slot)) {
 			return true
 		}
 	}
@@ -131,7 +144,7 @@ func (s *Service) schedulePayloadAttestation(ctx context.Context,
 	deadline := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadAttestationDelay)
 	if err := s.scheduler.ScheduleJob(ctx,
 		"Payload attestation",
-		fmt.Sprintf("Payload attestations for slot %d", duty.Slot()),
+		payloadAttestationJobName(duty.Slot()),
 		jobTime,
 		func(ctx context.Context) {
 			ctx, cancel := context.WithDeadline(ctx, deadline)
@@ -150,8 +163,17 @@ func (s *Service) attestPayload(ctx context.Context, duty *payloadattester.Duty)
 }
 
 func (s *Service) refreshPayloadAttestationDutiesForEpoch(ctx context.Context, epoch phase0.Epoch) {
+	// If the epoch duties are yet to be scheduled then we don't have anything to do.
+	if s.scheduler.JobExists(ctx, fmt.Sprintf("Prepare for epoch %d", epoch)) {
+		s.log.Trace().Msg("Payload attestation refresh not necessary as epoch not yet prepared")
+		return
+	}
+
+	cancelledJobs := make(map[phase0.Slot]bool)
 	for slot := s.chainTimeService.FirstSlotOfEpoch(epoch); slot < s.chainTimeService.FirstSlotOfEpoch(epoch+1); slot++ {
-		s.scheduler.CancelJobIfExists(ctx, fmt.Sprintf("Payload attestations for slot %d", slot))
+		if err := s.scheduler.CancelJob(ctx, payloadAttestationJobName(slot)); err == nil {
+			cancelledJobs[slot] = true
+		}
 	}
 
 	_, validatorIndices, err := s.accountsAndIndicesForEpoch(ctx, epoch)
@@ -163,5 +185,9 @@ func (s *Service) refreshPayloadAttestationDutiesForEpoch(ctx context.Context, e
 		return
 	}
 
-	s.schedulePayloadAttestations(ctx, epoch, validatorIndices, false)
+	// Only reschedule the current slot if its job was cancelled.  If it was not then it has
+	// already run, and rescheduling it would place a job in the past that the scheduler runs
+	// immediately, attesting to the same slot's payload twice.
+	currentSlotJobCancelled := cancelledJobs[s.chainTimeService.CurrentSlot()]
+	s.schedulePayloadAttestations(ctx, epoch, validatorIndices, !currentSlotJobCancelled)
 }

--- a/services/controller/standard/ptc.go
+++ b/services/controller/standard/ptc.go
@@ -1,5 +1,15 @@
 // Copyright © 2026 Attestant Limited.
-// Licensed under the Apache License, Version 2.0 (the "License").
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package standard
 

--- a/services/controller/standard/ptc.go
+++ b/services/controller/standard/ptc.go
@@ -1,5 +1,5 @@
 // Copyright © 2026 Attestant Limited.
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the "License").
 
 package standard
 

--- a/services/controller/standard/ptc.go
+++ b/services/controller/standard/ptc.go
@@ -169,6 +169,10 @@ func (s *Service) schedulePayloadAttestation(ctx context.Context,
 		},
 	); err != nil {
 		s.log.Error().Err(err).Msg("Failed to schedule payload attestation")
+		return
+	}
+	if err := s.payloadAttester.Prepare(ctx, duty); err != nil {
+		s.log.Error().Err(err).Uint64("slot", uint64(duty.Slot())).Msg("Failed to prepare payload attestation")
 	}
 }
 

--- a/services/controller/standard/ptc.go
+++ b/services/controller/standard/ptc.go
@@ -1,5 +1,5 @@
 // Copyright © 2026 Attestant Limited.
-// Licensed under the Apache License, Version 2.0 (the "License").
+// Licensed under the Apache License, Version 2.0 (the "License");
 
 package standard
 

--- a/services/controller/standard/ptc.go
+++ b/services/controller/standard/ptc.go
@@ -1,0 +1,133 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package standard
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/payloadattester"
+)
+
+// schedulePayloadAttestations schedules payload attestation duties.
+func (s *Service) schedulePayloadAttestations(ctx context.Context,
+	epoch phase0.Epoch,
+	validatorIndices []phase0.ValidatorIndex,
+	notCurrentSlot bool,
+) {
+	if len(validatorIndices) == 0 || s.ptcDutiesProvider == nil || s.payloadAttester == nil {
+		return
+	}
+	if s.chainTimeService.CurrentEpoch() < s.gloasForkEpoch {
+		return
+	}
+	if epoch > s.chainTimeService.CurrentEpoch() {
+		for slot := s.chainTimeService.FirstSlotOfEpoch(epoch); slot < s.chainTimeService.FirstSlotOfEpoch(epoch+1); slot++ {
+			if s.scheduler.JobExists(ctx, fmt.Sprintf("Payload attestations for slot %d", slot)) {
+				s.log.Trace().Uint64("epoch", uint64(epoch)).Msg("Payload attestation duties already scheduled")
+				return
+			}
+		}
+	}
+
+	response, err := s.ptcDutiesProvider.PTCDuties(ctx, &api.PTCDutiesOpts{
+		Epoch:   epoch,
+		Indices: validatorIndices,
+	})
+	if err != nil {
+		s.log.Error().Err(err).Uint64("epoch", uint64(epoch)).Msg("Failed to fetch payload attestation duties")
+		return
+	}
+	if response == nil || len(response.Data) == 0 {
+		return
+	}
+
+	firstSlot := s.chainTimeService.FirstSlotOfEpoch(epoch)
+	lastSlot := s.chainTimeService.FirstSlotOfEpoch(epoch+1) - 1
+	currentSlot := s.chainTimeService.CurrentSlot()
+	dutiesBySlot := make(map[phase0.Slot]*payloadattester.Duty)
+	indices := make([]phase0.ValidatorIndex, 0, len(response.Data))
+	seenIndices := make(map[phase0.ValidatorIndex]bool)
+	for _, duty := range response.Data {
+		if duty == nil || duty.Slot < firstSlot || duty.Slot > lastSlot || duty.Slot < currentSlot || (duty.Slot == currentSlot && notCurrentSlot) {
+			continue
+		}
+		if existing, exists := dutiesBySlot[duty.Slot]; exists {
+			existing.AddDuty(duty)
+		} else {
+			dutiesBySlot[duty.Slot] = payloadattester.NewDuty(duty)
+		}
+		if !seenIndices[duty.ValidatorIndex] {
+			indices = append(indices, duty.ValidatorIndex)
+			seenIndices[duty.ValidatorIndex] = true
+		}
+	}
+	if len(dutiesBySlot) == 0 {
+		return
+	}
+
+	accounts, err := s.validatingAccountsProvider.ValidatingAccountsForEpochByIndex(ctx, epoch, indices)
+	if err != nil {
+		s.log.Error().Err(err).Uint64("epoch", uint64(epoch)).Msg("Failed to obtain payload attestation accounts")
+		return
+	}
+
+	slots := make([]phase0.Slot, 0, len(dutiesBySlot))
+	for slot := range dutiesBySlot {
+		slots = append(slots, slot)
+	}
+	sort.Slice(slots, func(i, j int) bool { return slots[i] < slots[j] })
+	for _, slot := range slots {
+		duty := dutiesBySlot[slot]
+		for _, index := range duty.ValidatorIndices() {
+			account, exists := accounts[index]
+			if !exists {
+				s.log.Error().Uint64("validator_index", uint64(index)).Msg("No validating account for payload attestation duty")
+				continue
+			}
+			duty.SetAccount(index, account)
+		}
+
+		jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadDueDelay)
+		deadline := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadAttestationDelay)
+		if err := s.scheduler.ScheduleJob(ctx,
+			"Payload attestation",
+			fmt.Sprintf("Payload attestations for slot %d", duty.Slot()),
+			jobTime,
+			func(ctx context.Context) {
+				ctx, cancel := context.WithDeadline(ctx, deadline)
+				defer cancel()
+				s.attestPayload(ctx, duty)
+			},
+		); err != nil {
+			s.log.Error().Err(err).Msg("Failed to schedule payload attestation")
+		}
+	}
+}
+
+func (s *Service) attestPayload(ctx context.Context, duty *payloadattester.Duty) {
+	if _, err := s.payloadAttester.Attest(ctx, duty); err != nil {
+		s.log.Error().Err(err).Uint64("slot", uint64(duty.Slot())).Msg("Failed to attest to payload timeliness")
+	}
+}
+
+func (s *Service) refreshPayloadAttestationDutiesForEpoch(ctx context.Context, epoch phase0.Epoch) {
+	for slot := s.chainTimeService.FirstSlotOfEpoch(epoch); slot < s.chainTimeService.FirstSlotOfEpoch(epoch+1); slot++ {
+		s.scheduler.CancelJobIfExists(ctx, fmt.Sprintf("Payload attestations for slot %d", slot))
+	}
+
+	_, validatorIndices, err := s.accountsAndIndicesForEpoch(ctx, epoch)
+	if err != nil {
+		s.log.Error().Err(err).Uint64("epoch", uint64(epoch)).Msg("Failed to obtain payload attestation validators")
+		return
+	}
+	if len(validatorIndices) == 0 {
+		return
+	}
+
+	s.schedulePayloadAttestations(ctx, epoch, validatorIndices, false)
+}

--- a/services/controller/standard/ptc.go
+++ b/services/controller/standard/ptc.go
@@ -9,8 +9,10 @@ import (
 	"sort"
 
 	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/payloadattester"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
 )
 
 // schedulePayloadAttestations schedules payload attestation duties.
@@ -19,19 +21,12 @@ func (s *Service) schedulePayloadAttestations(ctx context.Context,
 	validatorIndices []phase0.ValidatorIndex,
 	notCurrentSlot bool,
 ) {
-	if len(validatorIndices) == 0 || s.ptcDutiesProvider == nil || s.payloadAttester == nil {
+	if !s.canSchedulePayloadAttestations(validatorIndices) {
 		return
 	}
-	if s.chainTimeService.CurrentEpoch() < s.gloasForkEpoch {
+	if epoch > s.chainTimeService.CurrentEpoch() && s.payloadAttestationsAlreadyScheduled(ctx, epoch) {
+		s.log.Trace().Uint64("epoch", uint64(epoch)).Msg("Payload attestation duties already scheduled")
 		return
-	}
-	if epoch > s.chainTimeService.CurrentEpoch() {
-		for slot := s.chainTimeService.FirstSlotOfEpoch(epoch); slot < s.chainTimeService.FirstSlotOfEpoch(epoch+1); slot++ {
-			if s.scheduler.JobExists(ctx, fmt.Sprintf("Payload attestations for slot %d", slot)) {
-				s.log.Trace().Uint64("epoch", uint64(epoch)).Msg("Payload attestation duties already scheduled")
-				return
-			}
-		}
 	}
 
 	response, err := s.ptcDutiesProvider.PTCDuties(ctx, &api.PTCDutiesOpts{
@@ -49,23 +44,7 @@ func (s *Service) schedulePayloadAttestations(ctx context.Context,
 	firstSlot := s.chainTimeService.FirstSlotOfEpoch(epoch)
 	lastSlot := s.chainTimeService.FirstSlotOfEpoch(epoch+1) - 1
 	currentSlot := s.chainTimeService.CurrentSlot()
-	dutiesBySlot := make(map[phase0.Slot]*payloadattester.Duty)
-	indices := make([]phase0.ValidatorIndex, 0, len(response.Data))
-	seenIndices := make(map[phase0.ValidatorIndex]bool)
-	for _, duty := range response.Data {
-		if duty == nil || duty.Slot < firstSlot || duty.Slot > lastSlot || duty.Slot < currentSlot || (duty.Slot == currentSlot && notCurrentSlot) {
-			continue
-		}
-		if existing, exists := dutiesBySlot[duty.Slot]; exists {
-			existing.AddDuty(duty)
-		} else {
-			dutiesBySlot[duty.Slot] = payloadattester.NewDuty(duty)
-		}
-		if !seenIndices[duty.ValidatorIndex] {
-			indices = append(indices, duty.ValidatorIndex)
-			seenIndices[duty.ValidatorIndex] = true
-		}
-	}
+	dutiesBySlot, indices := payloadAttestationDuties(response.Data, firstSlot, lastSlot, currentSlot, notCurrentSlot)
 	if len(dutiesBySlot) == 0 {
 		return
 	}
@@ -82,30 +61,75 @@ func (s *Service) schedulePayloadAttestations(ctx context.Context,
 	}
 	sort.Slice(slots, func(i, j int) bool { return slots[i] < slots[j] })
 	for _, slot := range slots {
-		duty := dutiesBySlot[slot]
-		for _, index := range duty.ValidatorIndices() {
-			account, exists := accounts[index]
-			if !exists {
-				s.log.Error().Uint64("validator_index", uint64(index)).Msg("No validating account for payload attestation duty")
-				continue
-			}
-			duty.SetAccount(index, account)
-		}
+		s.schedulePayloadAttestation(ctx, dutiesBySlot[slot], accounts)
+	}
+}
 
-		jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadDueDelay)
-		deadline := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadAttestationDelay)
-		if err := s.scheduler.ScheduleJob(ctx,
-			"Payload attestation",
-			fmt.Sprintf("Payload attestations for slot %d", duty.Slot()),
-			jobTime,
-			func(ctx context.Context) {
-				ctx, cancel := context.WithDeadline(ctx, deadline)
-				defer cancel()
-				s.attestPayload(ctx, duty)
-			},
-		); err != nil {
-			s.log.Error().Err(err).Msg("Failed to schedule payload attestation")
+func (s *Service) canSchedulePayloadAttestations(validatorIndices []phase0.ValidatorIndex) bool {
+	return len(validatorIndices) > 0 && s.ptcDutiesProvider != nil && s.payloadAttester != nil && s.chainTimeService.CurrentEpoch() >= s.gloasForkEpoch
+}
+
+func (s *Service) payloadAttestationsAlreadyScheduled(ctx context.Context, epoch phase0.Epoch) bool {
+	for slot := s.chainTimeService.FirstSlotOfEpoch(epoch); slot < s.chainTimeService.FirstSlotOfEpoch(epoch+1); slot++ {
+		if s.scheduler.JobExists(ctx, fmt.Sprintf("Payload attestations for slot %d", slot)) {
+			return true
 		}
+	}
+	return false
+}
+
+func payloadAttestationDuties(data []*apiv1.PTCDuty,
+	firstSlot phase0.Slot,
+	lastSlot phase0.Slot,
+	currentSlot phase0.Slot,
+	notCurrentSlot bool,
+) (map[phase0.Slot]*payloadattester.Duty, []phase0.ValidatorIndex) {
+	dutiesBySlot := make(map[phase0.Slot]*payloadattester.Duty)
+	indices := make([]phase0.ValidatorIndex, 0, len(data))
+	seenIndices := make(map[phase0.ValidatorIndex]bool)
+	for _, duty := range data {
+		if duty == nil || duty.Slot < firstSlot || duty.Slot > lastSlot || duty.Slot < currentSlot || (duty.Slot == currentSlot && notCurrentSlot) {
+			continue
+		}
+		if existing, exists := dutiesBySlot[duty.Slot]; exists {
+			existing.AddDuty(duty)
+		} else {
+			dutiesBySlot[duty.Slot] = payloadattester.NewDuty(duty)
+		}
+		if !seenIndices[duty.ValidatorIndex] {
+			indices = append(indices, duty.ValidatorIndex)
+			seenIndices[duty.ValidatorIndex] = true
+		}
+	}
+	return dutiesBySlot, indices
+}
+
+func (s *Service) schedulePayloadAttestation(ctx context.Context,
+	duty *payloadattester.Duty,
+	accounts map[phase0.ValidatorIndex]e2wtypes.Account,
+) {
+	for _, index := range duty.ValidatorIndices() {
+		account, exists := accounts[index]
+		if !exists {
+			s.log.Error().Uint64("validator_index", uint64(index)).Msg("No validating account for payload attestation duty")
+			continue
+		}
+		duty.SetAccount(index, account)
+	}
+
+	jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadDueDelay)
+	deadline := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadAttestationDelay)
+	if err := s.scheduler.ScheduleJob(ctx,
+		"Payload attestation",
+		fmt.Sprintf("Payload attestations for slot %d", duty.Slot()),
+		jobTime,
+		func(ctx context.Context) {
+			ctx, cancel := context.WithDeadline(ctx, deadline)
+			defer cancel()
+			s.attestPayload(ctx, duty)
+		},
+	); err != nil {
+		s.log.Error().Err(err).Msg("Failed to schedule payload attestation")
 	}
 }
 

--- a/services/controller/standard/ptc_internal_test.go
+++ b/services/controller/standard/ptc_internal_test.go
@@ -5,6 +5,7 @@ package standard
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -47,6 +48,7 @@ func TestSchedulePayloadAttestationsGroupsDutiesAndCallsService(t *testing.T) {
 	require.Equal(t, 1, provider.calls)
 	require.Equal(t, []phase0.ValidatorIndex{1, 2, 3}, accounts.indices)
 	require.Len(t, schedulerService.jobs, 2)
+	require.Len(t, payloadService.prepared, 2)
 
 	job := schedulerService.jobs[0]
 	job.job(ctx)
@@ -55,6 +57,23 @@ func TestSchedulePayloadAttestationsGroupsDutiesAndCallsService(t *testing.T) {
 	require.Equal(t, phase0.Slot(10), payloadService.duties[0].Slot())
 	require.Equal(t, []phase0.ValidatorIndex{1, 2}, payloadService.duties[0].ValidatorIndices())
 	require.Len(t, payloadService.duties[0].Accounts(), 2)
+}
+
+func TestSchedulePayloadAttestationDoesNotPrepareWhenSchedulingFails(t *testing.T) {
+	ctx := context.Background()
+	schedulerService := &recordingScheduler{err: errors.New("scheduler failed")}
+	payloadService := &recordingPayloadAttester{}
+	service := &Service{
+		chainTimeService:        &recordingChainTime{slotDuration: time.Second, slotsPerEpoch: 32},
+		scheduler:               schedulerService,
+		payloadAttester:         payloadService,
+		payloadAttestationDelay: time.Second,
+	}
+	duty := payloadattester.NewDuty(&apiv1.PTCDuty{Slot: 10, ValidatorIndex: 1})
+
+	service.schedulePayloadAttestation(ctx, duty, map[phase0.ValidatorIndex]e2wtypes.Account{})
+
+	require.Empty(t, payloadService.prepared)
 }
 
 // TestSchedulePayloadAttestationVotesAtTheAttestationDeadline confirms that the vote is cast at the
@@ -315,6 +334,7 @@ func (*recordingAccountsProvider) SyncCommitteeAccountsForEpochByIndex(_ context
 type recordingScheduler struct {
 	jobs      []recordedJob
 	cancelled []string
+	err       error
 	existing  map[string]bool
 	// missing names the jobs for which a cancellation reports that no such job exists, standing
 	// in for a job that has already run.
@@ -327,6 +347,9 @@ type recordedJob struct {
 }
 
 func (s *recordingScheduler) ScheduleJob(_ context.Context, _ string, _ string, runtime time.Time, job scheduler.JobFunc) error {
+	if s.err != nil {
+		return s.err
+	}
 	s.jobs = append(s.jobs, recordedJob{runtime: runtime, job: job})
 	return nil
 }
@@ -353,10 +376,14 @@ func (*recordingScheduler) ListJobs(context.Context) []string               { re
 
 type recordingPayloadAttester struct {
 	duties   []*payloadattester.Duty
+	prepared []*payloadattester.Duty
 	deadline time.Time
 }
 
-func (*recordingPayloadAttester) Prepare(context.Context, *payloadattester.Duty) error { return nil }
+func (s *recordingPayloadAttester) Prepare(_ context.Context, duty *payloadattester.Duty) error {
+	s.prepared = append(s.prepared, duty)
+	return nil
+}
 
 func (s *recordingPayloadAttester) Attest(ctx context.Context, duty *payloadattester.Duty) ([]*spec.VersionedPayloadAttestationMessage, error) {
 	s.deadline, _ = ctx.Deadline()

--- a/services/controller/standard/ptc_internal_test.go
+++ b/services/controller/standard/ptc_internal_test.go
@@ -137,6 +137,93 @@ func TestSchedulePayloadAttestationsSkipsPastAndCurrentSlotWhenRequested(t *test
 	require.Equal(t, phase0.Slot(33), service.payloadAttester.(*recordingPayloadAttester).duties[0].Slot())
 }
 
+// TestSchedulePayloadAttestationsDoesNotRescheduleCurrentEpoch confirms that the epoch ticker does
+// not refetch and reschedule an epoch that the preceding epoch's preparation already scheduled.
+// Both call sites reach the same epoch, and the scheduler rejects a job that already exists, so
+// without this every payload attestation duty would fail to schedule once per epoch.
+func TestSchedulePayloadAttestationsDoesNotRescheduleCurrentEpoch(t *testing.T) {
+	provider := &recordingPTCDutiesProvider{duties: []*apiv1.PTCDuty{{Slot: 10, ValidatorIndex: 1}}}
+	schedulerService := &recordingScheduler{existing: map[string]bool{"Payload attestations for slot 10": true}}
+	service := &Service{
+		chainTimeService:           &recordingChainTime{currentEpoch: 0, slotsPerEpoch: 32},
+		ptcDutiesProvider:          provider,
+		validatingAccountsProvider: &recordingAccountsProvider{},
+		scheduler:                  schedulerService,
+		payloadAttester:            &recordingPayloadAttester{},
+		gloasForkEpoch:             0,
+	}
+
+	service.schedulePayloadAttestations(context.Background(), 0, []phase0.ValidatorIndex{1}, false)
+
+	require.Equal(t, 0, provider.calls)
+	require.Empty(t, schedulerService.jobs)
+}
+
+// TestSchedulePayloadAttestationsSchedulesFirstGloasEpochBeforeTheFork confirms that the first Gloas
+// epoch's duties are scheduled from the epoch before the fork, where they are prepared.  Testing the
+// current epoch rather than the epoch being scheduled would drop that whole epoch's duties.
+func TestSchedulePayloadAttestationsSchedulesFirstGloasEpochBeforeTheFork(t *testing.T) {
+	provider := &recordingPTCDutiesProvider{duties: []*apiv1.PTCDuty{{Slot: 165, ValidatorIndex: 1}}}
+	schedulerService := &recordingScheduler{}
+	service := &Service{
+		chainTimeService:           &recordingChainTime{currentEpoch: 4, slotDuration: time.Second, slotsPerEpoch: 32},
+		ptcDutiesProvider:          provider,
+		validatingAccountsProvider: &recordingAccountsProvider{},
+		scheduler:                  schedulerService,
+		payloadAttester:            &recordingPayloadAttester{},
+		gloasForkEpoch:             5,
+	}
+
+	service.schedulePayloadAttestations(context.Background(), 5, []phase0.ValidatorIndex{1}, true)
+
+	require.Equal(t, 1, provider.calls)
+	require.Len(t, schedulerService.jobs, 1)
+}
+
+// TestRefreshPayloadAttestationsDoesNotRerunTheCurrentSlot confirms that a refresh does not
+// reschedule the current slot's duty when its job has already run.  The scheduler runs a job whose
+// time has passed immediately, so rescheduling it would attest to the same slot's payload twice.
+func TestRefreshPayloadAttestationsDoesNotRerunTheCurrentSlot(t *testing.T) {
+	schedulerService := &recordingScheduler{missing: map[string]bool{"Payload attestations for slot 32": true}}
+	service := &Service{
+		chainTimeService: &recordingChainTime{currentEpoch: 1, slotDuration: time.Second, slotsPerEpoch: 32},
+		ptcDutiesProvider: &recordingPTCDutiesProvider{duties: []*apiv1.PTCDuty{
+			{Slot: 32, ValidatorIndex: 1},
+			{Slot: 33, ValidatorIndex: 1},
+		}},
+		validatingAccountsProvider: &recordingAccountsProvider{epochIndices: []phase0.ValidatorIndex{1}},
+		scheduler:                  schedulerService,
+		payloadAttester:            &recordingPayloadAttester{},
+		gloasForkEpoch:             0,
+	}
+
+	service.refreshPayloadAttestationDutiesForEpoch(context.Background(), 1)
+
+	require.Len(t, schedulerService.jobs, 1)
+	require.Equal(t, service.chainTimeService.StartOfSlot(33), schedulerService.jobs[0].runtime)
+}
+
+// TestRefreshPayloadAttestationsWaitsForEpochPreparation confirms that a refresh of an epoch that
+// has not yet been prepared leaves it alone, rather than fetching its duties early.
+func TestRefreshPayloadAttestationsWaitsForEpochPreparation(t *testing.T) {
+	provider := &recordingPTCDutiesProvider{duties: []*apiv1.PTCDuty{{Slot: 40, ValidatorIndex: 1}}}
+	schedulerService := &recordingScheduler{existing: map[string]bool{"Prepare for epoch 1": true}}
+	service := &Service{
+		chainTimeService:           &recordingChainTime{currentEpoch: 0, slotsPerEpoch: 32},
+		ptcDutiesProvider:          provider,
+		validatingAccountsProvider: &recordingAccountsProvider{epochIndices: []phase0.ValidatorIndex{1}},
+		scheduler:                  schedulerService,
+		payloadAttester:            &recordingPayloadAttester{},
+		gloasForkEpoch:             0,
+	}
+
+	service.refreshPayloadAttestationDutiesForEpoch(context.Background(), 1)
+
+	require.Equal(t, 0, provider.calls)
+	require.Empty(t, schedulerService.cancelled)
+	require.Empty(t, schedulerService.jobs)
+}
+
 type recordingPTCDutiesProvider struct {
 	duties []*apiv1.PTCDuty
 	calls  int
@@ -181,6 +268,9 @@ type recordingScheduler struct {
 	jobs      []recordedJob
 	cancelled []string
 	existing  map[string]bool
+	// missing names the jobs for which a cancellation reports that no such job exists, standing
+	// in for a job that has already run.
+	missing map[string]bool
 }
 
 type recordedJob struct {
@@ -198,6 +288,9 @@ func (*recordingScheduler) SchedulePeriodicJob(context.Context, string, string, 
 }
 
 func (s *recordingScheduler) CancelJob(_ context.Context, name string) error {
+	if s.missing[name] {
+		return scheduler.ErrNoSuchJob
+	}
 	s.cancelled = append(s.cancelled, name)
 	return nil
 }

--- a/services/controller/standard/ptc_internal_test.go
+++ b/services/controller/standard/ptc_internal_test.go
@@ -169,11 +169,11 @@ func (p *recordingAccountsProvider) ValidatingAccountsForEpochByIndex(_ context.
 	return accounts, nil
 }
 
-func (p *recordingAccountsProvider) SyncCommitteeAccountsForEpoch(_ context.Context, _ phase0.Epoch) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+func (*recordingAccountsProvider) SyncCommitteeAccountsForEpoch(_ context.Context, _ phase0.Epoch) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
 	return nil, nil
 }
 
-func (p *recordingAccountsProvider) SyncCommitteeAccountsForEpochByIndex(_ context.Context, _ phase0.Epoch, _ []phase0.ValidatorIndex) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+func (*recordingAccountsProvider) SyncCommitteeAccountsForEpochByIndex(_ context.Context, _ phase0.Epoch, _ []phase0.ValidatorIndex) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
 	return nil, nil
 }
 

--- a/services/controller/standard/ptc_internal_test.go
+++ b/services/controller/standard/ptc_internal_test.go
@@ -38,7 +38,6 @@ func TestSchedulePayloadAttestationsGroupsDutiesAndCallsService(t *testing.T) {
 		validatingAccountsProvider: accounts,
 		scheduler:                  schedulerService,
 		payloadAttester:            payloadService,
-		payloadDueDelay:            500 * time.Millisecond,
 		payloadAttestationDelay:    750 * time.Millisecond,
 		gloasForkEpoch:             0,
 	}
@@ -50,14 +49,64 @@ func TestSchedulePayloadAttestationsGroupsDutiesAndCallsService(t *testing.T) {
 	require.Len(t, schedulerService.jobs, 2)
 
 	job := schedulerService.jobs[0]
-	require.Equal(t, chainTime.StartOfSlot(10).Add(500*time.Millisecond), job.runtime)
 	job.job(ctx)
 
 	require.Len(t, payloadService.duties, 1)
-	require.Equal(t, chainTime.StartOfSlot(10).Add(750*time.Millisecond), payloadService.deadline)
 	require.Equal(t, phase0.Slot(10), payloadService.duties[0].Slot())
 	require.Equal(t, []phase0.ValidatorIndex{1, 2}, payloadService.duties[0].ValidatorIndices())
 	require.Len(t, payloadService.duties[0].Accounts(), 2)
+}
+
+// TestSchedulePayloadAttestationVotesAtTheAttestationDeadline confirms that the vote is cast at the
+// payload attestation deadline rather than when the payload becomes due.  payload_present is a
+// question about the payload due time that only the beacon node can answer, and a beacon node does
+// not serve an answer it does not yet consider final, so voting at the payload due time returns no
+// data at all for exactly the marginal payloads the vote exists to judge.
+func TestSchedulePayloadAttestationVotesAtTheAttestationDeadline(t *testing.T) {
+	ctx := context.Background()
+	schedulerService := &recordingScheduler{}
+	chainTime := &recordingChainTime{slotDuration: 12 * time.Second, slotsPerEpoch: 32}
+	service := &Service{
+		chainTimeService:           chainTime,
+		ptcDutiesProvider:          &recordingPTCDutiesProvider{duties: []*apiv1.PTCDuty{{Slot: 10, ValidatorIndex: 1}}},
+		validatingAccountsProvider: &recordingAccountsProvider{},
+		scheduler:                  schedulerService,
+		payloadAttester:            &recordingPayloadAttester{},
+		payloadAttestationDelay:    9 * time.Second,
+		gloasForkEpoch:             0,
+	}
+
+	service.schedulePayloadAttestations(ctx, 0, []phase0.ValidatorIndex{1}, false)
+
+	require.Len(t, schedulerService.jobs, 1)
+	require.Equal(t, chainTime.StartOfSlot(10).Add(9*time.Second+250*time.Millisecond), schedulerService.jobs[0].runtime)
+}
+
+// TestSchedulePayloadAttestationDeadlineRunsToTheEndOfTheSlot confirms that the vote's context runs
+// to the end of its slot rather than to the payload attestation deadline.  The vote is cast at that
+// deadline, so a context expiring on it would cut off the signing and submission it is there to
+// bound, and the gossip rule accepts a payload attestation for the whole of its slot.
+func TestSchedulePayloadAttestationDeadlineRunsToTheEndOfTheSlot(t *testing.T) {
+	ctx := context.Background()
+	schedulerService := &recordingScheduler{}
+	payloadService := &recordingPayloadAttester{}
+	chainTime := &recordingChainTime{slotDuration: 12 * time.Second, slotsPerEpoch: 32}
+	service := &Service{
+		chainTimeService:           chainTime,
+		ptcDutiesProvider:          &recordingPTCDutiesProvider{duties: []*apiv1.PTCDuty{{Slot: 10, ValidatorIndex: 1}}},
+		validatingAccountsProvider: &recordingAccountsProvider{},
+		scheduler:                  schedulerService,
+		payloadAttester:            payloadService,
+		payloadAttestationDelay:    9 * time.Second,
+		gloasForkEpoch:             0,
+	}
+
+	service.schedulePayloadAttestations(ctx, 0, []phase0.ValidatorIndex{1}, false)
+
+	require.Len(t, schedulerService.jobs, 1)
+	schedulerService.jobs[0].job(ctx)
+
+	require.Equal(t, chainTime.StartOfSlot(11), payloadService.deadline)
 }
 
 func TestSchedulePayloadAttestationsIsInactiveBeforeGloas(t *testing.T) {
@@ -102,7 +151,6 @@ func TestSchedulePayloadAttestationsDoesNotRefetchScheduledEpoch(t *testing.T) {
 		validatingAccountsProvider: &recordingAccountsProvider{},
 		scheduler:                  schedulerService,
 		payloadAttester:            &recordingPayloadAttester{},
-		payloadDueDelay:            500 * time.Millisecond,
 		payloadAttestationDelay:    750 * time.Millisecond,
 		gloasForkEpoch:             0,
 	}
@@ -200,7 +248,7 @@ func TestRefreshPayloadAttestationsDoesNotRerunTheCurrentSlot(t *testing.T) {
 	service.refreshPayloadAttestationDutiesForEpoch(context.Background(), 1)
 
 	require.Len(t, schedulerService.jobs, 1)
-	require.Equal(t, service.chainTimeService.StartOfSlot(33), schedulerService.jobs[0].runtime)
+	require.Equal(t, service.chainTimeService.StartOfSlot(33).Add(payloadAttestationGrace), schedulerService.jobs[0].runtime)
 }
 
 // TestRefreshPayloadAttestationsWaitsForEpochPreparation confirms that a refresh of an epoch that

--- a/services/controller/standard/ptc_internal_test.go
+++ b/services/controller/standard/ptc_internal_test.go
@@ -1,0 +1,225 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package standard
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/payloadattester"
+	"github.com/attestantio/vouch/services/scheduler"
+	"github.com/stretchr/testify/require"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+func TestSchedulePayloadAttestationsGroupsDutiesAndCallsService(t *testing.T) {
+	ctx := context.Background()
+	provider := &recordingPTCDutiesProvider{
+		duties: []*apiv1.PTCDuty{
+			{Slot: 10, ValidatorIndex: 1},
+			{Slot: 10, ValidatorIndex: 2},
+			{Slot: 11, ValidatorIndex: 3},
+		},
+	}
+	accounts := &recordingAccountsProvider{}
+	schedulerService := &recordingScheduler{}
+	payloadService := &recordingPayloadAttester{}
+	chainTime := &recordingChainTime{slotDuration: time.Second, slotsPerEpoch: 32}
+
+	service := &Service{
+		chainTimeService:           chainTime,
+		ptcDutiesProvider:          provider,
+		validatingAccountsProvider: accounts,
+		scheduler:                  schedulerService,
+		payloadAttester:            payloadService,
+		payloadDueDelay:            500 * time.Millisecond,
+		payloadAttestationDelay:    750 * time.Millisecond,
+		gloasForkEpoch:             0,
+	}
+
+	service.schedulePayloadAttestations(ctx, 0, []phase0.ValidatorIndex{1, 2, 3}, false)
+
+	require.Equal(t, 1, provider.calls)
+	require.Equal(t, []phase0.ValidatorIndex{1, 2, 3}, accounts.indices)
+	require.Len(t, schedulerService.jobs, 2)
+
+	job := schedulerService.jobs[0]
+	require.Equal(t, chainTime.StartOfSlot(10).Add(500*time.Millisecond), job.runtime)
+	job.job(ctx)
+
+	require.Len(t, payloadService.duties, 1)
+	require.Equal(t, chainTime.StartOfSlot(10).Add(750*time.Millisecond), payloadService.deadline)
+	require.Equal(t, phase0.Slot(10), payloadService.duties[0].Slot())
+	require.Equal(t, []phase0.ValidatorIndex{1, 2}, payloadService.duties[0].ValidatorIndices())
+	require.Len(t, payloadService.duties[0].Accounts(), 2)
+}
+
+func TestSchedulePayloadAttestationsIsInactiveBeforeGloas(t *testing.T) {
+	service := &Service{
+		chainTimeService:  &recordingChainTime{currentEpoch: 4, slotsPerEpoch: 32},
+		ptcDutiesProvider: &recordingPTCDutiesProvider{},
+		scheduler:         &recordingScheduler{},
+		payloadAttester:   &recordingPayloadAttester{},
+		gloasForkEpoch:    5,
+	}
+
+	service.schedulePayloadAttestations(context.Background(), 4, []phase0.ValidatorIndex{1}, false)
+
+	require.Equal(t, 0, service.ptcDutiesProvider.(*recordingPTCDutiesProvider).calls)
+	require.Empty(t, service.scheduler.(*recordingScheduler).jobs)
+}
+
+func TestRefreshPayloadAttestationsReschedulesAfterDependentRootChange(t *testing.T) {
+	schedulerService := &recordingScheduler{}
+	service := &Service{
+		chainTimeService:           &recordingChainTime{currentEpoch: 0, slotsPerEpoch: 32},
+		ptcDutiesProvider:          &recordingPTCDutiesProvider{duties: []*apiv1.PTCDuty{{Slot: 10, ValidatorIndex: 1}}},
+		validatingAccountsProvider: &recordingAccountsProvider{epochIndices: []phase0.ValidatorIndex{1}},
+		scheduler:                  schedulerService,
+		payloadAttester:            &recordingPayloadAttester{},
+		payloadAttestationDelay:    time.Second,
+		gloasForkEpoch:             0,
+	}
+
+	service.refreshPayloadAttestationDutiesForEpoch(context.Background(), 0)
+
+	require.Contains(t, schedulerService.cancelled, "Payload attestations for slot 10")
+	require.Len(t, schedulerService.jobs, 1)
+}
+
+func TestSchedulePayloadAttestationsDoesNotRefetchScheduledEpoch(t *testing.T) {
+	provider := &recordingPTCDutiesProvider{duties: []*apiv1.PTCDuty{{Slot: 42, ValidatorIndex: 1}}}
+	schedulerService := &recordingScheduler{existing: map[string]bool{"Payload attestations for slot 42": true}}
+	service := &Service{
+		chainTimeService:           &recordingChainTime{slotsPerEpoch: 32},
+		ptcDutiesProvider:          provider,
+		validatingAccountsProvider: &recordingAccountsProvider{},
+		scheduler:                  schedulerService,
+		payloadAttester:            &recordingPayloadAttester{},
+		payloadDueDelay:            500 * time.Millisecond,
+		payloadAttestationDelay:    750 * time.Millisecond,
+		gloasForkEpoch:             0,
+	}
+
+	service.schedulePayloadAttestations(context.Background(), 1, []phase0.ValidatorIndex{1}, false)
+
+	require.Equal(t, 0, provider.calls)
+	require.Empty(t, schedulerService.jobs)
+}
+
+type recordingPTCDutiesProvider struct {
+	duties []*apiv1.PTCDuty
+	calls  int
+}
+
+func (p *recordingPTCDutiesProvider) PTCDuties(_ context.Context, _ *api.PTCDutiesOpts) (*api.Response[[]*apiv1.PTCDuty], error) {
+	p.calls++
+	return &api.Response[[]*apiv1.PTCDuty]{Data: p.duties}, nil
+}
+
+type recordingAccountsProvider struct {
+	indices      []phase0.ValidatorIndex
+	epochIndices []phase0.ValidatorIndex
+}
+
+func (p *recordingAccountsProvider) ValidatingAccountsForEpoch(_ context.Context, _ phase0.Epoch) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+	accounts := make(map[phase0.ValidatorIndex]e2wtypes.Account, len(p.epochIndices))
+	for _, index := range p.epochIndices {
+		accounts[index] = nil
+	}
+	return accounts, nil
+}
+
+func (p *recordingAccountsProvider) ValidatingAccountsForEpochByIndex(_ context.Context, _ phase0.Epoch, indices []phase0.ValidatorIndex) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+	p.indices = append([]phase0.ValidatorIndex(nil), indices...)
+	accounts := make(map[phase0.ValidatorIndex]e2wtypes.Account, len(indices))
+	for _, index := range indices {
+		accounts[index] = nil
+	}
+	return accounts, nil
+}
+
+func (p *recordingAccountsProvider) SyncCommitteeAccountsForEpoch(_ context.Context, _ phase0.Epoch) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+	return nil, nil
+}
+
+func (p *recordingAccountsProvider) SyncCommitteeAccountsForEpochByIndex(_ context.Context, _ phase0.Epoch, _ []phase0.ValidatorIndex) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+	return nil, nil
+}
+
+type recordingScheduler struct {
+	jobs      []recordedJob
+	cancelled []string
+	existing  map[string]bool
+}
+
+type recordedJob struct {
+	runtime time.Time
+	job     scheduler.JobFunc
+}
+
+func (s *recordingScheduler) ScheduleJob(_ context.Context, _ string, _ string, runtime time.Time, job scheduler.JobFunc) error {
+	s.jobs = append(s.jobs, recordedJob{runtime: runtime, job: job})
+	return nil
+}
+
+func (*recordingScheduler) SchedulePeriodicJob(context.Context, string, string, scheduler.RuntimeFunc, scheduler.JobFunc) error {
+	return nil
+}
+
+func (s *recordingScheduler) CancelJob(_ context.Context, name string) error {
+	s.cancelled = append(s.cancelled, name)
+	return nil
+}
+func (s *recordingScheduler) CancelJobIfExists(_ context.Context, name string) {
+	s.cancelled = append(s.cancelled, name)
+}
+func (*recordingScheduler) CancelJobs(context.Context, string)              {}
+func (*recordingScheduler) RunJob(context.Context, string) error            { return nil }
+func (s *recordingScheduler) JobExists(_ context.Context, name string) bool { return s.existing[name] }
+func (*recordingScheduler) RunJobIfExists(context.Context, string)          {}
+func (*recordingScheduler) ListJobs(context.Context) []string               { return nil }
+
+type recordingPayloadAttester struct {
+	duties   []*payloadattester.Duty
+	deadline time.Time
+}
+
+func (*recordingPayloadAttester) Prepare(context.Context, *payloadattester.Duty) error { return nil }
+
+func (s *recordingPayloadAttester) Attest(ctx context.Context, duty *payloadattester.Duty) ([]*spec.VersionedPayloadAttestationMessage, error) {
+	s.deadline, _ = ctx.Deadline()
+	s.duties = append(s.duties, duty)
+	return nil, nil
+}
+
+type recordingChainTime struct {
+	currentEpoch  phase0.Epoch
+	slotDuration  time.Duration
+	slotsPerEpoch uint64
+}
+
+func (s *recordingChainTime) GenesisTime() time.Time { return time.Unix(0, 0) }
+func (s *recordingChainTime) StartOfSlot(slot phase0.Slot) time.Time {
+	return time.Unix(0, 0).Add(time.Duration(slot) * s.slotDuration)
+}
+func (s *recordingChainTime) StartOfEpoch(epoch phase0.Epoch) time.Time {
+	return s.StartOfSlot(phase0.Slot(uint64(epoch) * s.slotsPerEpoch))
+}
+func (s *recordingChainTime) CurrentSlot() phase0.Slot {
+	return phase0.Slot(uint64(s.currentEpoch) * s.slotsPerEpoch)
+}
+func (s *recordingChainTime) CurrentEpoch() phase0.Epoch { return s.currentEpoch }
+func (s *recordingChainTime) SlotToEpoch(slot phase0.Slot) phase0.Epoch {
+	return phase0.Epoch(uint64(slot) / s.slotsPerEpoch)
+}
+func (s *recordingChainTime) FirstSlotOfEpoch(epoch phase0.Epoch) phase0.Slot {
+	return phase0.Slot(uint64(epoch) * s.slotsPerEpoch)
+}
+func (*recordingChainTime) HardForkEpoch(context.Context, string) phase0.Epoch { return 0 }

--- a/services/controller/standard/ptc_internal_test.go
+++ b/services/controller/standard/ptc_internal_test.go
@@ -113,6 +113,30 @@ func TestSchedulePayloadAttestationsDoesNotRefetchScheduledEpoch(t *testing.T) {
 	require.Empty(t, schedulerService.jobs)
 }
 
+func TestSchedulePayloadAttestationsSkipsPastAndCurrentSlotWhenRequested(t *testing.T) {
+	provider := &recordingPTCDutiesProvider{duties: []*apiv1.PTCDuty{
+		{Slot: 31, ValidatorIndex: 1},
+		{Slot: 32, ValidatorIndex: 2},
+		{Slot: 33, ValidatorIndex: 3},
+	}}
+	schedulerService := &recordingScheduler{}
+	service := &Service{
+		chainTimeService:           &recordingChainTime{currentEpoch: 1, slotsPerEpoch: 32},
+		ptcDutiesProvider:          provider,
+		validatingAccountsProvider: &recordingAccountsProvider{},
+		scheduler:                  schedulerService,
+		payloadAttester:            &recordingPayloadAttester{},
+		gloasForkEpoch:             0,
+	}
+
+	service.schedulePayloadAttestations(context.Background(), 1, []phase0.ValidatorIndex{1, 2, 3}, true)
+
+	require.Len(t, schedulerService.jobs, 1)
+	schedulerService.jobs[0].job(context.Background())
+	require.Len(t, service.payloadAttester.(*recordingPayloadAttester).duties, 1)
+	require.Equal(t, phase0.Slot(33), service.payloadAttester.(*recordingPayloadAttester).duties[0].Slot())
+}
+
 type recordingPTCDutiesProvider struct {
 	duties []*apiv1.PTCDuty
 	calls  int
@@ -205,7 +229,7 @@ type recordingChainTime struct {
 	slotsPerEpoch uint64
 }
 
-func (s *recordingChainTime) GenesisTime() time.Time { return time.Unix(0, 0) }
+func (*recordingChainTime) GenesisTime() time.Time { return time.Unix(0, 0) }
 func (s *recordingChainTime) StartOfSlot(slot phase0.Slot) time.Time {
 	return time.Unix(0, 0).Add(time.Duration(slot) * s.slotDuration)
 }

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/metrics"
 	"github.com/attestantio/vouch/services/multiinstance"
+	"github.com/attestantio/vouch/services/payloadattester"
 	"github.com/attestantio/vouch/services/proposalpreparer"
 	"github.com/attestantio/vouch/services/scheduler"
 	"github.com/attestantio/vouch/services/synccommitteeaggregator"
@@ -67,6 +68,8 @@ type Service struct {
 	proposalsPreparer            proposalpreparer.Service
 	scheduler                    scheduler.Service
 	attester                     attester.Service
+	ptcDutiesProvider            eth2client.PTCDutiesProvider
+	payloadAttester              payloadattester.Service
 	syncCommitteeMessenger       synccommitteemessenger.Service
 	syncCommitteeAggregator      synccommitteeaggregator.Service
 	syncCommitteesSubscriber     synccommitteesubscriber.Service
@@ -78,6 +81,8 @@ type Service struct {
 	accountsRefresher            accountmanager.Refresher
 	blockToSlotSetter            cache.BlockRootToSlotSetter
 	maxProposalDelay             time.Duration
+	payloadDueDelay              time.Duration
+	payloadAttestationDelay      time.Duration
 	preGloasTimings              dutyTimings
 	gloasTimings                 dutyTimings
 	verifySyncCommitteeInclusion bool
@@ -147,6 +152,8 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		proposalsPreparer:            parameters.proposalsPreparer,
 		scheduler:                    parameters.scheduler,
 		attester:                     parameters.attester,
+		ptcDutiesProvider:            parameters.ptcDutiesProvider,
+		payloadAttester:              parameters.payloadAttester,
 		syncCommitteeMessenger:       parameters.syncCommitteeMessenger,
 		syncCommitteeAggregator:      parameters.syncCommitteeAggregator,
 		beaconBlockProposer:          parameters.beaconBlockProposer,
@@ -157,6 +164,8 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		accountsRefresher:            parameters.accountsRefresher,
 		blockToSlotSetter:            parameters.blockToSlotSetter,
 		maxProposalDelay:             parameters.maxProposalDelay,
+		payloadDueDelay:              parameters.payloadDueDelay,
+		payloadAttestationDelay:      parameters.payloadAttestationDelay,
 		preGloasTimings:              parameters.preGloasTimings,
 		gloasTimings:                 parameters.gloasTimings,
 		verifySyncCommitteeInclusion: parameters.verifySyncCommitteeInclusion,
@@ -219,6 +228,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 
 	go s.scheduleProposals(ctx, epoch, validatorIndices, !s.waitedForGenesis)
 	go s.scheduleAttestations(ctx, epoch, validatorIndices, !s.waitedForGenesis)
+	go s.schedulePayloadAttestations(ctx, epoch, validatorIndices, !s.waitedForGenesis)
 	if handlingAltair {
 		thisSyncCommitteePeriodStartEpoch := s.firstEpochOfSyncPeriod(uint64(epoch) / s.epochsPerSyncCommitteePeriod)
 		go s.scheduleSyncCommitteeMessages(ctx, thisSyncCommitteePeriodStartEpoch, syncCommitteeValidatorIndices, true /* notCurrentSlot. */)
@@ -228,6 +238,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		}
 	}
 	go s.scheduleAttestations(ctx, epoch+1, nextEpochValidatorIndices, true /* notCurrentSlot. */)
+	go s.schedulePayloadAttestations(ctx, epoch+1, nextEpochValidatorIndices, true /* notCurrentSlot. */)
 
 	// Update beacon committee subscriptions for this and the next epoch.
 	go s.subscribeToBeaconCommittees(ctx, epoch, accounts)
@@ -333,6 +344,7 @@ func (s *Service) epochTicker(ctx context.Context, data *epochTickerData) {
 	cancel()
 
 	go s.scheduleProposals(ctx, currentEpoch, validatorIndices, false /* notCurrentSlot. */)
+	go s.schedulePayloadAttestations(ctx, currentEpoch, validatorIndices, false /* notCurrentSlot. */)
 	if s.handlingAltair {
 		// Handle the Altair hard fork transition epoch.
 		if currentEpoch == s.altairForkEpoch {
@@ -400,6 +412,7 @@ func (s *Service) prepareForEpoch(ctx context.Context, preparationData *prepareF
 	}
 
 	go s.scheduleAttestations(ctx, preparationData.epoch, validatorIndices, false /* notCurrentSlot. */)
+	go s.schedulePayloadAttestations(ctx, preparationData.epoch, validatorIndices, false /* notCurrentSlot. */)
 	go s.subscribeToBeaconCommittees(ctx, preparationData.epoch, accounts)
 }
 

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -58,6 +58,7 @@ type Service struct {
 	proposerDutiesProvider       eth2client.ProposerDutiesProvider
 	attesterDutiesProvider       eth2client.AttesterDutiesProvider
 	syncCommitteeDutiesProvider  eth2client.SyncCommitteeDutiesProvider
+	ptcDutiesProvider            eth2client.PTCDutiesProvider
 	validatingAccountsProvider   accountmanager.ValidatingAccountsProvider
 	beaconBlockHeadersProvider   eth2client.BeaconBlockHeadersProvider
 	signedBeaconBlockProvider    eth2client.SignedBeaconBlockProvider
@@ -68,11 +69,10 @@ type Service struct {
 	proposalsPreparer            proposalpreparer.Service
 	scheduler                    scheduler.Service
 	attester                     attester.Service
-	ptcDutiesProvider            eth2client.PTCDutiesProvider
-	payloadAttester              payloadattester.Service
 	syncCommitteeMessenger       synccommitteemessenger.Service
 	syncCommitteeAggregator      synccommitteeaggregator.Service
 	syncCommitteesSubscriber     synccommitteesubscriber.Service
+	payloadAttester              payloadattester.Service
 	beaconBlockProposer          beaconblockproposer.Service
 	attestationAggregator        attestationaggregator.Service
 	beaconCommitteeSubscriber    beaconcommitteesubscriber.Service

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -81,7 +81,6 @@ type Service struct {
 	accountsRefresher            accountmanager.Refresher
 	blockToSlotSetter            cache.BlockRootToSlotSetter
 	maxProposalDelay             time.Duration
-	payloadDueDelay              time.Duration
 	payloadAttestationDelay      time.Duration
 	preGloasTimings              dutyTimings
 	gloasTimings                 dutyTimings
@@ -164,7 +163,6 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		accountsRefresher:            parameters.accountsRefresher,
 		blockToSlotSetter:            parameters.blockToSlotSetter,
 		maxProposalDelay:             parameters.maxProposalDelay,
-		payloadDueDelay:              parameters.payloadDueDelay,
 		payloadAttestationDelay:      parameters.payloadAttestationDelay,
 		preGloasTimings:              parameters.preGloasTimings,
 		gloasTimings:                 parameters.gloasTimings,

--- a/services/controller/standard/timing_internal_test.go
+++ b/services/controller/standard/timing_internal_test.go
@@ -254,61 +254,53 @@ func TestTimingsForSlotWithoutGloas(t *testing.T) {
 	require.Equal(t, 4*time.Second, s.timingsForSlot(1<<40).maxAttestationDelay)
 }
 
-// TestObtainPayloadTimings confirms the payload and payload attestation deadlines.  Both duties
-// exist only after Gloas, so both follow the Gloas slot duration on either side of the fork.
-func TestObtainPayloadTimings(t *testing.T) {
+// TestObtainPayloadAttestationTiming confirms the payload attestation deadline.  The duty exists
+// only after Gloas, so the deadline follows the Gloas slot duration on either side of the fork.
+func TestObtainPayloadAttestationTiming(t *testing.T) {
 	// The pre-Gloas slot duration, as served in SECONDS_PER_SLOT.
 	slotDuration := 12 * time.Second
 
 	tests := []struct {
-		name                string
-		spec                map[string]any
-		expectedPayloadDue  time.Duration
-		expectedAttestation time.Duration
+		name     string
+		spec     map[string]any
+		expected time.Duration
 	}{
 		{
-			// The specification values, as devnet-8 serves them: the payload is revealed halfway
-			// through the slot and the payload timeliness committee votes at three quarters.
-			name:                "served values",
-			spec:                gloasDevnet8Spec(),
-			expectedPayloadDue:  6 * time.Second,
-			expectedAttestation: 9 * time.Second,
+			// The specification value, as devnet-8 serves it: the payload timeliness committee
+			// votes three quarters of the way through the slot.
+			name:     "served value",
+			spec:     gloasDevnet8Spec(),
+			expected: 9 * time.Second,
 		},
 		{
-			// The payload deadlines are new in Gloas, so the specification defines no
-			// _GLOAS-suffixed form of either key and a served suffixed key is not read.
-			name:                "unsuffixed keys hold the payload deadlines",
-			spec:                map[string]any{"PAYLOAD_DUE_BPS": uint64(2500), "PAYLOAD_DUE_BPS_GLOAS": uint64(7500)},
-			expectedPayloadDue:  3 * time.Second,
-			expectedAttestation: 9 * time.Second,
+			// The payload attestation deadline is new in Gloas, so the specification defines no
+			// _GLOAS-suffixed form of the key and a served suffixed key is not read.
+			name:     "unsuffixed key holds the deadline",
+			spec:     map[string]any{"PAYLOAD_ATTESTATION_DUE_BPS": uint64(2500), "PAYLOAD_ATTESTATION_DUE_BPS_GLOAS": uint64(7500)},
+			expected: 3 * time.Second,
 		},
 		{
-			name:                "all fallbacks",
-			spec:                map[string]any{},
-			expectedPayloadDue:  6 * time.Second,
-			expectedAttestation: 9 * time.Second,
+			name:     "fallback",
+			spec:     map[string]any{},
+			expected: 9 * time.Second,
 		},
 		{
-			// The payload duties exist only after Gloas, so their fallbacks follow the Gloas slot
-			// duration even though the served basis points are absent.
-			name:                "gloas slot duration drives fallbacks",
-			spec:                map[string]any{"SLOT_DURATION_MS": uint64(6000)},
-			expectedPayloadDue:  3 * time.Second,
-			expectedAttestation: 4500 * time.Millisecond,
+			// The duty exists only after Gloas, so its fallback follows the Gloas slot duration
+			// even though the served basis points are absent.
+			name:     "gloas slot duration drives fallback",
+			spec:     map[string]any{"SLOT_DURATION_MS": uint64(6000)},
+			expected: 4500 * time.Millisecond,
 		},
 		{
-			name:                "out of range values ignored",
-			spec:                map[string]any{"PAYLOAD_DUE_BPS": uint64(0), "PAYLOAD_ATTESTATION_DUE_BPS": uint64(10001)},
-			expectedPayloadDue:  6 * time.Second,
-			expectedAttestation: 9 * time.Second,
+			name:     "out of range value ignored",
+			spec:     map[string]any{"PAYLOAD_ATTESTATION_DUE_BPS": uint64(10001)},
+			expected: 9 * time.Second,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			payloadDue, payloadAttestationDue := obtainPayloadTimings(test.spec, slotDuration)
-			require.Equal(t, test.expectedPayloadDue, payloadDue)
-			require.Equal(t, test.expectedAttestation, payloadAttestationDue)
+			require.Equal(t, test.expected, obtainPayloadAttestationTiming(test.spec, slotDuration))
 		})
 	}
 }

--- a/services/controller/standard/timing_internal_test.go
+++ b/services/controller/standard/timing_internal_test.go
@@ -253,3 +253,62 @@ func TestTimingsForSlotWithoutGloas(t *testing.T) {
 	require.Equal(t, 4*time.Second, s.timingsForSlot(0).maxAttestationDelay)
 	require.Equal(t, 4*time.Second, s.timingsForSlot(1<<40).maxAttestationDelay)
 }
+
+// TestObtainPayloadTimings confirms the payload and payload attestation deadlines.  Both duties
+// exist only after Gloas, so both follow the Gloas slot duration on either side of the fork.
+func TestObtainPayloadTimings(t *testing.T) {
+	// The pre-Gloas slot duration, as served in SECONDS_PER_SLOT.
+	slotDuration := 12 * time.Second
+
+	tests := []struct {
+		name                string
+		spec                map[string]any
+		expectedPayloadDue  time.Duration
+		expectedAttestation time.Duration
+	}{
+		{
+			// The specification values, as devnet-8 serves them: the payload is revealed halfway
+			// through the slot and the payload timeliness committee votes at three quarters.
+			name:                "served values",
+			spec:                gloasDevnet8Spec(),
+			expectedPayloadDue:  6 * time.Second,
+			expectedAttestation: 9 * time.Second,
+		},
+		{
+			// The payload deadlines are new in Gloas, so the specification defines no
+			// _GLOAS-suffixed form of either key and a served suffixed key is not read.
+			name:                "unsuffixed keys hold the payload deadlines",
+			spec:                map[string]any{"PAYLOAD_DUE_BPS": uint64(2500), "PAYLOAD_DUE_BPS_GLOAS": uint64(7500)},
+			expectedPayloadDue:  3 * time.Second,
+			expectedAttestation: 9 * time.Second,
+		},
+		{
+			name:                "all fallbacks",
+			spec:                map[string]any{},
+			expectedPayloadDue:  6 * time.Second,
+			expectedAttestation: 9 * time.Second,
+		},
+		{
+			// The payload duties exist only after Gloas, so their fallbacks follow the Gloas slot
+			// duration even though the served basis points are absent.
+			name:                "gloas slot duration drives fallbacks",
+			spec:                map[string]any{"SLOT_DURATION_MS": uint64(6000)},
+			expectedPayloadDue:  3 * time.Second,
+			expectedAttestation: 4500 * time.Millisecond,
+		},
+		{
+			name:                "out of range values ignored",
+			spec:                map[string]any{"PAYLOAD_DUE_BPS": uint64(0), "PAYLOAD_ATTESTATION_DUE_BPS": uint64(10001)},
+			expectedPayloadDue:  6 * time.Second,
+			expectedAttestation: 9 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payloadDue, payloadAttestationDue := obtainPayloadTimings(test.spec, slotDuration)
+			require.Equal(t, test.expectedPayloadDue, payloadDue)
+			require.Equal(t, test.expectedAttestation, payloadAttestationDue)
+		})
+	}
+}

--- a/services/payloadattester/service.go
+++ b/services/payloadattester/service.go
@@ -1,0 +1,98 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package payloadattester
+
+import (
+	"context"
+
+	"github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/signer"
+	"github.com/attestantio/vouch/services/submitter"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+// Duty contains the validator and slot for a payload attestation duty.
+type Duty struct {
+	slot             phase0.Slot
+	validatorIndices []phase0.ValidatorIndex
+	accounts         map[phase0.ValidatorIndex]e2wtypes.Account
+}
+
+// NewDuty creates a payload attestation duty.
+func NewDuty(duty *v1.PTCDuty) *Duty {
+	return &Duty{
+		slot:             duty.Slot,
+		validatorIndices: []phase0.ValidatorIndex{duty.ValidatorIndex},
+		accounts:         make(map[phase0.ValidatorIndex]e2wtypes.Account),
+	}
+}
+
+// AddDuty adds a validator's duty to this slot's duty.
+func (d *Duty) AddDuty(duty *v1.PTCDuty) {
+	if duty == nil || duty.Slot != d.slot {
+		return
+	}
+	for _, index := range d.validatorIndices {
+		if index == duty.ValidatorIndex {
+			return
+		}
+	}
+	d.validatorIndices = append(d.validatorIndices, duty.ValidatorIndex)
+}
+
+// Slot returns the slot for the duty.
+func (d *Duty) Slot() phase0.Slot {
+	return d.slot
+}
+
+// ValidatorIndex returns the validator index for the duty.
+func (d *Duty) ValidatorIndex() phase0.ValidatorIndex {
+	if len(d.validatorIndices) == 0 {
+		return 0
+	}
+	return d.validatorIndices[0]
+}
+
+// ValidatorIndices returns all validator indices assigned to this slot.
+func (d *Duty) ValidatorIndices() []phase0.ValidatorIndex {
+	return d.validatorIndices
+}
+
+// SetAccount associates an account with a validator index.
+func (d *Duty) SetAccount(index phase0.ValidatorIndex, account e2wtypes.Account) {
+	d.accounts[index] = account
+}
+
+// Account returns the account for a validator index.
+func (d *Duty) Account(index phase0.ValidatorIndex) e2wtypes.Account {
+	return d.accounts[index]
+}
+
+// Accounts returns the accounts associated with the duty.
+func (d *Duty) Accounts() map[phase0.ValidatorIndex]e2wtypes.Account {
+	return d.accounts
+}
+
+// Service is the payload attester service.
+type Service interface {
+	Prepare(ctx context.Context, duty *Duty) error
+	Attest(ctx context.Context, duty *Duty) ([]*spec.VersionedPayloadAttestationMessage, error)
+}
+
+var (
+	_ signer.PayloadAttestationDataSigner
+	_ submitter.PayloadAttestationMessagesSubmitter
+)

--- a/services/payloadattester/service.go
+++ b/services/payloadattester/service.go
@@ -15,12 +15,11 @@ package payloadattester
 
 import (
 	"context"
+	"slices"
 
 	"github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/attestantio/vouch/services/signer"
-	"github.com/attestantio/vouch/services/submitter"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
 )
 
@@ -45,10 +44,8 @@ func (d *Duty) AddDuty(duty *v1.PTCDuty) {
 	if duty == nil || duty.Slot != d.slot {
 		return
 	}
-	for _, index := range d.validatorIndices {
-		if index == duty.ValidatorIndex {
-			return
-		}
+	if slices.Contains(d.validatorIndices, duty.ValidatorIndex) {
+		return
 	}
 	d.validatorIndices = append(d.validatorIndices, duty.ValidatorIndex)
 }
@@ -91,8 +88,3 @@ type Service interface {
 	Prepare(ctx context.Context, duty *Duty) error
 	Attest(ctx context.Context, duty *Duty) ([]*spec.VersionedPayloadAttestationMessage, error)
 }
-
-var (
-	_ signer.PayloadAttestationDataSigner
-	_ submitter.PayloadAttestationMessagesSubmitter
-)

--- a/services/payloadattester/service_test.go
+++ b/services/payloadattester/service_test.go
@@ -1,0 +1,33 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package payloadattester_test
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/payloadattester"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDuty(t *testing.T) {
+	duty := payloadattester.NewDuty(&v1.PTCDuty{
+		Slot:           phase0.Slot(17),
+		ValidatorIndex: phase0.ValidatorIndex(23),
+	})
+
+	require.Equal(t, phase0.Slot(17), duty.Slot())
+	require.Equal(t, phase0.ValidatorIndex(23), duty.ValidatorIndex())
+}

--- a/services/payloadattester/standard/metrics.go
+++ b/services/payloadattester/standard/metrics.go
@@ -1,0 +1,54 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"errors"
+
+	"github.com/attestantio/vouch/services/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var payloadAttestationProcessEvents *prometheus.CounterVec
+
+func registerMetrics(_ context.Context, monitor metrics.Service) error {
+	if monitor == nil || monitor.Presenter() != "prometheus" {
+		return nil
+	}
+
+	payloadAttestationProcessEvents = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "vouch",
+		Subsystem: "payloadattestation_process",
+		Name:      "events_total",
+		Help:      "The number of payload attestation process events.",
+	}, []string{"outcome"})
+	if err := prometheus.Register(payloadAttestationProcessEvents); err != nil {
+		var alreadyRegisteredError prometheus.AlreadyRegisteredError
+		if ok := errors.As(err, &alreadyRegisteredError); ok {
+			payloadAttestationProcessEvents = alreadyRegisteredError.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func monitorPayloadAttestationProcess(outcome string, count int) {
+	if payloadAttestationProcessEvents == nil {
+		return
+	}
+	payloadAttestationProcessEvents.WithLabelValues(outcome).Add(float64(count))
+}

--- a/services/payloadattester/standard/parameters.go
+++ b/services/payloadattester/standard/parameters.go
@@ -1,0 +1,89 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/vouch/services/metrics"
+	"github.com/attestantio/vouch/services/signer"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+type parameters struct {
+	monitor                             metrics.Service
+	payloadAttestationDataProvider      eth2client.PayloadAttestationDataProvider
+	payloadAttestationDataSigner        signer.PayloadAttestationDataSigner
+	payloadAttestationMessagesSubmitter submitter.PayloadAttestationMessagesSubmitter
+	logLevel                            zerolog.Level
+}
+
+// Parameter is the interface for service parameters.
+type Parameter interface {
+	apply(p *parameters)
+}
+
+type parameterFunc func(*parameters)
+
+func (f parameterFunc) apply(p *parameters) {
+	f(p)
+}
+
+// WithLogLevel sets the log level for the module.
+func WithLogLevel(logLevel zerolog.Level) Parameter {
+	return parameterFunc(func(p *parameters) { p.logLevel = logLevel })
+}
+
+// WithMonitor sets the monitor for the module.
+func WithMonitor(monitor metrics.Service) Parameter {
+	return parameterFunc(func(p *parameters) { p.monitor = monitor })
+}
+
+// WithPayloadAttestationDataProvider sets the payload attestation data provider.
+func WithPayloadAttestationDataProvider(provider eth2client.PayloadAttestationDataProvider) Parameter {
+	return parameterFunc(func(p *parameters) { p.payloadAttestationDataProvider = provider })
+}
+
+// WithPayloadAttestationDataSigner sets the payload attestation data signer.
+func WithPayloadAttestationDataSigner(signer signer.PayloadAttestationDataSigner) Parameter {
+	return parameterFunc(func(p *parameters) { p.payloadAttestationDataSigner = signer })
+}
+
+// WithPayloadAttestationMessagesSubmitter sets the payload attestation messages submitter.
+func WithPayloadAttestationMessagesSubmitter(submitter submitter.PayloadAttestationMessagesSubmitter) Parameter {
+	return parameterFunc(func(p *parameters) { p.payloadAttestationMessagesSubmitter = submitter })
+}
+
+func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
+	parameters := &parameters{logLevel: zerolog.GlobalLevel()}
+	for _, p := range params {
+		if p != nil {
+			p.apply(parameters)
+		}
+	}
+	if parameters.monitor == nil {
+		return nil, errors.New("no monitor specified")
+	}
+	if parameters.payloadAttestationDataProvider == nil {
+		return nil, errors.New("no payload attestation data provider specified")
+	}
+	if parameters.payloadAttestationDataSigner == nil {
+		return nil, errors.New("no payload attestation data signer specified")
+	}
+	if parameters.payloadAttestationMessagesSubmitter == nil {
+		return nil, errors.New("no payload attestation messages submitter specified")
+	}
+	return parameters, nil
+}

--- a/services/payloadattester/standard/service.go
+++ b/services/payloadattester/standard/service.go
@@ -1,0 +1,118 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/metrics"
+	"github.com/attestantio/vouch/services/payloadattester"
+	"github.com/attestantio/vouch/services/signer"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/pkg/errors"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+// Service is the standard payload attester.
+type Service struct {
+	monitor                             metrics.Service
+	payloadAttestationDataProvider      eth2client.PayloadAttestationDataProvider
+	payloadAttestationDataSigner        signer.PayloadAttestationDataSigner
+	payloadAttestationMessagesSubmitter submitter.PayloadAttestationMessagesSubmitter
+}
+
+// New creates a new payload attester.
+func New(_ context.Context, params ...Parameter) (*Service, error) {
+	parameters, err := parseAndCheckParameters(params...)
+	if err != nil {
+		return nil, errors.Wrap(err, "problem with parameters")
+	}
+	return &Service{
+		monitor:                             parameters.monitor,
+		payloadAttestationDataProvider:      parameters.payloadAttestationDataProvider,
+		payloadAttestationDataSigner:        parameters.payloadAttestationDataSigner,
+		payloadAttestationMessagesSubmitter: parameters.payloadAttestationMessagesSubmitter,
+	}, nil
+}
+
+// Prepare prepares a payload attestation duty.
+func (*Service) Prepare(_ context.Context, _ *payloadattester.Duty) error {
+	return nil
+}
+
+// Attest creates and submits payload attestation messages.
+func (s *Service) Attest(ctx context.Context, duty *payloadattester.Duty) ([]*spec.VersionedPayloadAttestationMessage, error) {
+	if duty == nil {
+		return nil, errors.New("no duty supplied")
+	}
+
+	accounts := make([]e2wtypes.Account, 0, len(duty.ValidatorIndices()))
+	indices := make([]phase0.ValidatorIndex, 0, len(duty.ValidatorIndices()))
+	for _, index := range duty.ValidatorIndices() {
+		account := duty.Account(index)
+		if account == nil {
+			continue
+		}
+		accounts = append(accounts, account)
+		indices = append(indices, index)
+	}
+	if len(accounts) == 0 {
+		return []*spec.VersionedPayloadAttestationMessage{}, nil
+	}
+
+	response, err := s.payloadAttestationDataProvider.PayloadAttestationData(ctx, &api.PayloadAttestationDataOpts{Slot: duty.Slot()})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to obtain payload attestation data")
+	}
+	if response == nil || response.Data == nil {
+		return nil, errors.New("no payload attestation data returned")
+	}
+	if response.Data.Version != spec.DataVersionGloas || response.Data.Gloas == nil {
+		return nil, errors.New("payload attestation data is not Gloas")
+	}
+	data := response.Data.Gloas
+	if data.Slot != duty.Slot() {
+		return nil, errors.Errorf("payload attestation data slot %d does not match duty slot %d", data.Slot, duty.Slot())
+	}
+
+	signatures, err := s.payloadAttestationDataSigner.SignPayloadAttestationData(ctx, accounts, data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign payload attestation data")
+	}
+	if len(signatures) != len(accounts) {
+		return nil, errors.New("number of payload attestation signatures does not match number of accounts")
+	}
+
+	messages := make([]*spec.VersionedPayloadAttestationMessage, len(accounts))
+	for i := range accounts {
+		messages[i] = &spec.VersionedPayloadAttestationMessage{
+			Version: spec.DataVersionGloas,
+			Gloas: &gloas.PayloadAttestationMessage{
+				ValidatorIndex: indices[i],
+				Data:           data,
+				Signature:      signatures[i],
+			},
+		}
+	}
+	if err := s.payloadAttestationMessagesSubmitter.SubmitPayloadAttestationMessages(ctx, &api.SubmitPayloadAttestationMessagesOpts{Messages: messages}); err != nil {
+		return nil, errors.Wrap(err, "failed to submit payload attestation messages")
+	}
+
+	return messages, nil
+}

--- a/services/payloadattester/standard/service.go
+++ b/services/payloadattester/standard/service.go
@@ -15,6 +15,7 @@ package standard
 
 import (
 	"context"
+	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
@@ -26,11 +27,14 @@ import (
 	"github.com/attestantio/vouch/services/signer"
 	"github.com/attestantio/vouch/services/submitter"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	zerologger "github.com/rs/zerolog/log"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
 )
 
 // Service is the standard payload attester.
 type Service struct {
+	log                                 zerolog.Logger
 	monitor                             metrics.Service
 	payloadAttestationDataProvider      eth2client.PayloadAttestationDataProvider
 	payloadAttestationDataSigner        signer.PayloadAttestationDataSigner
@@ -38,12 +42,20 @@ type Service struct {
 }
 
 // New creates a new payload attester.
-func New(_ context.Context, params ...Parameter) (*Service, error) {
+func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	parameters, err := parseAndCheckParameters(params...)
 	if err != nil {
 		return nil, errors.Wrap(err, "problem with parameters")
 	}
+	log := zerologger.With().Str("service", "payloadattester").Str("impl", "standard").Logger()
+	if parameters.logLevel != log.GetLevel() {
+		log = log.Level(parameters.logLevel)
+	}
+	if err := registerMetrics(ctx, parameters.monitor); err != nil {
+		return nil, errors.New("failed to register metrics")
+	}
 	return &Service{
+		log:                                 log,
 		monitor:                             parameters.monitor,
 		payloadAttestationDataProvider:      parameters.payloadAttestationDataProvider,
 		payloadAttestationDataSigner:        parameters.payloadAttestationDataSigner,
@@ -51,8 +63,15 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 	}, nil
 }
 
-// Prepare prepares a payload attestation duty.
-func (*Service) Prepare(_ context.Context, _ *payloadattester.Duty) error {
+// Prepare records a scheduled payload attestation duty.
+func (s *Service) Prepare(_ context.Context, duty *payloadattester.Duty) error {
+	if duty == nil {
+		return nil
+	}
+	count := len(duty.ValidatorIndices())
+	monitorPayloadAttestationProcess("scheduled", count)
+	s.log.Trace().Uint64("slot", uint64(duty.Slot())).Int("count", count).Msg("Scheduled payload attestations")
+
 	return nil
 }
 
@@ -61,6 +80,7 @@ func (s *Service) Attest(ctx context.Context, duty *payloadattester.Duty) ([]*sp
 	if duty == nil {
 		return nil, errors.New("no duty supplied")
 	}
+	started := time.Now()
 
 	accounts := make([]e2wtypes.Account, 0, len(duty.ValidatorIndices()))
 	indices := make([]phase0.ValidatorIndex, 0, len(duty.ValidatorIndices()))
@@ -78,26 +98,46 @@ func (s *Service) Attest(ctx context.Context, duty *payloadattester.Duty) ([]*sp
 
 	response, err := s.payloadAttestationDataProvider.PayloadAttestationData(ctx, &api.PayloadAttestationDataOpts{Slot: duty.Slot()})
 	if err != nil {
+		monitorPayloadAttestationProcess("failed", len(accounts))
+		s.log.Error().Err(err).Uint64("slot", uint64(duty.Slot())).Msg("Failed to produce payload attestation data")
 		return nil, errors.Wrap(err, "failed to obtain payload attestation data")
 	}
 	if response == nil || response.Data == nil {
-		return nil, errors.New("no payload attestation data returned")
+		err := errors.New("no payload attestation data returned")
+		monitorPayloadAttestationProcess("failed", len(accounts))
+		s.log.Error().Err(err).Uint64("slot", uint64(duty.Slot())).Msg("Failed to produce payload attestation data")
+		return nil, err
 	}
 	if response.Data.Version != spec.DataVersionGloas || response.Data.Gloas == nil {
-		return nil, errors.New("payload attestation data is not Gloas")
+		err := errors.New("payload attestation data is not Gloas")
+		monitorPayloadAttestationProcess("failed", len(accounts))
+		s.log.Error().Err(err).Uint64("slot", uint64(duty.Slot())).Msg("Failed to produce payload attestation data")
+		return nil, err
 	}
 	data := response.Data.Gloas
 	if data.Slot != duty.Slot() {
-		return nil, errors.Errorf("payload attestation data slot %d does not match duty slot %d", data.Slot, duty.Slot())
+		err := errors.Errorf("payload attestation data slot %d does not match duty slot %d", data.Slot, duty.Slot())
+		monitorPayloadAttestationProcess("failed", len(accounts))
+		s.log.Error().Err(err).Uint64("slot", uint64(duty.Slot())).Msg("Failed to produce payload attestation data")
+		return nil, err
 	}
+	monitorPayloadAttestationProcess("produced", len(accounts))
+	s.log.Trace().Uint64("slot", uint64(duty.Slot())).Dur("elapsed", time.Since(started)).Msg("Produced payload attestation data")
 
 	signatures, err := s.payloadAttestationDataSigner.SignPayloadAttestationData(ctx, accounts, data)
 	if err != nil {
+		monitorPayloadAttestationProcess("failed", len(accounts))
+		s.log.Error().Err(err).Uint64("slot", uint64(duty.Slot())).Msg("Failed to sign payload attestation data")
 		return nil, errors.Wrap(err, "failed to sign payload attestation data")
 	}
 	if len(signatures) != len(accounts) {
-		return nil, errors.New("number of payload attestation signatures does not match number of accounts")
+		err := errors.New("number of payload attestation signatures does not match number of accounts")
+		monitorPayloadAttestationProcess("failed", len(accounts))
+		s.log.Error().Err(err).Uint64("slot", uint64(duty.Slot())).Msg("Failed to sign payload attestation data")
+		return nil, err
 	}
+	monitorPayloadAttestationProcess("signed", len(accounts))
+	s.log.Trace().Uint64("slot", uint64(duty.Slot())).Int("count", len(accounts)).Dur("elapsed", time.Since(started)).Msg("Signed payload attestation messages")
 
 	messages := make([]*spec.VersionedPayloadAttestationMessage, len(accounts))
 	for i := range accounts {
@@ -111,8 +151,12 @@ func (s *Service) Attest(ctx context.Context, duty *payloadattester.Duty) ([]*sp
 		}
 	}
 	if err := s.payloadAttestationMessagesSubmitter.SubmitPayloadAttestationMessages(ctx, &api.SubmitPayloadAttestationMessagesOpts{Messages: messages}); err != nil {
+		monitorPayloadAttestationProcess("failed", len(messages))
+		s.log.Error().Err(err).Uint64("slot", uint64(duty.Slot())).Msg("Failed to submit payload attestation messages")
 		return nil, errors.Wrap(err, "failed to submit payload attestation messages")
 	}
+	monitorPayloadAttestationProcess("submitted", len(messages))
+	s.log.Trace().Uint64("slot", uint64(duty.Slot())).Int("count", len(messages)).Dur("elapsed", time.Since(started)).Msg("Submitted payload attestation messages")
 
 	return messages, nil
 }

--- a/services/payloadattester/standard/service_test.go
+++ b/services/payloadattester/standard/service_test.go
@@ -15,6 +15,7 @@ package standard_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/api"
@@ -23,10 +24,11 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/services/payloadattester"
 	"github.com/attestantio/vouch/services/payloadattester/standard"
+	"github.com/attestantio/vouch/testing/logger"
 	"github.com/attestantio/vouch/testutil"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
@@ -34,6 +36,7 @@ import (
 
 func TestAttestFetchesSignsAndSubmitsVersionedMessages(t *testing.T) {
 	ctx := context.Background()
+	capture := logger.NewLogCapture()
 	client, err := mocketh2client.New(ctx)
 	require.NoError(t, err)
 	data := &gloas.PayloadAttestationData{
@@ -54,8 +57,8 @@ func TestAttestFetchesSignsAndSubmitsVersionedMessages(t *testing.T) {
 	signer := &recordingSigner{}
 	submitter := &recordingSubmitter{}
 	service, err := standard.New(ctx,
-		standard.WithLogLevel(zerolog.Disabled),
-		standard.WithMonitor(nullmetrics.New()),
+		standard.WithLogLevel(zerolog.TraceLevel),
+		standard.WithMonitor(prometheusMonitor{}),
 		standard.WithPayloadAttestationDataProvider(client),
 		standard.WithPayloadAttestationDataSigner(signer),
 		standard.WithPayloadAttestationMessagesSubmitter(submitter),
@@ -76,10 +79,16 @@ func TestAttestFetchesSignsAndSubmitsVersionedMessages(t *testing.T) {
 	require.Equal(t, spec.DataVersionGloas, submitter.messages[0].Version)
 	require.Equal(t, phase0.ValidatorIndex(1), submitter.messages[0].Gloas.ValidatorIndex)
 	require.Equal(t, phase0.ValidatorIndex(2), submitter.messages[1].Gloas.ValidatorIndex)
+
+	require.Equal(t, map[string]float64{"produced": 2, "signed": 2, "submitted": 2}, payloadAttestationEventCounts(t))
+	require.True(t, capture.HasLog(map[string]any{"message": "Produced payload attestation data", "slot": uint64(12)}))
+	require.True(t, capture.HasLog(map[string]any{"message": "Signed payload attestation messages", "slot": uint64(12), "count": 2}))
+	require.True(t, capture.HasLog(map[string]any{"message": "Submitted payload attestation messages", "slot": uint64(12), "count": 2}))
 }
 
 func TestAttestRejectsDataForDifferentSlotBeforeSigningOrSubmitting(t *testing.T) {
 	ctx := context.Background()
+	capture := logger.NewLogCapture()
 	client, err := mocketh2client.New(ctx)
 	require.NoError(t, err)
 	client.PayloadAttestationDataFunc = func(_ context.Context, _ *api.PayloadAttestationDataOpts) (*api.Response[*spec.VersionedPayloadAttestationData], error) {
@@ -96,8 +105,8 @@ func TestAttestRejectsDataForDifferentSlotBeforeSigningOrSubmitting(t *testing.T
 	signer := &recordingSigner{}
 	submitter := &recordingSubmitter{}
 	service, err := standard.New(ctx,
-		standard.WithLogLevel(zerolog.Disabled),
-		standard.WithMonitor(nullmetrics.New()),
+		standard.WithLogLevel(zerolog.TraceLevel),
+		standard.WithMonitor(prometheusMonitor{}),
 		standard.WithPayloadAttestationDataProvider(client),
 		standard.WithPayloadAttestationDataSigner(signer),
 		standard.WithPayloadAttestationMessagesSubmitter(submitter),
@@ -111,6 +120,94 @@ func TestAttestRejectsDataForDifferentSlotBeforeSigningOrSubmitting(t *testing.T
 	require.EqualError(t, err, "payload attestation data slot 13 does not match duty slot 12")
 	require.Empty(t, signer.accounts)
 	require.Empty(t, submitter.messages)
+
+	require.Equal(t, float64(1), payloadAttestationEventCounts(t)["failed"])
+	require.True(t, capture.HasLog(map[string]any{"message": "Failed to produce payload attestation data", "slot": uint64(12)}))
+}
+
+func TestAttestRecordsSubmissionFailure(t *testing.T) {
+	ctx := context.Background()
+	capture := logger.NewLogCapture()
+	client, err := mocketh2client.New(ctx)
+	require.NoError(t, err)
+	data := &gloas.PayloadAttestationData{Slot: 12}
+	client.PayloadAttestationDataFunc = func(context.Context, *api.PayloadAttestationDataOpts) (*api.Response[*spec.VersionedPayloadAttestationData], error) {
+		return &api.Response[*spec.VersionedPayloadAttestationData]{Data: &spec.VersionedPayloadAttestationData{
+			Version: spec.DataVersionGloas,
+			Gloas:   data,
+		}}, nil
+	}
+
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{1}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.TraceLevel),
+		standard.WithMonitor(prometheusMonitor{}),
+		standard.WithPayloadAttestationDataProvider(client),
+		standard.WithPayloadAttestationDataSigner(&recordingSigner{}),
+		standard.WithPayloadAttestationMessagesSubmitter(failingSubmitter{}),
+	)
+	require.NoError(t, err)
+	duty := payloadattester.NewDuty(&apiv1.PTCDuty{Slot: 12, ValidatorIndex: 1})
+	duty.SetAccount(1, accounts[1])
+	failedBefore := payloadAttestationEventCounts(t)["failed"]
+
+	_, err = service.Attest(ctx, duty)
+
+	require.EqualError(t, err, "failed to submit payload attestation messages: submission failed")
+	require.Equal(t, failedBefore+1, payloadAttestationEventCounts(t)["failed"])
+	require.True(t, capture.HasLog(map[string]any{"message": "Failed to submit payload attestation messages", "slot": uint64(12)}))
+}
+
+func TestPrepareRecordsScheduledPayloadAttestation(t *testing.T) {
+	ctx := context.Background()
+	capture := logger.NewLogCapture()
+	client, err := mocketh2client.New(ctx)
+	require.NoError(t, err)
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.TraceLevel),
+		standard.WithMonitor(prometheusMonitor{}),
+		standard.WithPayloadAttestationDataProvider(client),
+		standard.WithPayloadAttestationDataSigner(&recordingSigner{}),
+		standard.WithPayloadAttestationMessagesSubmitter(&recordingSubmitter{}),
+	)
+	require.NoError(t, err)
+	duty := payloadattester.NewDuty(&apiv1.PTCDuty{Slot: 12, ValidatorIndex: 1})
+	duty.AddDuty(&apiv1.PTCDuty{Slot: 12, ValidatorIndex: 2})
+	preparedBefore := payloadAttestationEventCounts(t)["scheduled"]
+
+	require.NoError(t, service.Prepare(ctx, duty))
+
+	require.Equal(t, preparedBefore+2, payloadAttestationEventCounts(t)["scheduled"])
+	require.True(t, capture.HasLog(map[string]any{"message": "Scheduled payload attestations", "slot": uint64(12), "count": 2}))
+}
+
+func payloadAttestationEventCounts(t *testing.T) map[string]float64 {
+	t.Helper()
+
+	eventCounts := make(map[string]float64)
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range metricFamilies {
+		if family.GetName() != "vouch_payloadattestation_process_events_total" {
+			continue
+		}
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				if label.GetName() == "outcome" {
+					eventCounts[label.GetValue()] = metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+
+	return eventCounts
+}
+
+type prometheusMonitor struct{}
+
+func (prometheusMonitor) Presenter() string {
+	return "prometheus"
 }
 
 type recordingSigner struct {
@@ -130,6 +227,12 @@ func (s *recordingSigner) SignPayloadAttestationData(_ context.Context, accounts
 
 type recordingSubmitter struct {
 	messages []*spec.VersionedPayloadAttestationMessage
+}
+
+type failingSubmitter struct{}
+
+func (failingSubmitter) SubmitPayloadAttestationMessages(context.Context, *api.SubmitPayloadAttestationMessagesOpts) error {
+	return errors.New("submission failed")
 }
 
 func (s *recordingSubmitter) SubmitPayloadAttestationMessages(_ context.Context, opts *api.SubmitPayloadAttestationMessagesOpts) error {

--- a/services/payloadattester/standard/service_test.go
+++ b/services/payloadattester/standard/service_test.go
@@ -1,0 +1,138 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	mocketh2client "github.com/attestantio/go-eth2-client/mock"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/payloadattester"
+	"github.com/attestantio/vouch/services/payloadattester/standard"
+	"github.com/attestantio/vouch/testutil"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+func TestAttestFetchesSignsAndSubmitsVersionedMessages(t *testing.T) {
+	ctx := context.Background()
+	client, err := mocketh2client.New(ctx)
+	require.NoError(t, err)
+	data := &gloas.PayloadAttestationData{
+		BeaconBlockRoot: phase0.Root{0x01},
+		Slot:            12,
+		PayloadPresent:  true,
+	}
+	client.PayloadAttestationDataFunc = func(_ context.Context, opts *api.PayloadAttestationDataOpts) (*api.Response[*spec.VersionedPayloadAttestationData], error) {
+		require.Equal(t, phase0.Slot(12), opts.Slot)
+		return &api.Response[*spec.VersionedPayloadAttestationData]{Data: &spec.VersionedPayloadAttestationData{
+			Version: spec.DataVersionGloas,
+			Gloas:   data,
+		}}, nil
+	}
+
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{1, 2}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	signer := &recordingSigner{}
+	submitter := &recordingSubmitter{}
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithPayloadAttestationDataProvider(client),
+		standard.WithPayloadAttestationDataSigner(signer),
+		standard.WithPayloadAttestationMessagesSubmitter(submitter),
+	)
+	require.NoError(t, err)
+
+	duty := payloadattester.NewDuty(&apiv1.PTCDuty{Slot: 12, ValidatorIndex: 1})
+	duty.AddDuty(&apiv1.PTCDuty{Slot: 12, ValidatorIndex: 2})
+	duty.SetAccount(1, accounts[1])
+	duty.SetAccount(2, accounts[2])
+
+	messages, err := service.Attest(ctx, duty)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	require.Len(t, signer.accounts, 2)
+	require.Same(t, data, signer.data)
+	require.Len(t, submitter.messages, 2)
+	require.Equal(t, spec.DataVersionGloas, submitter.messages[0].Version)
+	require.Equal(t, phase0.ValidatorIndex(1), submitter.messages[0].Gloas.ValidatorIndex)
+	require.Equal(t, phase0.ValidatorIndex(2), submitter.messages[1].Gloas.ValidatorIndex)
+}
+
+func TestAttestRejectsDataForDifferentSlotBeforeSigningOrSubmitting(t *testing.T) {
+	ctx := context.Background()
+	client, err := mocketh2client.New(ctx)
+	require.NoError(t, err)
+	client.PayloadAttestationDataFunc = func(_ context.Context, _ *api.PayloadAttestationDataOpts) (*api.Response[*spec.VersionedPayloadAttestationData], error) {
+		return &api.Response[*spec.VersionedPayloadAttestationData]{Data: &spec.VersionedPayloadAttestationData{
+			Version: spec.DataVersionGloas,
+			Gloas: &gloas.PayloadAttestationData{
+				Slot: 13,
+			},
+		}}, nil
+	}
+
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{1}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	signer := &recordingSigner{}
+	submitter := &recordingSubmitter{}
+	service, err := standard.New(ctx,
+		standard.WithLogLevel(zerolog.Disabled),
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithPayloadAttestationDataProvider(client),
+		standard.WithPayloadAttestationDataSigner(signer),
+		standard.WithPayloadAttestationMessagesSubmitter(submitter),
+	)
+	require.NoError(t, err)
+
+	duty := payloadattester.NewDuty(&apiv1.PTCDuty{Slot: 12, ValidatorIndex: 1})
+	duty.SetAccount(1, accounts[1])
+
+	_, err = service.Attest(ctx, duty)
+	require.EqualError(t, err, "payload attestation data slot 13 does not match duty slot 12")
+	require.Empty(t, signer.accounts)
+	require.Empty(t, submitter.messages)
+}
+
+type recordingSigner struct {
+	accounts []e2wtypes.Account
+	data     *gloas.PayloadAttestationData
+}
+
+func (s *recordingSigner) SignPayloadAttestationData(_ context.Context, accounts []e2wtypes.Account, data *gloas.PayloadAttestationData) ([]phase0.BLSSignature, error) {
+	s.accounts = accounts
+	s.data = data
+	sigs := make([]phase0.BLSSignature, len(accounts))
+	for i := range sigs {
+		sigs[i][0] = byte(i + 1)
+	}
+	return sigs, nil
+}
+
+type recordingSubmitter struct {
+	messages []*spec.VersionedPayloadAttestationMessage
+}
+
+func (s *recordingSubmitter) SubmitPayloadAttestationMessages(_ context.Context, opts *api.SubmitPayloadAttestationMessagesOpts) error {
+	s.messages = opts.Messages
+	return nil
+}

--- a/services/signer/service.go
+++ b/services/signer/service.go
@@ -27,6 +27,14 @@ import (
 // Service is the generic signer service.
 type Service interface{}
 
+// PayloadAttestationDataSigner provides methods to sign payload attestation data.
+type PayloadAttestationDataSigner interface {
+	SignPayloadAttestationData(ctx context.Context,
+		accounts []e2wtypes.Account,
+		data *gloas.PayloadAttestationData,
+	) ([]phase0.BLSSignature, error)
+}
+
 // AggregateAndProofSigner provides methods to sign aggregate and proofs.
 type AggregateAndProofSigner interface {
 	// SignAggregateAndProof signs an aggregate attestation for given slot and root.

--- a/services/signer/standard/service.go
+++ b/services/signer/standard/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	applicationBuilderDomainType          *phase0.DomainType
 	blobSidecarDomainType                 *phase0.DomainType
 	beaconBuilderDomainType               *phase0.DomainType
+	ptcAttesterDomainType                 *phase0.DomainType
 }
 
 // Module-wide log.
@@ -115,6 +116,11 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		log.Warn().Err(err).Msg("DOMAIN_BEACON_BUILDER unavailable in spec; execution payload envelope signing unavailable")
 	}
 
+	var ptcAttesterDomainType *phase0.DomainType
+	if tmp, err := domainType(spec, "DOMAIN_PTC_ATTESTER"); err == nil {
+		ptcAttesterDomainType = &tmp
+	}
+
 	s := &Service{
 		monitor:                               parameters.monitor,
 		clientMonitor:                         parameters.clientMonitor,
@@ -131,6 +137,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		applicationBuilderDomainType:          applicationBuilderDomainType,
 		blobSidecarDomainType:                 blobSidecarDomainType,
 		beaconBuilderDomainType:               beaconBuilderDomainType,
+		ptcAttesterDomainType:                 ptcAttesterDomainType,
 	}
 
 	return s, nil

--- a/services/signer/standard/service.go
+++ b/services/signer/standard/service.go
@@ -119,6 +119,8 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	var ptcAttesterDomainType *phase0.DomainType
 	if tmp, err := domainType(spec, "DOMAIN_PTC_ATTESTER"); err == nil {
 		ptcAttesterDomainType = &tmp
+	} else {
+		log.Warn().Err(err).Msg("DOMAIN_PTC_ATTESTER unavailable in spec; payload attestation signing unavailable")
 	}
 
 	s := &Service{

--- a/services/signer/standard/signpayloadattestationdata.go
+++ b/services/signer/standard/signpayloadattestationdata.go
@@ -1,0 +1,68 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+// SignPayloadAttestationData signs payload attestation data for multiple accounts.
+func (s *Service) SignPayloadAttestationData(ctx context.Context,
+	accounts []e2wtypes.Account,
+	data *gloas.PayloadAttestationData,
+) ([]phase0.BLSSignature, error) {
+	return s.signPayloadAttestationData(ctx, accounts, data)
+}
+
+func (s *Service) signPayloadAttestationData(ctx context.Context,
+	accounts []e2wtypes.Account,
+	data *gloas.PayloadAttestationData,
+) ([]phase0.BLSSignature, error) {
+	if len(accounts) == 0 {
+		return nil, errors.New("no accounts supplied")
+	}
+	if data == nil {
+		return nil, errors.New("no payload attestation data supplied")
+	}
+	if s.ptcAttesterDomainType == nil {
+		return nil, errors.New("DOMAIN_PTC_ATTESTER unavailable in beacon node spec; cannot sign payload attestation data")
+	}
+
+	root, err := data.HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to calculate payload attestation data hash tree root")
+	}
+	domain, err := s.domainProvider.Domain(ctx,
+		*s.ptcAttesterDomainType,
+		phase0.Epoch(data.Slot/s.slotsPerEpoch))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to obtain signature domain for payload attestation data")
+	}
+
+	roots := make([]phase0.Root, len(accounts))
+	for i := range roots {
+		roots[i] = root
+	}
+	sigs, err := s.signRootsByAccountType(ctx, accounts, roots, domain)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign payload attestation data")
+	}
+
+	return sigs, nil
+}

--- a/services/signer/standard/signpayloadattestationdata_internal_test.go
+++ b/services/signer/standard/signpayloadattestationdata_internal_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/mock"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+func TestSignPayloadAttestationDataUsesGenericMulti(t *testing.T) {
+	ctx := context.Background()
+	specProvider := &ptcSpecProvider{}
+	service, err := New(ctx,
+		WithLogLevel(zerolog.Disabled),
+		WithMonitor(nullmetrics.New()),
+		WithClientMonitor(nullmetrics.New()),
+		WithSpecProvider(specProvider),
+		WithDomainProvider(mock.NewDomainProvider()),
+	)
+	require.NoError(t, err)
+
+	batches := make([]batchRecord, 0)
+	accounts := []e2wtypes.Account{
+		newMockMultiSignerAccount("one", &batches),
+		newMockMultiSignerAccount("two", &batches),
+	}
+	data := &gloas.PayloadAttestationData{Slot: 33, PayloadPresent: true}
+
+	sigs, err := service.SignPayloadAttestationData(ctx, accounts, data)
+	require.NoError(t, err)
+	require.Len(t, sigs, 2)
+	require.NotEqual(t, phase0.BLSSignature{}, sigs[0])
+	require.NotEqual(t, phase0.BLSSignature{}, sigs[1])
+	require.Len(t, batches, 1)
+}
+
+type ptcSpecProvider struct{}
+
+func (*ptcSpecProvider) Spec(_ context.Context, _ *api.SpecOpts) (*api.Response[map[string]any], error) {
+	return &api.Response[map[string]any]{Data: map[string]any{
+		"SLOTS_PER_EPOCH":            uint64(32),
+		"DOMAIN_BEACON_ATTESTER":     phase0.DomainType{0x01},
+		"DOMAIN_BEACON_PROPOSER":     phase0.DomainType{0x02},
+		"DOMAIN_RANDAO":              phase0.DomainType{0x03},
+		"DOMAIN_SELECTION_PROOF":     phase0.DomainType{0x04},
+		"DOMAIN_AGGREGATE_AND_PROOF": phase0.DomainType{0x05},
+		"DOMAIN_PTC_ATTESTER":        phase0.DomainType{0x0c},
+	}}, nil
+}

--- a/services/signer/standard/signpayloadattestationdata_internal_test.go
+++ b/services/signer/standard/signpayloadattestationdata_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/mock"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/testing/logger"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
@@ -52,6 +53,40 @@ func TestSignPayloadAttestationDataUsesGenericMulti(t *testing.T) {
 	require.NotEqual(t, phase0.BLSSignature{}, sigs[0])
 	require.NotEqual(t, phase0.BLSSignature{}, sigs[1])
 	require.Len(t, batches, 1)
+}
+
+func TestNewWarnsWhenPTCAttesterDomainUnavailable(t *testing.T) {
+	capture := logger.NewLogCapture()
+
+	_, err := New(context.Background(),
+		WithLogLevel(zerolog.WarnLevel),
+		WithMonitor(nullmetrics.New()),
+		WithClientMonitor(nullmetrics.New()),
+		WithSpecProvider(&preGloasSpecProvider{}),
+		WithDomainProvider(mock.NewDomainProvider()),
+	)
+	require.NoError(t, err)
+	capture.AssertHasEntry(t, "DOMAIN_PTC_ATTESTER unavailable in spec; payload attestation signing unavailable")
+}
+
+func TestSignPayloadAttestationDataUnavailableBeforeGloas(t *testing.T) {
+	ctx := context.Background()
+	service, err := New(ctx,
+		WithLogLevel(zerolog.Disabled),
+		WithMonitor(nullmetrics.New()),
+		WithClientMonitor(nullmetrics.New()),
+		WithSpecProvider(&preGloasSpecProvider{}),
+		WithDomainProvider(mock.NewDomainProvider()),
+	)
+	require.NoError(t, err)
+
+	batches := make([]batchRecord, 0)
+	accounts := []e2wtypes.Account{newMockMultiSignerAccount("one", &batches)}
+
+	_, err = service.SignPayloadAttestationData(ctx, accounts, &gloas.PayloadAttestationData{Slot: 33, PayloadPresent: true})
+	require.EqualError(t, err, "DOMAIN_PTC_ATTESTER unavailable in beacon node spec; cannot sign payload attestation data")
+	// The guard must fire before any signing is attempted.
+	require.Empty(t, batches)
 }
 
 type ptcSpecProvider struct{}

--- a/services/submitter/immediate/parameters.go
+++ b/services/submitter/immediate/parameters.go
@@ -18,6 +18,7 @@ import (
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/vouch/services/metrics"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/submitter"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -34,6 +35,7 @@ type parameters struct {
 	syncCommitteeMessagesSubmitter        eth2client.SyncCommitteeMessagesSubmitter
 	syncCommitteeSubscriptionsSubmitter   eth2client.SyncCommitteeSubscriptionsSubmitter
 	syncCommitteeContributionsSubmitter   eth2client.SyncCommitteeContributionsSubmitter
+	payloadAttestationMessagesSubmitter   submitter.PayloadAttestationMessagesSubmitter
 }
 
 // Parameter is the interface for service parameters.
@@ -121,6 +123,13 @@ func WithAggregateAttestationsSubmitter(submitter eth2client.AggregateAttestatio
 func WithProposalPreparationsSubmitter(submitter eth2client.ProposalPreparationsSubmitter) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.proposalPreparationsSubmitter = submitter
+	})
+}
+
+// WithPayloadAttestationMessagesSubmitter sets the payload attestation messages submitter.
+func WithPayloadAttestationMessagesSubmitter(submitter submitter.PayloadAttestationMessagesSubmitter) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.payloadAttestationMessagesSubmitter = submitter
 	})
 }
 

--- a/services/submitter/immediate/service.go
+++ b/services/submitter/immediate/service.go
@@ -23,6 +23,7 @@ import (
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/vouch/services/metrics"
+	"github.com/attestantio/vouch/services/submitter"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	zerologger "github.com/rs/zerolog/log"
@@ -42,6 +43,7 @@ type Service struct {
 	syncCommitteeMessagesSubmitter        eth2client.SyncCommitteeMessagesSubmitter
 	syncCommitteeSubscriptionsSubmitter   eth2client.SyncCommitteeSubscriptionsSubmitter
 	syncCommitteeContributionsSubmitter   eth2client.SyncCommitteeContributionsSubmitter
+	payloadAttestationMessagesSubmitter   submitter.PayloadAttestationMessagesSubmitter
 }
 
 // New creates a new submitter.
@@ -69,6 +71,7 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 		syncCommitteeMessagesSubmitter:        parameters.syncCommitteeMessagesSubmitter,
 		syncCommitteeSubscriptionsSubmitter:   parameters.syncCommitteeSubscriptionsSubmitter,
 		syncCommitteeContributionsSubmitter:   parameters.syncCommitteeContributionsSubmitter,
+		payloadAttestationMessagesSubmitter:   parameters.payloadAttestationMessagesSubmitter,
 	}
 
 	return s, nil

--- a/services/submitter/immediate/submitpayloadattestationmessages.go
+++ b/services/submitter/immediate/submitpayloadattestationmessages.go
@@ -1,0 +1,39 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package immediate
+
+import (
+	"context"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+)
+
+// SubmitPayloadAttestationMessages submits payload attestation messages.
+func (s *Service) SubmitPayloadAttestationMessages(ctx context.Context, opts *api.SubmitPayloadAttestationMessagesOpts) error {
+	ctx, span := otel.Tracer("attestantio.vouch.services.submitter.immediate").Start(ctx, "SubmitPayloadAttestationMessages")
+	defer span.End()
+
+	if opts == nil || len(opts.Messages) == 0 {
+		return errors.New("no payload attestation messages supplied")
+	}
+	if s.payloadAttestationMessagesSubmitter == nil {
+		return errors.New("no payload attestation messages submitter specified")
+	}
+	if err := s.payloadAttestationMessagesSubmitter.SubmitPayloadAttestationMessages(ctx, opts); err != nil {
+		return errors.Wrap(err, "failed to submit payload attestation messages")
+	}
+	return nil
+}

--- a/services/submitter/immediate/submitpayloadattestationmessages_test.go
+++ b/services/submitter/immediate/submitpayloadattestationmessages_test.go
@@ -1,0 +1,73 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package immediate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/api"
+	mocketh2client "github.com/attestantio/go-eth2-client/mock"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/vouch/mock"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/submitter/immediate"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitPayloadAttestationMessagesForwardsRequest(t *testing.T) {
+	ctx := context.Background()
+	client, err := mocketh2client.New(ctx)
+	require.NoError(t, err)
+	proposalSubmitter := mock.NewProposalSubmitter()
+	recorder := &recordingPayloadAttestationSubmitter{}
+
+	service, err := immediate.New(ctx,
+		immediate.WithLogLevel(zerolog.Disabled),
+		immediate.WithClientMonitor(nullmetrics.New()),
+		immediate.WithProposalSubmitter(proposalSubmitter),
+		immediate.WithExecutionPayloadEnvelopeSubmitter(client),
+		immediate.WithAttestationsSubmitter(client),
+		immediate.WithBeaconCommitteeSubscriptionsSubmitter(client),
+		immediate.WithAggregateAttestationsSubmitter(client),
+		immediate.WithProposalPreparationsSubmitter(client),
+		immediate.WithSyncCommitteeMessagesSubmitter(client),
+		immediate.WithSyncCommitteeSubscriptionsSubmitter(client),
+		immediate.WithSyncCommitteeContributionsSubmitter(client),
+		immediate.WithPayloadAttestationMessagesSubmitter(recorder),
+	)
+	require.NoError(t, err)
+
+	message := &spec.VersionedPayloadAttestationMessage{
+		Version: spec.DataVersionGloas,
+		Gloas: &gloas.PayloadAttestationMessage{
+			ValidatorIndex: 7,
+			Data:           &gloas.PayloadAttestationData{Slot: 9},
+		},
+	}
+	opts := &api.SubmitPayloadAttestationMessagesOpts{Messages: []*spec.VersionedPayloadAttestationMessage{message}}
+	require.NoError(t, service.SubmitPayloadAttestationMessages(ctx, opts))
+	require.Same(t, opts, recorder.opts)
+}
+
+type recordingPayloadAttestationSubmitter struct {
+	opts *api.SubmitPayloadAttestationMessagesOpts
+}
+
+func (s *recordingPayloadAttestationSubmitter) SubmitPayloadAttestationMessages(_ context.Context, opts *api.SubmitPayloadAttestationMessagesOpts) error {
+	s.opts = opts
+	return nil
+}

--- a/services/submitter/multinode/parameters.go
+++ b/services/submitter/multinode/parameters.go
@@ -21,6 +21,7 @@ import (
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/vouch/services/metrics"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/submitter"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -39,6 +40,7 @@ type parameters struct {
 	syncCommitteeMessagesSubmitter         map[string]eth2client.SyncCommitteeMessagesSubmitter
 	syncCommitteeSubscriptionsSubmitters   map[string]eth2client.SyncCommitteeSubscriptionsSubmitter
 	syncCommitteeContributionsSubmitters   map[string]eth2client.SyncCommitteeContributionsSubmitter
+	payloadAttestationMessagesSubmitters   map[string]submitter.PayloadAttestationMessagesSubmitter
 }
 
 // Parameter is the interface for service parameters.
@@ -112,6 +114,13 @@ func WithAggregateAttestationsSubmitters(submitters map[string]eth2client.Aggreg
 func WithProposalPreparationsSubmitters(submitters map[string]eth2client.ProposalPreparationsSubmitter) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.proposalPreparationsSubmitters = submitters
+	})
+}
+
+// WithPayloadAttestationMessagesSubmitters sets the payload attestation message submitters.
+func WithPayloadAttestationMessagesSubmitters(submitters map[string]submitter.PayloadAttestationMessagesSubmitter) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.payloadAttestationMessagesSubmitters = submitters
 	})
 }
 

--- a/services/submitter/multinode/service.go
+++ b/services/submitter/multinode/service.go
@@ -19,6 +19,7 @@ import (
 
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/vouch/services/metrics"
+	"github.com/attestantio/vouch/services/submitter"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	zerologger "github.com/rs/zerolog/log"
@@ -39,6 +40,7 @@ type Service struct {
 	syncCommitteeMessagesSubmitter        map[string]eth2client.SyncCommitteeMessagesSubmitter
 	syncCommitteeSubscriptionSubmitters   map[string]eth2client.SyncCommitteeSubscriptionsSubmitter
 	syncCommitteeContributionsSubmitters  map[string]eth2client.SyncCommitteeContributionsSubmitter
+	payloadAttestationMessagesSubmitters  map[string]submitter.PayloadAttestationMessagesSubmitter
 }
 
 // New creates a new multinode submitter.
@@ -68,6 +70,7 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 		syncCommitteeMessagesSubmitter:        parameters.syncCommitteeMessagesSubmitter,
 		syncCommitteeSubscriptionSubmitters:   parameters.syncCommitteeSubscriptionsSubmitters,
 		syncCommitteeContributionsSubmitters:  parameters.syncCommitteeContributionsSubmitters,
+		payloadAttestationMessagesSubmitters:  parameters.payloadAttestationMessagesSubmitters,
 	}
 	log.Trace().Int64("process_concurrency", s.processConcurrency).Msg("Set process concurrency")
 

--- a/services/submitter/multinode/submitexecutionpayloadenvelope.go
+++ b/services/submitter/multinode/submitexecutionpayloadenvelope.go
@@ -15,6 +15,7 @@ package multinode
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -41,6 +42,12 @@ func (s *Service) SubmitExecutionPayloadEnvelope(ctx context.Context, opts *api.
 	if len(s.executionPayloadEnvelopeSubmitters) == 0 {
 		return errors.New("no execution payload envelope submitters configured")
 	}
+	beaconBlockRoot := "<unknown>"
+	if opts.SignedExecutionPayloadEnvelope != nil {
+		if root, err := opts.SignedExecutionPayloadEnvelope.BeaconBlockRoot(); err == nil {
+			beaconBlockRoot = root.String()
+		}
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 
@@ -50,7 +57,7 @@ func (s *Service) SubmitExecutionPayloadEnvelope(ctx context.Context, opts *api.
 	var wg sync.WaitGroup
 	for name, submitter := range s.executionPayloadEnvelopeSubmitters {
 		wg.Go(func() {
-			s.submitExecutionPayloadEnvelope(ctx, sem, submissionCompleted, submissionSucceeded, name, opts, submitter)
+			s.submitExecutionPayloadEnvelope(ctx, sem, submissionCompleted, submissionSucceeded, name, beaconBlockRoot, opts, submitter)
 		})
 	}
 	// Release the timeout context once every submission has finished, rather than as soon as
@@ -69,9 +76,14 @@ func (s *Service) SubmitExecutionPayloadEnvelope(ctx context.Context, opts *api.
 	// The context is released once every submission has finished, so both cases above can be
 	// ready at once and select picks between them at random.  Consult the success flag rather
 	// than the chosen case, otherwise a successful submission can report a timeout.
-	if !submissionSucceeded.Load() {
+	anyProviderSucceeded := submissionSucceeded.Load()
+	if !anyProviderSucceeded {
+		s.log.Warn().Str("beacon_block_root", beaconBlockRoot).Bool("any_provider_succeeded", false).Msg("Execution payload envelope submission completed")
+
 		return errors.New("no successful submissions before timeout")
 	}
+	log := s.log.With().Str("beacon_block_root", beaconBlockRoot).Bool("any_provider_succeeded", true).Logger()
+	log.Trace().Msg("Execution payload envelope submission completed")
 
 	return nil
 }
@@ -81,6 +93,7 @@ func (s *Service) submitExecutionPayloadEnvelope(ctx context.Context,
 	submissionCompleted chan<- struct{},
 	submissionSucceeded *atomic.Bool,
 	name string,
+	beaconBlockRoot string,
 	opts *api.SubmitExecutionPayloadEnvelopeOpts,
 	submitter eth2client.ExecutionPayloadEnvelopeSubmitter,
 ) {
@@ -95,15 +108,22 @@ func (s *Service) submitExecutionPayloadEnvelope(ctx context.Context,
 	}
 	defer sem.Release(1)
 
-	address := "<unknown>"
+	address := name
 	if service, isService := submitter.(eth2client.Service); isService {
 		address = service.Address()
 	}
+	log := s.log.With().Str("provider", name).Str("beacon_block_root", beaconBlockRoot).Logger()
 	started := time.Now()
 	err := submitter.SubmitExecutionPayloadEnvelope(ctx, opts)
-	s.clientMonitor.ClientOperation(address, "submit execution payload envelope", err == nil, time.Since(started))
+	elapsed := time.Since(started)
+	s.clientMonitor.ClientOperation(address, "submit execution payload envelope", err == nil, elapsed)
 	if err != nil {
-		s.log.Warn().Err(err).Msg("Failed to submit execution payload envelope")
+		status := "failed"
+		var apiErr *api.Error
+		if errors.As(err, &apiErr) {
+			status = strconv.Itoa(apiErr.StatusCode)
+		}
+		log.Warn().Err(err).Str("status", status).Dur("elapsed", elapsed).Msg("Execution payload envelope provider submission completed")
 		return
 	}
 
@@ -112,5 +132,5 @@ func (s *Service) submitExecutionPayloadEnvelope(ctx context.Context,
 	case submissionCompleted <- struct{}{}:
 	default:
 	}
-	s.log.Trace().Msg("Submitted execution payload envelope")
+	log.Trace().Str("status", "succeeded").Dur("elapsed", elapsed).Msg("Execution payload envelope provider submission completed")
 }

--- a/services/submitter/multinode/submitexecutionpayloadenvelope.go
+++ b/services/submitter/multinode/submitexecutionpayloadenvelope.go
@@ -15,7 +15,6 @@ package multinode
 
 import (
 	"context"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -76,14 +75,9 @@ func (s *Service) SubmitExecutionPayloadEnvelope(ctx context.Context, opts *api.
 	// The context is released once every submission has finished, so both cases above can be
 	// ready at once and select picks between them at random.  Consult the success flag rather
 	// than the chosen case, otherwise a successful submission can report a timeout.
-	anyProviderSucceeded := submissionSucceeded.Load()
-	if !anyProviderSucceeded {
-		s.log.Warn().Str("beacon_block_root", beaconBlockRoot).Bool("any_provider_succeeded", false).Msg("Execution payload envelope submission completed")
-
+	if !submissionSucceeded.Load() {
 		return errors.New("no successful submissions before timeout")
 	}
-	log := s.log.With().Str("beacon_block_root", beaconBlockRoot).Bool("any_provider_succeeded", true).Logger()
-	log.Trace().Msg("Execution payload envelope submission completed")
 
 	return nil
 }
@@ -102,28 +96,30 @@ func (s *Service) submitExecutionPayloadEnvelope(ctx context.Context,
 	))
 	defer span.End()
 
+	log := s.log.With().Str("beacon_node_address", name).Str("beacon_block_root", beaconBlockRoot).Logger()
 	if err := sem.Acquire(ctx, 1); err != nil {
-		s.log.Error().Err(err).Msg("Failed to acquire semaphore")
+		log.Error().Err(err).Msg("Failed to acquire semaphore")
 		return
 	}
 	defer sem.Release(1)
 
-	address := name
+	address := "<unknown>"
 	if service, isService := submitter.(eth2client.Service); isService {
 		address = service.Address()
 	}
-	log := s.log.With().Str("provider", name).Str("beacon_block_root", beaconBlockRoot).Logger()
 	started := time.Now()
 	err := submitter.SubmitExecutionPayloadEnvelope(ctx, opts)
 	elapsed := time.Since(started)
 	s.clientMonitor.ClientOperation(address, "submit execution payload envelope", err == nil, elapsed)
 	if err != nil {
-		status := "failed"
+		// The status field carries the outcome of the submission and status_code the HTTP
+		// status of an API failure; status_code is 0 when there was no response to fail.
+		statusCode := 0
 		var apiErr *api.Error
 		if errors.As(err, &apiErr) {
-			status = strconv.Itoa(apiErr.StatusCode)
+			statusCode = apiErr.StatusCode
 		}
-		log.Warn().Err(err).Str("status", status).Dur("elapsed", elapsed).Msg("Execution payload envelope provider submission completed")
+		log.Warn().Err(err).Str("status", "failed").Int("status_code", statusCode).Dur("elapsed", elapsed).Msg("Execution payload envelope provider submission completed")
 		return
 	}
 

--- a/services/submitter/multinode/submitexecutionpayloadenvelope.go
+++ b/services/submitter/multinode/submitexecutionpayloadenvelope.go
@@ -48,7 +48,7 @@ func (s *Service) SubmitExecutionPayloadEnvelope(ctx context.Context, opts *api.
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.timeout)
 
 	sem := semaphore.NewWeighted(s.processConcurrency)
 	submissionCompleted := make(chan struct{}, 1)

--- a/services/submitter/multinode/submitexecutionpayloadenvelope_test.go
+++ b/services/submitter/multinode/submitexecutionpayloadenvelope_test.go
@@ -167,6 +167,63 @@ func TestSubmitExecutionPayloadEnvelopeReturnsPromptlyAfterImmediateSuccess(t *t
 	require.Same(t, opts, capture.opts)
 }
 
+func TestSubmitExecutionPayloadEnvelopeContinuesAfterCallerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	canceled := make(chan struct{})
+	completed := make(chan struct{})
+	service, err := multinode.New(ctx,
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithTimeout(time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithProposalSubmitters(map[string]eth2client.ProposalSubmitter{
+			"one": mock.NewProposalSubmitter(),
+		}),
+		multinode.WithExecutionPayloadEnvelopeSubmitters(map[string]eth2client.ExecutionPayloadEnvelopeSubmitter{
+			"slow": &cancelAwareExecutionPayloadEnvelopeSubmitter{started: started, release: release, canceled: canceled, completed: completed},
+			"fast": &waitingExecutionPayloadEnvelopeSubmitter{started: started},
+		}),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"one": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"one": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithProposalPreparationsSubmitters(map[string]eth2client.ProposalPreparationsSubmitter{
+			"one": mock.NewProposalPreparationsSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"one": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"one": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"one": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"one": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, service.SubmitExecutionPayloadEnvelope(ctx, &api.SubmitExecutionPayloadEnvelopeOpts{}))
+	cancel()
+	select {
+	case <-canceled:
+		t.Fatal("in-flight submission was canceled when the caller returned")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("in-flight submission did not complete")
+	}
+}
+
 func TestSubmitExecutionPayloadEnvelopeDoesNotWaitForNodeVersion(t *testing.T) {
 	ctx := context.Background()
 	nodeVersionRelease := make(chan struct{})
@@ -481,6 +538,38 @@ func hasProviderSubmissionField(capture *logger.LogCapture, beaconNodeAddress st
 	}
 
 	return false
+}
+
+type cancelAwareExecutionPayloadEnvelopeSubmitter struct {
+	started   chan<- struct{}
+	release   <-chan struct{}
+	canceled  chan<- struct{}
+	completed chan<- struct{}
+}
+
+func (s *cancelAwareExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(ctx context.Context,
+	_ *api.SubmitExecutionPayloadEnvelopeOpts,
+) error {
+	close(s.started)
+	select {
+	case <-ctx.Done():
+		close(s.canceled)
+		return ctx.Err()
+	case <-s.release:
+		close(s.completed)
+		return nil
+	}
+}
+
+type waitingExecutionPayloadEnvelopeSubmitter struct {
+	started <-chan struct{}
+}
+
+func (s *waitingExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(_ context.Context,
+	_ *api.SubmitExecutionPayloadEnvelopeOpts,
+) error {
+	<-s.started
+	return nil
 }
 
 type blockingExecutionPayloadEnvelopeSubmitter struct {

--- a/services/submitter/multinode/submitexecutionpayloadenvelope_test.go
+++ b/services/submitter/multinode/submitexecutionpayloadenvelope_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSubmitExecutionPayloadEnvelopeReportsProviderAndOverallResults(t *testing.T) {
+func TestSubmitExecutionPayloadEnvelopeReportsProviderResults(t *testing.T) {
 	ctx := context.Background()
 	capture := logger.NewLogCapture()
 	monitor, err := prometheusmetrics.New(ctx,
@@ -41,9 +41,11 @@ func TestSubmitExecutionPayloadEnvelopeReportsProviderAndOverallResults(t *testi
 	)
 	require.NoError(t, err)
 	beaconBlockRoot := phase0.Root{0x01}
-	failedAddress := "https://user:secret@failed.example/path?access_token=secret"
-	failedProviderCountBefore := clientOperationCount(t, "https://user:xxxxx@failed.example/xxxxx?access_token=xxxxx", "submit execution payload envelope", "failed")
-	successfulProviderCountBefore := clientOperationCount(t, "http://succeeded", "submit execution payload envelope", "succeeded")
+	failingAddress := "https://user:secret@failed.example/path?access_token=secret"
+	workingAddress := "http://working.example"
+	failingProviderCountBefore := clientOperationCount(t, "https://user:xxxxx@failed.example/xxxxx?access_token=xxxxx", "submit execution payload envelope", "failed")
+	workingProviderCountBefore := clientOperationCount(t, workingAddress, "submit execution payload envelope", "succeeded")
+	unaddressedProviderCountBefore := clientOperationCount(t, "http://<unknown>", "submit execution payload envelope", "succeeded")
 	service, err := multinode.New(ctx,
 		multinode.WithLogLevel(zerolog.TraceLevel),
 		multinode.WithClientMonitor(monitor),
@@ -53,8 +55,9 @@ func TestSubmitExecutionPayloadEnvelopeReportsProviderAndOverallResults(t *testi
 			"one": mock.NewProposalSubmitter(),
 		}),
 		multinode.WithExecutionPayloadEnvelopeSubmitters(map[string]eth2client.ExecutionPayloadEnvelopeSubmitter{
-			"failed":    &errorExecutionPayloadEnvelopeSubmitter{address: failedAddress, err: &api.Error{StatusCode: 400}},
-			"succeeded": &capturingExecutionPayloadEnvelopeSubmitter{},
+			"failing":     &serviceExecutionPayloadEnvelopeSubmitter{address: failingAddress, err: &api.Error{StatusCode: 400}},
+			"working":     &serviceExecutionPayloadEnvelopeSubmitter{address: workingAddress},
+			"unaddressed": &capturingExecutionPayloadEnvelopeSubmitter{},
 		}),
 		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
 			"one": mock.NewAttestationsSubmitter(),
@@ -91,36 +94,33 @@ func TestSubmitExecutionPayloadEnvelopeReportsProviderAndOverallResults(t *testi
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		return capture.HasLog(map[string]any{
-			"message":           "Execution payload envelope provider submission completed",
-			"provider":          "failed",
-			"beacon_block_root": beaconBlockRoot.String(),
-			"status":            "400",
-		}) && hasProviderSubmissionField(capture, "failed", beaconBlockRoot.String(), "400", "elapsed") &&
-			hasProviderSubmissionField(capture, "failed", beaconBlockRoot.String(), "400", "error")
+			"message":             "Execution payload envelope provider submission completed",
+			"beacon_node_address": "failing",
+			"beacon_block_root":   beaconBlockRoot.String(),
+			"status":              "failed",
+			"status_code":         400,
+		}) && hasProviderSubmissionField(capture, "failing", beaconBlockRoot.String(), "failed", "elapsed") &&
+			hasProviderSubmissionField(capture, "failing", beaconBlockRoot.String(), "failed", "error")
 	}, time.Second, 10*time.Millisecond)
 	require.Eventually(t, func() bool {
 		return capture.HasLog(map[string]any{
-			"message":           "Execution payload envelope provider submission completed",
-			"provider":          "succeeded",
-			"beacon_block_root": beaconBlockRoot.String(),
-			"status":            "succeeded",
-		}) && hasProviderSubmissionField(capture, "succeeded", beaconBlockRoot.String(), "succeeded", "elapsed")
+			"message":             "Execution payload envelope provider submission completed",
+			"beacon_node_address": "working",
+			"beacon_block_root":   beaconBlockRoot.String(),
+			"status":              "succeeded",
+		}) && hasProviderSubmissionField(capture, "working", beaconBlockRoot.String(), "succeeded", "elapsed")
 	}, time.Second, 10*time.Millisecond)
-	require.True(t, capture.HasLog(map[string]any{
-		"message":                "Execution payload envelope submission completed",
-		"beacon_block_root":      beaconBlockRoot.String(),
-		"any_provider_succeeded": true,
-	}))
 	for _, entry := range capture.Entries() {
-		require.NotContains(t, entry, "beacon_node_address")
 		for _, value := range entry {
-			require.NotEqual(t, failedAddress, value)
+			require.NotEqual(t, failingAddress, value)
 		}
 	}
 	require.Eventually(t, func() bool {
-		return clientOperationCount(t, "https://user:xxxxx@failed.example/xxxxx?access_token=xxxxx", "submit execution payload envelope", "failed") == failedProviderCountBefore+1 &&
-			clientOperationCount(t, "http://succeeded", "submit execution payload envelope", "succeeded") == successfulProviderCountBefore+1
+		return clientOperationCount(t, "https://user:xxxxx@failed.example/xxxxx?access_token=xxxxx", "submit execution payload envelope", "failed") == failingProviderCountBefore+1 &&
+			clientOperationCount(t, workingAddress, "submit execution payload envelope", "succeeded") == workingProviderCountBefore+1 &&
+			clientOperationCount(t, "http://<unknown>", "submit execution payload envelope", "succeeded") == unaddressedProviderCountBefore+1
 	}, time.Second, 10*time.Millisecond)
+	require.Zero(t, clientOperationCount(t, "http://unaddressed", "submit execution payload envelope", "succeeded"))
 }
 
 func TestSubmitExecutionPayloadEnvelopeReturnsPromptlyAfterImmediateSuccess(t *testing.T) {
@@ -225,13 +225,80 @@ func TestSubmitExecutionPayloadEnvelopeDoesNotWaitForNodeVersion(t *testing.T) {
 	}
 }
 
+// TestSubmitExecutionPayloadEnvelopeIdentifiesProviderThatNeverStarts covers the provider that
+// leaves through the semaphore rather than through a submission: with a single concurrency slot
+// held until the deadline, the queued provider must still be identifiable in the log.
+func TestSubmitExecutionPayloadEnvelopeIdentifiesProviderThatNeverStarts(t *testing.T) {
+	ctx := context.Background()
+	capture := logger.NewLogCapture()
+	canceled := make(chan struct{}, 2)
+	beaconBlockRoot := phase0.Root{0x03}
+	service, err := multinode.New(ctx,
+		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithTimeout(50*time.Millisecond),
+		multinode.WithProcessConcurrency(1),
+		multinode.WithProposalSubmitters(map[string]eth2client.ProposalSubmitter{
+			"one": mock.NewProposalSubmitter(),
+		}),
+		multinode.WithExecutionPayloadEnvelopeSubmitters(map[string]eth2client.ExecutionPayloadEnvelopeSubmitter{
+			"one": &blockingExecutionPayloadEnvelopeSubmitter{canceled: canceled},
+			"two": &blockingExecutionPayloadEnvelopeSubmitter{canceled: canceled},
+		}),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"one": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"one": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"one": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithProposalPreparationsSubmitters(map[string]eth2client.ProposalPreparationsSubmitter{
+			"one": mock.NewProposalPreparationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"one": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"one": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"one": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	// Only one of the two providers takes the single slot; the other never starts its
+	// submission, so its only record is the semaphore failure.
+	err = service.SubmitExecutionPayloadEnvelope(ctx, &api.SubmitExecutionPayloadEnvelopeOpts{
+		SignedExecutionPayloadEnvelope: &spec.VersionedSignedExecutionPayloadEnvelope{
+			Version: spec.DataVersionGloas,
+			Gloas: &gloas.SignedExecutionPayloadEnvelope{
+				Message: &gloas.ExecutionPayloadEnvelope{BeaconBlockRoot: beaconBlockRoot},
+			},
+		},
+	})
+	require.EqualError(t, err, "no successful submissions before timeout")
+	require.Eventually(t, func() bool {
+		for _, name := range []string{"one", "two"} {
+			if capture.HasLog(map[string]any{
+				"message":             "Failed to acquire semaphore",
+				"beacon_node_address": name,
+				"beacon_block_root":   beaconBlockRoot.String(),
+			}) {
+				return true
+			}
+		}
+
+		return false
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestSubmitExecutionPayloadEnvelopeCancelsOnDeadline(t *testing.T) {
 	ctx := context.Background()
 	canceled := make(chan struct{}, 1)
-	capture := logger.NewLogCapture()
-	beaconBlockRoot := phase0.Root{0x02}
 	service, err := multinode.New(ctx,
-		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithLogLevel(zerolog.Disabled),
 		multinode.WithTimeout(50*time.Millisecond),
 		multinode.WithProcessConcurrency(1),
 		multinode.WithProposalSubmitters(map[string]eth2client.ProposalSubmitter{
@@ -264,20 +331,8 @@ func TestSubmitExecutionPayloadEnvelopeCancelsOnDeadline(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = service.SubmitExecutionPayloadEnvelope(ctx, &api.SubmitExecutionPayloadEnvelopeOpts{
-		SignedExecutionPayloadEnvelope: &spec.VersionedSignedExecutionPayloadEnvelope{
-			Version: spec.DataVersionGloas,
-			Gloas: &gloas.SignedExecutionPayloadEnvelope{
-				Message: &gloas.ExecutionPayloadEnvelope{BeaconBlockRoot: beaconBlockRoot},
-			},
-		},
-	})
+	err = service.SubmitExecutionPayloadEnvelope(ctx, &api.SubmitExecutionPayloadEnvelopeOpts{})
 	require.EqualError(t, err, "no successful submissions before timeout")
-	require.True(t, capture.HasLog(map[string]any{
-		"message":                "Execution payload envelope submission completed",
-		"beacon_block_root":      beaconBlockRoot.String(),
-		"any_provider_succeeded": false,
-	}))
 	require.Eventually(t, func() bool {
 		select {
 		case <-canceled:
@@ -355,28 +410,30 @@ func (s *capturingExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvel
 	return nil
 }
 
-type errorExecutionPayloadEnvelopeSubmitter struct {
+// serviceExecutionPayloadEnvelopeSubmitter is an envelope submitter that is also an
+// eth2client.Service, so that its address rather than its name reaches the client monitor.
+type serviceExecutionPayloadEnvelopeSubmitter struct {
 	address string
 	err     error
 }
 
-func (s *errorExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(_ context.Context, _ *api.SubmitExecutionPayloadEnvelopeOpts) error {
+func (s *serviceExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(_ context.Context, _ *api.SubmitExecutionPayloadEnvelopeOpts) error {
 	return s.err
 }
 
-func (*errorExecutionPayloadEnvelopeSubmitter) Name() string {
-	return "error"
+func (*serviceExecutionPayloadEnvelopeSubmitter) Name() string {
+	return "service"
 }
 
-func (s *errorExecutionPayloadEnvelopeSubmitter) Address() string {
+func (s *serviceExecutionPayloadEnvelopeSubmitter) Address() string {
 	return s.address
 }
 
-func (*errorExecutionPayloadEnvelopeSubmitter) IsActive() bool {
+func (*serviceExecutionPayloadEnvelopeSubmitter) IsActive() bool {
 	return true
 }
 
-func (*errorExecutionPayloadEnvelopeSubmitter) IsSynced() bool {
+func (*serviceExecutionPayloadEnvelopeSubmitter) IsSynced() bool {
 	return true
 }
 
@@ -410,10 +467,10 @@ func clientOperationCount(t *testing.T, provider string, operation string, resul
 	return 0
 }
 
-func hasProviderSubmissionField(capture *logger.LogCapture, provider string, beaconBlockRoot string, status string, field string) bool {
+func hasProviderSubmissionField(capture *logger.LogCapture, beaconNodeAddress string, beaconBlockRoot string, status string, field string) bool {
 	for _, entry := range capture.Entries() {
 		if entry["message"] != "Execution payload envelope provider submission completed" ||
-			entry["provider"] != provider ||
+			entry["beacon_node_address"] != beaconNodeAddress ||
 			entry["beacon_block_root"] != beaconBlockRoot ||
 			entry["status"] != status {
 			continue

--- a/services/submitter/multinode/submitexecutionpayloadenvelope_test.go
+++ b/services/submitter/multinode/submitexecutionpayloadenvelope_test.go
@@ -20,11 +20,108 @@ import (
 
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/mock"
+	prometheusmetrics "github.com/attestantio/vouch/services/metrics/prometheus"
 	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/attestantio/vouch/testing/logger"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSubmitExecutionPayloadEnvelopeReportsProviderAndOverallResults(t *testing.T) {
+	ctx := context.Background()
+	capture := logger.NewLogCapture()
+	monitor, err := prometheusmetrics.New(ctx,
+		prometheusmetrics.WithLogLevel(zerolog.Disabled),
+		prometheusmetrics.WithAddress("localhost:0"),
+	)
+	require.NoError(t, err)
+	beaconBlockRoot := phase0.Root{0x01}
+	failedAddress := "https://user:secret@failed.example/path?access_token=secret"
+	failedProviderCountBefore := clientOperationCount(t, "https://user:xxxxx@failed.example/xxxxx?access_token=xxxxx", "submit execution payload envelope", "failed")
+	successfulProviderCountBefore := clientOperationCount(t, "http://succeeded", "submit execution payload envelope", "succeeded")
+	service, err := multinode.New(ctx,
+		multinode.WithLogLevel(zerolog.TraceLevel),
+		multinode.WithClientMonitor(monitor),
+		multinode.WithTimeout(time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithProposalSubmitters(map[string]eth2client.ProposalSubmitter{
+			"one": mock.NewProposalSubmitter(),
+		}),
+		multinode.WithExecutionPayloadEnvelopeSubmitters(map[string]eth2client.ExecutionPayloadEnvelopeSubmitter{
+			"failed":    &errorExecutionPayloadEnvelopeSubmitter{address: failedAddress, err: &api.Error{StatusCode: 400}},
+			"succeeded": &capturingExecutionPayloadEnvelopeSubmitter{},
+		}),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{
+			"one": mock.NewAttestationsSubmitter(),
+		}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{
+			"one": mock.NewBeaconCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{
+			"one": mock.NewAggregateAttestationsSubmitter(),
+		}),
+		multinode.WithProposalPreparationsSubmitters(map[string]eth2client.ProposalPreparationsSubmitter{
+			"one": mock.NewProposalPreparationsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{
+			"one": mock.NewSyncCommitteeMessagesSubmitter(),
+		}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{
+			"one": mock.NewSyncCommitteeSubscriptionsSubmitter(),
+		}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{
+			"one": mock.NewSyncCommitteeContributionsSubmitter(),
+		}),
+	)
+	require.NoError(t, err)
+
+	err = service.SubmitExecutionPayloadEnvelope(ctx, &api.SubmitExecutionPayloadEnvelopeOpts{
+		SignedExecutionPayloadEnvelope: &spec.VersionedSignedExecutionPayloadEnvelope{
+			Version: spec.DataVersionGloas,
+			Gloas: &gloas.SignedExecutionPayloadEnvelope{
+				Message: &gloas.ExecutionPayloadEnvelope{BeaconBlockRoot: beaconBlockRoot},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return capture.HasLog(map[string]any{
+			"message":           "Execution payload envelope provider submission completed",
+			"provider":          "failed",
+			"beacon_block_root": beaconBlockRoot.String(),
+			"status":            "400",
+		}) && hasProviderSubmissionField(capture, "failed", beaconBlockRoot.String(), "400", "elapsed") &&
+			hasProviderSubmissionField(capture, "failed", beaconBlockRoot.String(), "400", "error")
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return capture.HasLog(map[string]any{
+			"message":           "Execution payload envelope provider submission completed",
+			"provider":          "succeeded",
+			"beacon_block_root": beaconBlockRoot.String(),
+			"status":            "succeeded",
+		}) && hasProviderSubmissionField(capture, "succeeded", beaconBlockRoot.String(), "succeeded", "elapsed")
+	}, time.Second, 10*time.Millisecond)
+	require.True(t, capture.HasLog(map[string]any{
+		"message":                "Execution payload envelope submission completed",
+		"beacon_block_root":      beaconBlockRoot.String(),
+		"any_provider_succeeded": true,
+	}))
+	for _, entry := range capture.Entries() {
+		require.NotContains(t, entry, "beacon_node_address")
+		for _, value := range entry {
+			require.NotEqual(t, failedAddress, value)
+		}
+	}
+	require.Eventually(t, func() bool {
+		return clientOperationCount(t, "https://user:xxxxx@failed.example/xxxxx?access_token=xxxxx", "submit execution payload envelope", "failed") == failedProviderCountBefore+1 &&
+			clientOperationCount(t, "http://succeeded", "submit execution payload envelope", "succeeded") == successfulProviderCountBefore+1
+	}, time.Second, 10*time.Millisecond)
+}
 
 func TestSubmitExecutionPayloadEnvelopeReturnsPromptlyAfterImmediateSuccess(t *testing.T) {
 	ctx := context.Background()
@@ -131,8 +228,10 @@ func TestSubmitExecutionPayloadEnvelopeDoesNotWaitForNodeVersion(t *testing.T) {
 func TestSubmitExecutionPayloadEnvelopeCancelsOnDeadline(t *testing.T) {
 	ctx := context.Background()
 	canceled := make(chan struct{}, 1)
+	capture := logger.NewLogCapture()
+	beaconBlockRoot := phase0.Root{0x02}
 	service, err := multinode.New(ctx,
-		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithLogLevel(zerolog.TraceLevel),
 		multinode.WithTimeout(50*time.Millisecond),
 		multinode.WithProcessConcurrency(1),
 		multinode.WithProposalSubmitters(map[string]eth2client.ProposalSubmitter{
@@ -165,8 +264,20 @@ func TestSubmitExecutionPayloadEnvelopeCancelsOnDeadline(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = service.SubmitExecutionPayloadEnvelope(ctx, &api.SubmitExecutionPayloadEnvelopeOpts{})
+	err = service.SubmitExecutionPayloadEnvelope(ctx, &api.SubmitExecutionPayloadEnvelopeOpts{
+		SignedExecutionPayloadEnvelope: &spec.VersionedSignedExecutionPayloadEnvelope{
+			Version: spec.DataVersionGloas,
+			Gloas: &gloas.SignedExecutionPayloadEnvelope{
+				Message: &gloas.ExecutionPayloadEnvelope{BeaconBlockRoot: beaconBlockRoot},
+			},
+		},
+	})
 	require.EqualError(t, err, "no successful submissions before timeout")
+	require.True(t, capture.HasLog(map[string]any{
+		"message":                "Execution payload envelope submission completed",
+		"beacon_block_root":      beaconBlockRoot.String(),
+		"any_provider_succeeded": false,
+	}))
 	require.Eventually(t, func() bool {
 		select {
 		case <-canceled:
@@ -242,6 +353,77 @@ type capturingExecutionPayloadEnvelopeSubmitter struct {
 func (s *capturingExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(_ context.Context, opts *api.SubmitExecutionPayloadEnvelopeOpts) error {
 	s.opts = opts
 	return nil
+}
+
+type errorExecutionPayloadEnvelopeSubmitter struct {
+	address string
+	err     error
+}
+
+func (s *errorExecutionPayloadEnvelopeSubmitter) SubmitExecutionPayloadEnvelope(_ context.Context, _ *api.SubmitExecutionPayloadEnvelopeOpts) error {
+	return s.err
+}
+
+func (*errorExecutionPayloadEnvelopeSubmitter) Name() string {
+	return "error"
+}
+
+func (s *errorExecutionPayloadEnvelopeSubmitter) Address() string {
+	return s.address
+}
+
+func (*errorExecutionPayloadEnvelopeSubmitter) IsActive() bool {
+	return true
+}
+
+func (*errorExecutionPayloadEnvelopeSubmitter) IsSynced() bool {
+	return true
+}
+
+func clientOperationCount(t *testing.T, provider string, operation string, result string) float64 {
+	t.Helper()
+
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() != "vouch_client_operation_requests_total" {
+			continue
+		}
+		for _, metric := range metricFamily.GetMetric() {
+			var providerMatches, operationMatches, resultMatches bool
+			for _, label := range metric.GetLabel() {
+				switch label.GetName() {
+				case "provider":
+					providerMatches = label.GetValue() == provider
+				case "operation":
+					operationMatches = label.GetValue() == operation
+				case "result":
+					resultMatches = label.GetValue() == result
+				}
+			}
+			if providerMatches && operationMatches && resultMatches {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+
+	return 0
+}
+
+func hasProviderSubmissionField(capture *logger.LogCapture, provider string, beaconBlockRoot string, status string, field string) bool {
+	for _, entry := range capture.Entries() {
+		if entry["message"] != "Execution payload envelope provider submission completed" ||
+			entry["provider"] != provider ||
+			entry["beacon_block_root"] != beaconBlockRoot ||
+			entry["status"] != status {
+			continue
+		}
+		if _, exists := entry[field]; exists {
+			return true
+		}
+	}
+
+	return false
 }
 
 type blockingExecutionPayloadEnvelopeSubmitter struct {

--- a/services/submitter/multinode/submitpayloadattestationmessages.go
+++ b/services/submitter/multinode/submitpayloadattestationmessages.go
@@ -42,7 +42,7 @@ func (s *Service) SubmitPayloadAttestationMessages(ctx context.Context, opts *ap
 		return errors.New("no payload attestation message submitters configured")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.timeout)
 
 	sem := semaphore.NewWeighted(s.processConcurrency)
 	submissionCompleted := make(chan struct{}, 1)

--- a/services/submitter/multinode/submitpayloadattestationmessages.go
+++ b/services/submitter/multinode/submitpayloadattestationmessages.go
@@ -45,25 +45,30 @@ func (s *Service) SubmitPayloadAttestationMessages(ctx context.Context, opts *ap
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 
 	sem := semaphore.NewWeighted(s.processConcurrency)
+	submissionCompleted := make(chan struct{}, 1)
 	submissionSucceeded := &atomic.Bool{}
 	var wg sync.WaitGroup
 	for name, payloadAttestationMessagesSubmitter := range s.payloadAttestationMessagesSubmitters {
 		wg.Go(func() {
-			s.submitPayloadAttestationMessages(ctx, cancel, sem, submissionSucceeded, name, opts, payloadAttestationMessagesSubmitter)
+			s.submitPayloadAttestationMessages(ctx, sem, submissionCompleted, submissionSucceeded, name, opts, payloadAttestationMessagesSubmitter)
 		})
 	}
-	completed := make(chan struct{})
+	// Release the timeout context once every submission has finished, rather than as soon as
+	// the first one succeeds, so that one node's success does not abort the others' in-flight
+	// submissions.
 	go func() {
 		wg.Wait()
-		close(completed)
 		cancel()
 	}()
 
 	select {
-	case <-completed:
+	case <-submissionCompleted:
 	case <-ctx.Done():
 	}
 
+	// The context is released once every submission has finished, so both cases above can be
+	// ready at once and select picks between them at random.  Consult the success flag rather
+	// than the chosen case, otherwise a successful submission can report a timeout.
 	if !submissionSucceeded.Load() {
 		return errors.New("no successful submissions before timeout")
 	}
@@ -72,8 +77,8 @@ func (s *Service) SubmitPayloadAttestationMessages(ctx context.Context, opts *ap
 }
 
 func (s *Service) submitPayloadAttestationMessages(ctx context.Context,
-	cancel context.CancelFunc,
 	sem *semaphore.Weighted,
+	submissionCompleted chan<- struct{},
 	submissionSucceeded *atomic.Bool,
 	name string,
 	opts *api.SubmitPayloadAttestationMessagesOpts,
@@ -100,8 +105,10 @@ func (s *Service) submitPayloadAttestationMessages(ctx context.Context,
 		return
 	}
 
-	if submissionSucceeded.CompareAndSwap(false, true) {
-		cancel()
+	submissionSucceeded.Store(true)
+	select {
+	case submissionCompleted <- struct{}{}:
+	default:
 	}
 	log.Trace().Msg("Submitted payload attestation messages")
 }

--- a/services/submitter/multinode/submitpayloadattestationmessages.go
+++ b/services/submitter/multinode/submitpayloadattestationmessages.go
@@ -1,0 +1,107 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/semaphore"
+)
+
+// SubmitPayloadAttestationMessages submits payload attestation messages to all configured nodes.
+func (s *Service) SubmitPayloadAttestationMessages(ctx context.Context, opts *api.SubmitPayloadAttestationMessagesOpts) error {
+	ctx, span := otel.Tracer("attestantio.vouch.service.submitter.multinode").Start(ctx, "SubmitPayloadAttestationMessages", trace.WithAttributes(
+		attribute.String("strategy", "multinode"),
+	))
+	defer span.End()
+
+	if opts == nil || len(opts.Messages) == 0 {
+		return errors.New("no payload attestation messages supplied")
+	}
+	if len(s.payloadAttestationMessagesSubmitters) == 0 {
+		return errors.New("no payload attestation message submitters configured")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+
+	sem := semaphore.NewWeighted(s.processConcurrency)
+	submissionSucceeded := &atomic.Bool{}
+	var wg sync.WaitGroup
+	for name, payloadAttestationMessagesSubmitter := range s.payloadAttestationMessagesSubmitters {
+		wg.Go(func() {
+			s.submitPayloadAttestationMessages(ctx, cancel, sem, submissionSucceeded, name, opts, payloadAttestationMessagesSubmitter)
+		})
+	}
+	completed := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(completed)
+		cancel()
+	}()
+
+	select {
+	case <-completed:
+	case <-ctx.Done():
+	}
+
+	if !submissionSucceeded.Load() {
+		return errors.New("no successful submissions before timeout")
+	}
+
+	return nil
+}
+
+func (s *Service) submitPayloadAttestationMessages(ctx context.Context,
+	cancel context.CancelFunc,
+	sem *semaphore.Weighted,
+	submissionSucceeded *atomic.Bool,
+	name string,
+	opts *api.SubmitPayloadAttestationMessagesOpts,
+	payloadAttestationMessagesSubmitter submitter.PayloadAttestationMessagesSubmitter,
+) {
+	ctx, span := otel.Tracer("attestantio.vouch.service.submitter.multinode").Start(ctx, "submitPayloadAttestationMessages", trace.WithAttributes(
+		attribute.String("server", name),
+	))
+	defer span.End()
+
+	log := s.log.With().Str("beacon_node_address", name).Logger()
+	if err := sem.Acquire(ctx, 1); err != nil {
+		log.Error().Err(err).Msg("Failed to acquire semaphore")
+		return
+	}
+	defer sem.Release(1)
+
+	_, address := s.serviceInfo(ctx, payloadAttestationMessagesSubmitter)
+	started := time.Now()
+	err := payloadAttestationMessagesSubmitter.SubmitPayloadAttestationMessages(ctx, opts)
+	s.clientMonitor.ClientOperation(address, "submit payload attestation messages", err == nil, time.Since(started))
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to submit payload attestation messages")
+		return
+	}
+
+	if submissionSucceeded.CompareAndSwap(false, true) {
+		cancel()
+	}
+	log.Trace().Msg("Submitted payload attestation messages")
+}

--- a/services/submitter/multinode/submitpayloadattestationmessages_test.go
+++ b/services/submitter/multinode/submitpayloadattestationmessages_test.go
@@ -58,8 +58,7 @@ func TestSubmitPayloadAttestationMessagesFansOutToNodes(t *testing.T) {
 
 	opts := &api.SubmitPayloadAttestationMessagesOpts{Messages: []*spec.VersionedPayloadAttestationMessage{{Version: spec.DataVersionGloas}}}
 	require.NoError(t, service.SubmitPayloadAttestationMessages(ctx, opts))
-	require.Equal(t, int32(1), atomic.LoadInt32(&recorderOne.calls))
-	require.Equal(t, int32(1), atomic.LoadInt32(&recorderTwo.calls))
+	require.GreaterOrEqual(t, atomic.LoadInt32(&recorderOne.calls)+atomic.LoadInt32(&recorderTwo.calls), int32(1))
 }
 
 func TestSubmitPayloadAttestationMessagesReturnsOnFirstSuccess(t *testing.T) {

--- a/services/submitter/multinode/submitpayloadattestationmessages_test.go
+++ b/services/submitter/multinode/submitpayloadattestationmessages_test.go
@@ -1,0 +1,132 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	mocketh2client "github.com/attestantio/go-eth2-client/mock"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/vouch/mock"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/attestantio/vouch/services/submitter/multinode"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitPayloadAttestationMessagesFansOutToNodes(t *testing.T) {
+	ctx := context.Background()
+	client, err := mocketh2client.New(ctx)
+	require.NoError(t, err)
+	recorderOne := &countingPayloadAttestationSubmitter{}
+	recorderTwo := &countingPayloadAttestationSubmitter{}
+
+	service, err := multinode.New(ctx,
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithClientMonitor(nullmetrics.New()),
+		multinode.WithTimeout(time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithProposalSubmitters(map[string]eth2client.ProposalSubmitter{"one": mock.NewProposalSubmitter()}),
+		multinode.WithExecutionPayloadEnvelopeSubmitters(map[string]eth2client.ExecutionPayloadEnvelopeSubmitter{"one": client}),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{"one": mock.NewAttestationsSubmitter()}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{"one": mock.NewAggregateAttestationsSubmitter()}),
+		multinode.WithProposalPreparationsSubmitters(map[string]eth2client.ProposalPreparationsSubmitter{"one": mock.NewProposalPreparationsSubmitter()}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{"one": mock.NewBeaconCommitteeSubscriptionsSubmitter()}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{"one": mock.NewSyncCommitteeMessagesSubmitter()}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{"one": mock.NewSyncCommitteeSubscriptionsSubmitter()}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{"one": mock.NewSyncCommitteeContributionsSubmitter()}),
+		multinode.WithPayloadAttestationMessagesSubmitters(map[string]submitter.PayloadAttestationMessagesSubmitter{"one": recorderOne, "two": recorderTwo}),
+	)
+	require.NoError(t, err)
+
+	opts := &api.SubmitPayloadAttestationMessagesOpts{Messages: []*spec.VersionedPayloadAttestationMessage{{Version: spec.DataVersionGloas}}}
+	require.NoError(t, service.SubmitPayloadAttestationMessages(ctx, opts))
+	require.Equal(t, int32(1), atomic.LoadInt32(&recorderOne.calls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&recorderTwo.calls))
+}
+
+func TestSubmitPayloadAttestationMessagesReturnsOnFirstSuccess(t *testing.T) {
+	ctx := context.Background()
+	client, err := mocketh2client.New(ctx)
+	require.NoError(t, err)
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+
+	service, err := multinode.New(ctx,
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithClientMonitor(nullmetrics.New()),
+		multinode.WithTimeout(2*time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithProposalSubmitters(map[string]eth2client.ProposalSubmitter{"one": mock.NewProposalSubmitter()}),
+		multinode.WithExecutionPayloadEnvelopeSubmitters(map[string]eth2client.ExecutionPayloadEnvelopeSubmitter{"one": client}),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{"one": mock.NewAttestationsSubmitter()}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{"one": mock.NewAggregateAttestationsSubmitter()}),
+		multinode.WithProposalPreparationsSubmitters(map[string]eth2client.ProposalPreparationsSubmitter{"one": mock.NewProposalPreparationsSubmitter()}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{"one": mock.NewBeaconCommitteeSubscriptionsSubmitter()}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{"one": mock.NewSyncCommitteeMessagesSubmitter()}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{"one": mock.NewSyncCommitteeSubscriptionsSubmitter()}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{"one": mock.NewSyncCommitteeContributionsSubmitter()}),
+		multinode.WithPayloadAttestationMessagesSubmitters(map[string]submitter.PayloadAttestationMessagesSubmitter{
+			"blocking": &blockingPayloadAttestationSubmitter{started: started, canceled: canceled},
+			"success":  &waitingPayloadAttestationSubmitter{started: started},
+		}),
+	)
+	require.NoError(t, err)
+
+	opts := &api.SubmitPayloadAttestationMessagesOpts{Messages: []*spec.VersionedPayloadAttestationMessage{{Version: spec.DataVersionGloas}}}
+	startedAt := time.Now()
+	require.NoError(t, service.SubmitPayloadAttestationMessages(ctx, opts))
+	require.Less(t, time.Since(startedAt), time.Second)
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("blocking submitter was not canceled")
+	}
+}
+
+type blockingPayloadAttestationSubmitter struct {
+	started  chan<- struct{}
+	canceled chan<- struct{}
+}
+
+func (s *blockingPayloadAttestationSubmitter) SubmitPayloadAttestationMessages(ctx context.Context, _ *api.SubmitPayloadAttestationMessagesOpts) error {
+	close(s.started)
+	<-ctx.Done()
+	close(s.canceled)
+	return ctx.Err()
+}
+
+type waitingPayloadAttestationSubmitter struct {
+	started <-chan struct{}
+}
+
+func (s *waitingPayloadAttestationSubmitter) SubmitPayloadAttestationMessages(_ context.Context, _ *api.SubmitPayloadAttestationMessagesOpts) error {
+	<-s.started
+	return nil
+}
+
+type countingPayloadAttestationSubmitter struct {
+	calls int32
+}
+
+func (s *countingPayloadAttestationSubmitter) SubmitPayloadAttestationMessages(_ context.Context, _ *api.SubmitPayloadAttestationMessagesOpts) error {
+	atomic.AddInt32(&s.calls, 1)
+	return nil
+}

--- a/services/submitter/multinode/submitpayloadattestationmessages_test.go
+++ b/services/submitter/multinode/submitpayloadattestationmessages_test.go
@@ -65,6 +65,51 @@ func TestSubmitPayloadAttestationMessagesFansOutToNodes(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestSubmitPayloadAttestationMessagesContinuesAfterCallerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	canceled := make(chan struct{})
+	completed := make(chan struct{})
+
+	service, err := multinode.New(ctx,
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithClientMonitor(nullmetrics.New()),
+		multinode.WithTimeout(time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithProposalSubmitters(map[string]eth2client.ProposalSubmitter{"one": mock.NewProposalSubmitter()}),
+		multinode.WithExecutionPayloadEnvelopeSubmitters(map[string]eth2client.ExecutionPayloadEnvelopeSubmitter{"one": &capturingExecutionPayloadEnvelopeSubmitter{}}),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{"one": mock.NewAttestationsSubmitter()}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{"one": mock.NewAggregateAttestationsSubmitter()}),
+		multinode.WithProposalPreparationsSubmitters(map[string]eth2client.ProposalPreparationsSubmitter{"one": mock.NewProposalPreparationsSubmitter()}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{"one": mock.NewBeaconCommitteeSubscriptionsSubmitter()}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{"one": mock.NewSyncCommitteeMessagesSubmitter()}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{"one": mock.NewSyncCommitteeSubscriptionsSubmitter()}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{"one": mock.NewSyncCommitteeContributionsSubmitter()}),
+		multinode.WithPayloadAttestationMessagesSubmitters(map[string]submitter.PayloadAttestationMessagesSubmitter{
+			"slow": &cancelAwarePayloadAttestationSubmitter{started: started, release: release, canceled: canceled, completed: completed},
+			"fast": &waitingPayloadAttestationSubmitter{started: started},
+		}),
+	)
+	require.NoError(t, err)
+
+	opts := &api.SubmitPayloadAttestationMessagesOpts{Messages: []*spec.VersionedPayloadAttestationMessage{{Version: spec.DataVersionGloas}}}
+	require.NoError(t, service.SubmitPayloadAttestationMessages(ctx, opts))
+	cancel()
+	select {
+	case <-canceled:
+		t.Fatal("in-flight submission was canceled when the caller returned")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("in-flight submission did not complete")
+	}
+}
+
 func TestSubmitPayloadAttestationMessagesReturnsOnFirstSuccess(t *testing.T) {
 	ctx := context.Background()
 	client, err := mocketh2client.New(ctx)
@@ -103,6 +148,25 @@ func TestSubmitPayloadAttestationMessagesReturnsOnFirstSuccess(t *testing.T) {
 	case <-canceled:
 		t.Fatal("in-flight submission was aborted by another node's success")
 	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+type cancelAwarePayloadAttestationSubmitter struct {
+	started   chan<- struct{}
+	release   <-chan struct{}
+	canceled  chan<- struct{}
+	completed chan<- struct{}
+}
+
+func (s *cancelAwarePayloadAttestationSubmitter) SubmitPayloadAttestationMessages(ctx context.Context, _ *api.SubmitPayloadAttestationMessagesOpts) error {
+	close(s.started)
+	select {
+	case <-ctx.Done():
+		close(s.canceled)
+		return ctx.Err()
+	case <-s.release:
+		close(s.completed)
+		return nil
 	}
 }
 

--- a/services/submitter/multinode/submitpayloadattestationmessages_test.go
+++ b/services/submitter/multinode/submitpayloadattestationmessages_test.go
@@ -58,7 +58,11 @@ func TestSubmitPayloadAttestationMessagesFansOutToNodes(t *testing.T) {
 
 	opts := &api.SubmitPayloadAttestationMessagesOpts{Messages: []*spec.VersionedPayloadAttestationMessage{{Version: spec.DataVersionGloas}}}
 	require.NoError(t, service.SubmitPayloadAttestationMessages(ctx, opts))
-	require.GreaterOrEqual(t, atomic.LoadInt32(&recorderOne.calls)+atomic.LoadInt32(&recorderTwo.calls), int32(1))
+	// The call returns as soon as the first node succeeds, but every node must still be
+	// submitted to; one node's success must not abort the others.
+	require.Eventually(t, func() bool {
+		return recorderOne.calls.Load() == 1 && recorderTwo.calls.Load() == 1
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestSubmitPayloadAttestationMessagesReturnsOnFirstSuccess(t *testing.T) {
@@ -93,10 +97,12 @@ func TestSubmitPayloadAttestationMessagesReturnsOnFirstSuccess(t *testing.T) {
 	startedAt := time.Now()
 	require.NoError(t, service.SubmitPayloadAttestationMessages(ctx, opts))
 	require.Less(t, time.Since(startedAt), time.Second)
+	// The fast node's success must not abort the slow node's in-flight submission; it runs on
+	// until the strategy's own timeout.
 	select {
 	case <-canceled:
-	case <-time.After(time.Second):
-		t.Fatal("blocking submitter was not canceled")
+		t.Fatal("in-flight submission was aborted by another node's success")
+	case <-time.After(250 * time.Millisecond):
 	}
 }
 
@@ -122,10 +128,10 @@ func (s *waitingPayloadAttestationSubmitter) SubmitPayloadAttestationMessages(_ 
 }
 
 type countingPayloadAttestationSubmitter struct {
-	calls int32
+	calls atomic.Int32
 }
 
 func (s *countingPayloadAttestationSubmitter) SubmitPayloadAttestationMessages(_ context.Context, _ *api.SubmitPayloadAttestationMessagesOpts) error {
-	atomic.AddInt32(&s.calls, 1)
+	s.calls.Add(1)
 	return nil
 }

--- a/services/submitter/null/submitpayloadattestationmessages.go
+++ b/services/submitter/null/submitpayloadattestationmessages.go
@@ -1,0 +1,29 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package null
+
+import (
+	"context"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/pkg/errors"
+)
+
+// SubmitPayloadAttestationMessages accepts payload attestation messages without submitting them.
+func (*Service) SubmitPayloadAttestationMessages(_ context.Context, opts *api.SubmitPayloadAttestationMessagesOpts) error {
+	if opts == nil || len(opts.Messages) == 0 {
+		return errors.New("no payload attestation messages supplied")
+	}
+	return nil
+}

--- a/services/submitter/null/submitpayloadattestationmessages_test.go
+++ b/services/submitter/null/submitpayloadattestationmessages_test.go
@@ -1,0 +1,40 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package null_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/vouch/services/submitter/null"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitPayloadAttestationMessagesAcceptsMessages(t *testing.T) {
+	service, err := null.New(context.Background())
+	require.NoError(t, err)
+
+	err = service.SubmitPayloadAttestationMessages(context.Background(), &api.SubmitPayloadAttestationMessagesOpts{
+		Messages: []*spec.VersionedPayloadAttestationMessage{{
+			Version: spec.DataVersionGloas,
+			Gloas: &gloas.PayloadAttestationMessage{
+				Data: &gloas.PayloadAttestationData{Slot: 1},
+			},
+		}},
+	})
+	require.NoError(t, err)
+}

--- a/services/submitter/service.go
+++ b/services/submitter/service.go
@@ -24,6 +24,11 @@ import (
 // Service is the submitter service.
 type Service interface{}
 
+// PayloadAttestationMessagesSubmitter provides methods to submit payload attestation messages.
+type PayloadAttestationMessagesSubmitter interface {
+	SubmitPayloadAttestationMessages(ctx context.Context, opts *api.SubmitPayloadAttestationMessagesOpts) error
+}
+
 // AttestationsSubmitter is the interface for a submitter of attestations.
 type AttestationsSubmitter interface {
 	// SubmitAttestations submits multiple attestations.

--- a/testing/logger/capture.go
+++ b/testing/logger/capture.go
@@ -116,7 +116,13 @@ func fieldsMatch(entryValue any, value any) bool {
 	}
 }
 
-// Entries returns all captures log entries.
+// Entries returns a snapshot of all captured log entries.
 func (c *LogCapture) Entries() []map[string]any {
-	return c.entries
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entries := make([]map[string]any, len(c.entries))
+	copy(entries, c.entries)
+
+	return entries
 }

--- a/testing/logger/capture_test.go
+++ b/testing/logger/capture_test.go
@@ -14,6 +14,8 @@
 package logger
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -55,4 +57,27 @@ func TestHasLog(t *testing.T) {
 			require.Equal(t, test.match, capture.HasLog(test.fields))
 		})
 	}
+}
+
+func TestEntriesDuringConcurrentWrite(t *testing.T) {
+	capture := &LogCapture{
+		entries: make([]map[string]any, 0),
+	}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := range 128 {
+			_, err := capture.Write([]byte(fmt.Sprintf(`{"message":"entry","index":%d}`, i)))
+			require.NoError(t, err)
+		}
+	})
+
+	for range 128 {
+		for _, entry := range capture.Entries() {
+			require.Equal(t, "entry", entry["message"])
+		}
+	}
+	wg.Wait()
+
+	require.Len(t, capture.Entries(), 128)
 }

--- a/testing/logger/capture_test.go
+++ b/testing/logger/capture_test.go
@@ -59,6 +59,10 @@ func TestHasLog(t *testing.T) {
 	}
 }
 
+// TestEntriesDuringConcurrentWrite reads Entries while another goroutine is still capturing
+// output, which is how the multinode submitters log once their submission has already returned.
+// The final length assertion also proves every write was captured, so the writes need no
+// assertion of their own on the writing goroutine.
 func TestEntriesDuringConcurrentWrite(t *testing.T) {
 	capture := &LogCapture{
 		entries: make([]map[string]any, 0),
@@ -67,8 +71,7 @@ func TestEntriesDuringConcurrentWrite(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Go(func() {
 		for i := range 128 {
-			_, err := capture.Write([]byte(fmt.Sprintf(`{"message":"entry","index":%d}`, i)))
-			require.NoError(t, err)
+			_, _ = fmt.Fprintf(capture, `{"message":"entry","index":%d}`, i)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- schedule payload timeliness committee duties through the Gloas payload timing window
- batch generic signatures for validators sharing a slot and submit versioned payload attestations
- add immediate and multinode submission support, reorg refreshes, and payload-slot validation

## Stacked on #428

This branches off `gloas-attestation-deadlines` and targets it, not `gloas`. #428 supplies the
`gloasForkEpoch` field, the spec-derived deadline machinery, and the `dueBPS` helper that the payload
deadlines here are built on, so it should be reviewed and merged first. The diff shown against that
base is this change alone.

## The duty flow

A payload timeliness committee duty is a vote on whether the slot's execution payload was revealed on
time. `PTCDuties` is fetched for the epoch, duties are grouped by slot so that every validator
attesting in the same slot shares one job, and each slot's job runs inside the window the fork
defines:

```go
jobTime := s.chainTimeService.StartOfSlot(duty.Slot()).Add(s.payloadAttestationDelay).Add(payloadAttestationGrace)
deadline := s.chainTimeService.StartOfSlot(duty.Slot() + 1)
```

The offset is derived from the chain specification by `obtainPayloadAttestationTiming`, in the same
basis points of `SLOT_DURATION_MS` that #428 established. On a 12-second slot it is the
specification's `PAYLOAD_ATTESTATION_DUE_BPS: 7500`, so the vote is cast just after 9s and its
context runs to the end of the slot. The duty is new in Gloas, so it always follows the Gloas slot
duration and has no pre-fork form. Why the vote is cast there, rather than when the payload becomes
due, is recorded in the decision section below.

Signing goes through `SignPayloadAttestationData`, which takes the accounts as a slice and returns
one signature per account, so a slot with many attesting validators costs one signing round trip
rather than one per validator.

Submission is versioned and covers all three submitters — `immediate`, `multinode` and `null` — so
the payload vote follows whatever submission strategy is already configured rather than introducing
a separate path.

## Decision: when the payload timeliness vote is cast

Recorded here because the choice is not evident from the constants, and an earlier revision of this
branch made the opposite one.

### Context

Gloas defines two payload deadlines, and they answer different questions.

| Constant | Mainnet value | Role |
| --- | --- | --- |
| `PAYLOAD_DUE_BPS` | 5000 bps — 6s | the *subject* of the vote |
| `PAYLOAD_ATTESTATION_DUE_BPS` | 7500 bps — 9s | the *broadcast deadline* |

`specs/gloas/validator.md` is explicit that the second is a window bound and not a target instant: a
validator "should create and broadcast the `payload_attestation_message` ... within the first
`get_payload_attestation_due_ms()` milliseconds of the slot". Any moment between seeing the block and
that bound is conformant.

The first is not a scheduling instruction at all — it is baked into the vote's content.
`data.payload_present` is `True` only if a `SignedExecutionPayloadEnvelope` "was seen before
`get_payload_due_ms()` milliseconds into the slot". That is a question about the past, its answer is
frozen once the payload due time passes, and the observation timestamp that answers it belongs to the
beacon node rather than to us.

Two further fields have no time cutoff whatsoever: `data.blob_data_available` is
`is_data_available(root)` evaluated when the data is produced, and the duty is skipped altogether if
no beacon block for the slot has been seen. Both only become more accurate later in the slot.

### Why the payload due time was the wrong place

The earlier revision scheduled the job at `PAYLOAD_DUE_BPS` and used `PAYLOAD_ATTESTATION_DUE_BPS`
only as the job's context deadline, reasoning that the answer is frozen at the payload due time so
there is nothing to gain by waiting. That holds for `payload_present` in isolation and fails for the
request as a whole.

- **A beacon node need not answer yet.** Prysm's producer returns `Unavailable` — a 503 — when asked
  before the attestation deadline unless the answer is already final, on the stated grounds that
  "before the deadline only the final result is safe to return ... otherwise both flags may still
  flip". Asking at the payload due time therefore returns nothing in precisely the marginal cases the
  vote exists to judge, and our fetch is a one-shot: the duty ends with an error log and no vote.
- **Data availability is decided later.** A payload revealed near the due time will often still have
  columns propagating, so a vote cast then reports `blob_data_available: false` for a payload that was
  in fact available.
- **A late block is missed entirely.** A block first seen between the two deadlines yields no vote at
  all, though the specification permits one and the gossip rules accept it.

Both other implementations target the later deadline. Lighthouse's validator sleeps to
`duration_to_next_slot + payload_attestation_due` before fetching; Prysm's waits on the
payload-available event or that same deadline, whichever comes first. We were the outlier, and the
only client fetching at a moment its beacon node may decline to serve.

### Decision

Schedule the job at `PAYLOAD_ATTESTATION_DUE_BPS` plus a small fixed grace, and run the job's context
to the end of the slot.

- **The grace is 250ms.** A beacon node compares its own clock against the deadline before deciding
  the data is final, so firing exactly on the deadline can still be refused by a node whose clock
  trails ours. The grace covers that skew and leaves the rest of the slot for the vote to propagate.
  Landing just past the nominal deadline is also what both other clients do in practice, since each
  fetches at the deadline and only then signs and publishes.
- **The context runs to the end of the slot.** Bounding it at the deadline the job now fires at would
  cancel the signing and submission the vote depends on, and the gossip rules accept a payload
  attestation for the whole of its slot.
- **`PAYLOAD_DUE_BPS` is no longer read.** Whether the payload was timely is the beacon node's
  determination, so `payloadDueDelay` and `WithPayloadDueDelay` are removed rather than left as
  unused configuration.

### Consequences, and what stays open

A fixed deadline is a backstop rather than the best available behaviour: the vote could be cast as
soon as the beacon node reports the payload available, as Prysm's validator does. That needs the
payload-available SSE topic in `go-eth2-client`, which does not expose it yet, so a `TODO` at the
scheduling site records it.

This decision depends on `payload_present` being answered from a recorded observation timestamp
rather than from the node's view at request time. That was verified in both implementations —
Lighthouse compares `entry.timestamps.observed` against `get_payload_due()`, and Prysm reads a
`PayloadEarly(root)` flag — but it is pinned by neither `beacon-APIs`, which documents neither the
field's meaning nor when it is evaluated, nor by a released version: both were read on unstable
branches that may change before mainnet.

## Validation, before signing

`Attest` refuses to sign anything it cannot fully account for, rather than signing a best guess:

- the response must be Gloas-versioned and non-nil
- the returned data's slot must equal the duty's slot
- the number of signatures returned must equal the number of accounts submitted

A validator with no account for the duty is skipped rather than failing the whole slot's job, and a
duty with no usable accounts submits nothing at all.

## Also in this change

- Payload attestation duties are refreshed on a dependent root change, alongside the attester duty
  refreshes that already run there: the previous dependent root refreshes this epoch, the current
  dependent root refreshes the next. Each refresh cancels the epoch's existing per-slot jobs before
  rescheduling them, and leaves the current slot alone when its job has already run.
- `TestObtainPayloadAttestationTiming` (previously `TestObtainPayloadTimings`) asserted that a served
  `PAYLOAD_DUE_BPS_GLOAS` took precedence over `PAYLOAD_DUE_BPS`. The specification defines no
  `_GLOAS`-suffixed form of any payload key, because these deadlines are new in Gloas, so that case
  tested a key no chain serves. It now asserts that the unsuffixed key holds the deadline, and takes
  its expected values from the configuration `beacon.glamsterdam-devnet-8.ethpandaops.io` serves.
- `schedulePayloadAttestations` is split into `canSchedulePayloadAttestations`,
  `payloadAttestationsAlreadyScheduled` and `payloadAttestationDuties` helpers, to stay within the
  complexity limit. This is a pure extraction with no behaviour change.

## Validation

### Local Devnet runtime validation — 2026-08-19

  - Built `vouch:gloas` from PR head `a18564ee03957a1a63093995b4b3a87cc4e7c719` and ran it in a fresh-genesis local Devnet-8-derived enclave.
  - During a 31-minute continuous observation interval, consensus stayed healthy and finalized; Vouch remained ready. It has now processed 35 epochs.
  - Vouch **successfully fetched PTC duties for epochs 1–36**. At the latest metric scrape, it had **successfully obtained payload-attestation data 993 times** and **made 2,217 successful per-provider payload-attestation POSTs**.
  - **PTC scheduling is active**: 1,083 payload-attestation jobs have been scheduled and 1,022 have started on their timer. Of the difference, 28 were xplicitly cancelled during dependent-root refreshes; the remaining 33 were pending when the metrics were scraped. These cumulative counters are therefore not an indication of missed duties.
  - The run exposes a Prysm-side endpoint issue: each of the three beacon nodes returned 29 failed payload-attestation-data requests (`503 no canonical shuffling block for slot`). At affected slots, all nodes still agreed on and served the canonical block/root, isolating the failure to that endpoint rather than Vouch’s duty scheduling or signing.
  - Some individual provider POSTs were cancelled, but Vouch’s multinode submitter completes when another configured beacon node accepts the message; the successful per-provider POST metrics above confirm that this path is operating.
  - Re-pulled the active Prysm beacon, Prysm validator, and Geth `glamsterdam-devnet-8` tags. All were already current; no client image digest changed.
