### PR TITLE
Honour the configured timeout when submitting validator registrations.

### DIFF
--- a/services/blockrelay/standard/submitvalidatorregistrations.go
+++ b/services/blockrelay/standard/submitvalidatorregistrations.go
@@ -235,21 +235,26 @@ func (s *Service) submitRelayRegistrations(ctx context.Context,
 				s.log.Error().Str("builder", builder).Msg("Builder client does not accept validator registrations")
 				return
 			}
-			if err := submitter.SubmitValidatorRegistrations(ctx, &builderapi.SubmitValidatorRegistrationsOpts{
-				// Validator registrations can take a long time, as they are processed sequentially by some relays.  As such,
-				// unilaterally set the timeout here.  This code is within a waitgroup, so we're okay to wait for a little longer
-				// than we would with most requests.
-				Common: builderapi.CommonOpts{
-					Timeout: time.Second * time.Duration(len(providerRegistrations)),
-				},
-				Registrations: providerRegistrations,
-			}); err != nil {
+			if err := submitter.SubmitValidatorRegistrations(ctx, registrationOpts(providerRegistrations)); err != nil {
 				s.log.Error().Err(err).Str("builder", builder).Msg("Failed to submit validator registrations")
 				return
 			}
 		}(ctx, builder, providerRegistrations, s.monitor)
 	}
 	wg.Wait()
+}
+
+// registrationOpts returns the options with which to submit the given registrations to a relay.
+//
+// No per-call timeout is set, so the timeout configured for the client applies
+// (builderclient.submitvalidatorregistrations, optionally overridden per relay).  A per-call
+// timeout can only shorten the deadline and never extend it, because the client's own timeout is
+// a hard ceiling on the request, so setting one here would override the configured value with a
+// value that can only ever be lower.
+func registrationOpts(registrations []*builderapi.VersionedSignedValidatorRegistration) *builderapi.SubmitValidatorRegistrationsOpts {
+	return &builderapi.SubmitValidatorRegistrationsOpts{
+		Registrations: registrations,
+	}
 }
 
 func (s *Service) submitConsensusRegistrations(ctx context.Context,

--- a/services/blockrelay/standard/submitvalidatorregistrations_internal_test.go
+++ b/services/blockrelay/standard/submitvalidatorregistrations_internal_test.go
@@ -1,0 +1,54 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"testing"
+
+	builderapi "github.com/attestantio/go-builder-client/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistrationOpts(t *testing.T) {
+	registrations := []*builderapi.VersionedSignedValidatorRegistration{{}, {}}
+
+	tests := []struct {
+		name          string
+		registrations []*builderapi.VersionedSignedValidatorRegistration
+	}{
+		{
+			name:          "Empty",
+			registrations: []*builderapi.VersionedSignedValidatorRegistration{},
+		},
+		{
+			name:          "Single",
+			registrations: registrations[:1],
+		},
+		{
+			name:          "Multiple",
+			registrations: registrations,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := registrationOpts(test.registrations)
+
+			require.Equal(t, test.registrations, opts.Registrations)
+			// The timeout must be left unset so that the timeout configured for the client
+			// applies.  A per-call timeout can only shorten the deadline, never extend it.
+			require.Zero(t, opts.Common.Timeout)
+		})
+	}
+}


### PR DESCRIPTION
Validator registrations are submitted with a per-call timeout of one second per registration:

```go
Common: builderapi.CommonOpts{
    Timeout: time.Second * time.Duration(len(providerRegistrations)),
},
```

The comment above it says the intent is to wait *longer* than usual, because some relays process
registrations sequentially. The per-call timeout cannot do that. `go-builder-client` builds each
relay's `http.Client` with `Timeout: parameters.timeout` — the value resolved from
`builderclient.submitvalidatorregistrations`, optionally overridden per relay — and
`http.Client.Timeout` is an absolute ceiling on the whole request, independent of any context
deadline. The per-call value is applied on top of that as a context deadline, so the effective
budget is `min(configured, 1s × count)`. The formula can only ever shorten the deadline.

Two consequences:

* `builderclient.submitvalidatorregistrations.timeout` is honoured for every other builder call
  and ignored for this one.
* Any batch smaller than the configured timeout in seconds is capped below it. A single
  registration gets one second.

Measured against a `httptest` server that sleeps 4s, to confirm the direction of the clamp:

| client timeout (configured) | per-call `Common.Timeout` | outcome |
|---|---|---|
| 2s | 10s | aborted at 2.00s — the per-call value cannot raise the ceiling |
| 10s | 1s | aborted at 1.00s — today's single-registration behaviour |
| 10s | 0 (unset) | succeeded at 4.00s — the configured value applies |

The case where this actually bites is the shared MEV-boost passthrough: registrations arriving at
`/eth/v1/builder/validators` are forwarded a handful at a time, so each submission gets 1–4
seconds. On a mainnet node forwarding for an SSV cluster I see a steady ~1% of submissions fail
with `context deadline exceeded` across five relays, concentrated on the slower ones — with the
configured timeout at 10s, which is never reached. The failures are invisible to the caller
(`ValidatorRegistrations` returns `nil, nil` regardless), so the only symptom is the log line.

This change leaves the per-call timeout unset so the configured timeout applies. Batches large
enough for the formula to exceed the configured value are unaffected — the client's own timeout
already clamped them — so the crossover is `count == configured timeout in seconds`, and the
periodic full-registration sweep keeps exactly the budget it has today.

The options construction is extracted into `registrationOpts` so the absence of a per-call
timeout can be asserted in a test; a future reinstatement of the formula then fails CI rather than
silently restoring a one-second deadline.
