### PR TITLE
Prepare proposer preferences for publication

### DIFF
--- a/clients_test.go
+++ b/clients_test.go
@@ -246,7 +246,7 @@ func TestSimpleProposalProviderRejectsZeroFeeRecipient(t *testing.T) {
 		knownClientsMu.Unlock()
 	})
 
-	provider, err := selectProposalProvider(ctx, null.New(), nil, nil, nil)
+	provider, err := selectProposalProvider(ctx, null.New(), nil, nil, nil, nil)
 	require.NoError(t, err)
 	includePayload := true
 	response, err := provider.EPBSProposal(ctx, &api.EPBSProposalOpts{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/attestantio/go-block-relay v0.6.0
 	github.com/attestantio/go-builder-client v0.8.0
 	github.com/attestantio/go-certmanager v0.2.0
-	github.com/attestantio/go-eth2-client v0.29.1-0.20260817140745-1263dc7060ea
+	github.com/attestantio/go-eth2-client v0.29.1-0.20260821085032-826788087ec1
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/google/uuid v1.6.0
 	github.com/holiman/uint256 v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/attestantio/go-certmanager v0.2.0 h1:Hzj12L5fofK7b281uohMBN0HQuSx+8Rf
 github.com/attestantio/go-certmanager v0.2.0/go.mod h1:Dn+C/okccD+2RugizT1ryrjX65cBMZl55fNYtmaVYAg=
 github.com/attestantio/go-eth2-client v0.29.1-0.20260817140745-1263dc7060ea h1:izccFMj70xj1wIVONNLjC5W9zy8i9cV0UEt0puL0vIg=
 github.com/attestantio/go-eth2-client v0.29.1-0.20260817140745-1263dc7060ea/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
+github.com/attestantio/go-eth2-client v0.29.1-0.20260821085032-826788087ec1 h1:kGUe7dY5orDJIcAygYwuam/H0xRt8yb4GQPxhRiJO5o=
+github.com/attestantio/go-eth2-client v0.29.1-0.20260821085032-826788087ec1/go.mod h1:yhVnKAzIsFhtawbq6k/rA/Dy4vsPpu2Z2cGdQVrIjd0=
 github.com/aws/aws-sdk-go v1.44.81/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=

--- a/main.go
+++ b/main.go
@@ -67,6 +67,8 @@ import (
 	standardpayloadattester "github.com/attestantio/vouch/services/payloadattester/standard"
 	"github.com/attestantio/vouch/services/proposalpreparer"
 	standardproposalpreparer "github.com/attestantio/vouch/services/proposalpreparer/standard"
+	"github.com/attestantio/vouch/services/proposerpreferences"
+	standardproposerpreferences "github.com/attestantio/vouch/services/proposerpreferences/standard"
 	"github.com/attestantio/vouch/services/scheduler"
 	advancedscheduler "github.com/attestantio/vouch/services/scheduler/advanced"
 	"github.com/attestantio/vouch/services/signer"
@@ -385,6 +387,11 @@ func startServices(ctx context.Context,
 		return nil, nil, errors.Wrap(err, "failed to start payload attester")
 	}
 
+	proposerPreferences, err := startProposerPreferences(ctx, monitor, signerSvc, submitter)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to start proposer preferences")
+	}
+
 	blockRelay, err := startBlockRelay(ctx, majordomo, monitor, eth2Client, schedulerSvc, chainTime, accountManager, signerSvc, cacheSvc)
 	if err != nil {
 		return nil, nil, err
@@ -446,6 +453,8 @@ func startServices(ctx context.Context,
 		beaconBlockHeaderProvider,
 		multiInstance,
 		payloadAttester,
+		proposerPreferences,
+		blockRelay,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -474,6 +483,8 @@ func initController(ctx context.Context,
 	beaconBlockHeaderProvider eth2client.BeaconBlockHeadersProvider,
 	multiInstance multiinstance.Service,
 	payloadAttester payloadattester.Service,
+	proposerPreferences proposerpreferences.Service,
+	blockRelay blockrelay.Service,
 ) (
 	*standardcontroller.Service,
 	error,
@@ -524,6 +535,16 @@ func initController(ctx context.Context,
 		controllerParams = append(controllerParams,
 			standardcontroller.WithPTCDutiesProvider(ptcDutiesProvider),
 			standardcontroller.WithPayloadAttester(payloadAttester),
+		)
+	}
+	if proposerPreferences != nil {
+		executionConfigProvider, ok := blockRelay.(blockrelay.ExecutionConfigProvider)
+		if !ok {
+			return nil, errors.New("block relay does not provide execution configuration")
+		}
+		controllerParams = append(controllerParams,
+			standardcontroller.WithProposerPreferences(proposerPreferences),
+			standardcontroller.WithExecutionConfigProvider(executionConfigProvider),
 		)
 	}
 	controller, err := standardcontroller.New(ctx, controllerParams...)
@@ -1676,6 +1697,9 @@ func selectSubmitterStrategy(ctx context.Context, monitor metrics.Service, eth2C
 		if payloadAttestationMessagesSubmitter, ok := eth2Client.(eth2client.PayloadAttestationMessagesSubmitter); ok {
 			params = append(params, immediatesubmitter.WithPayloadAttestationMessagesSubmitter(payloadAttestationMessagesSubmitter))
 		}
+		if proposerPreferencesSubmitter, ok := eth2Client.(eth2client.ProposerPreferencesSubmitter); ok {
+			params = append(params, immediatesubmitter.WithProposerPreferencesSubmitter(proposerPreferencesSubmitter))
+		}
 		submitter, err = immediatesubmitter.New(ctx, params...)
 	}
 	if err != nil {
@@ -1721,6 +1745,34 @@ func startPayloadAttester(ctx context.Context,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start standard payload attester service")
+	}
+
+	return service, nil
+}
+
+// startProposerPreferences starts proposer preferences publishing when the signer and submitter
+// both support it.  The controller publishes only for proposal epochs at or after GLOAS_FORK_EPOCH.
+func startProposerPreferences(ctx context.Context,
+	monitor metrics.Service,
+	signerSvc signer.Service,
+	submitterStrategy submitter.Service,
+) (proposerpreferences.Service, error) {
+	proposerPreferencesSigner, ok := signerSvc.(signer.ProposerPreferencesSigner)
+	if !ok {
+		return nil, nil
+	}
+	proposerPreferencesSubmitter, ok := submitterStrategy.(submitter.ProposerPreferencesSubmitter)
+	if !ok {
+		return nil, nil
+	}
+
+	service, err := standardproposerpreferences.New(ctx,
+		standardproposerpreferences.WithMonitor(monitor),
+		standardproposerpreferences.WithSigner(proposerPreferencesSigner),
+		standardproposerpreferences.WithSubmitter(proposerPreferencesSubmitter),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start standard proposer preferences service")
 	}
 
 	return service, nil
@@ -1874,6 +1926,16 @@ func startMultinodeSubmitter(ctx context.Context,
 		}
 	}
 
+	var proposerPreferencesSubmitters map[string]eth2client.ProposerPreferencesSubmitter
+	if _, ok := eth2Client.(eth2client.ProposerPreferencesSubmitter); ok {
+		proposerPreferencesSubmitters, err = genericAddressToClientMapper[eth2client.ProposerPreferencesSubmitter](ctx, monitor,
+			"submitter.proposal.multinode",
+			"proposer preferences submitter strategy")
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	params := []multinodesubmitter.Parameter{
 		multinodesubmitter.WithClientMonitor(monitor.(metrics.ClientMonitor)),
 		multinodesubmitter.WithProcessConcurrency(util.ProcessConcurrency("submitter.multinode")),
@@ -1891,6 +1953,9 @@ func startMultinodeSubmitter(ctx context.Context,
 	}
 	if payloadAttestationMessagesSubmitters != nil {
 		params = append(params, multinodesubmitter.WithPayloadAttestationMessagesSubmitters(payloadAttestationMessagesSubmitters))
+	}
+	if proposerPreferencesSubmitters != nil {
+		params = append(params, multinodesubmitter.WithProposerPreferencesSubmitters(proposerPreferencesSubmitters))
 	}
 	submitterService, err := multinodesubmitter.New(ctx, params...)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1705,9 +1705,13 @@ func selectSubmitterStrategy(ctx context.Context, monitor metrics.Service, eth2C
 		if payloadAttestationMessagesSubmitter, ok := eth2Client.(eth2client.PayloadAttestationMessagesSubmitter); ok {
 			params = append(params, immediatesubmitter.WithPayloadAttestationMessagesSubmitter(payloadAttestationMessagesSubmitter))
 		}
-		if proposerPreferencesSubmitter, ok := eth2Client.(eth2client.ProposerPreferencesSubmitter); ok {
-			params = append(params, immediatesubmitter.WithProposerPreferencesSubmitter(proposerPreferencesSubmitter))
+		proposerPreferencesSubmitters, mapErr := addressToClientMapper[eth2client.ProposerPreferencesSubmitter](ctx, monitor,
+			util.BeaconNodeAddressesForBeaconBlockProposal(),
+			"proposer preferences submitter strategy")
+		if mapErr != nil {
+			return nil, mapErr
 		}
+		params = append(params, immediatesubmitter.WithProposerPreferencesSubmitters(proposerPreferencesSubmitters))
 		submitter, err = immediatesubmitter.New(ctx, params...)
 	}
 	if err != nil {
@@ -1840,8 +1844,12 @@ func selectPayloadAttestationDataProvider(ctx context.Context, monitor metrics.S
 }
 
 func genericAddressToClientMapper[T any](ctx context.Context, monitor metrics.Service, path, description string) (map[string]T, error) {
+	return addressToClientMapper[T](ctx, monitor, util.BeaconNodeAddresses(path), description)
+}
+
+func addressToClientMapper[T any](ctx context.Context, monitor metrics.Service, addresses []string, description string) (map[string]T, error) {
 	addressToClientMap := make(map[string]T)
-	for _, address := range util.BeaconNodeAddresses(path) {
+	for _, address := range addresses {
 		client, err := fetchClient(ctx, monitor, address)
 		if err != nil {
 			return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch client %s for %s", address, description))
@@ -1936,8 +1944,8 @@ func startMultinodeSubmitter(ctx context.Context,
 
 	var proposerPreferencesSubmitters map[string]eth2client.ProposerPreferencesSubmitter
 	if _, ok := eth2Client.(eth2client.ProposerPreferencesSubmitter); ok {
-		proposerPreferencesSubmitters, err = genericAddressToClientMapper[eth2client.ProposerPreferencesSubmitter](ctx, monitor,
-			"submitter.proposal.multinode",
+		proposerPreferencesSubmitters, err = addressToClientMapper[eth2client.ProposerPreferencesSubmitter](ctx, monitor,
+			util.BeaconNodeAddressesForBeaconBlockProposal(),
 			"proposer preferences submitter strategy")
 		if err != nil {
 			return nil, err

--- a/main.go
+++ b/main.go
@@ -407,6 +407,7 @@ func startServices(ctx context.Context,
 		blockRelay,
 		accountManager,
 		submitter,
+		proposerPreferences,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -483,7 +484,7 @@ func initController(ctx context.Context,
 	beaconBlockHeaderProvider eth2client.BeaconBlockHeadersProvider,
 	multiInstance multiinstance.Service,
 	payloadAttester payloadattester.Service,
-	proposerPreferences proposerpreferences.Service,
+	proposerPreferences proposerpreferences.Publisher,
 	blockRelay blockrelay.Service,
 ) (
 	*standardcontroller.Service,
@@ -717,6 +718,7 @@ func startProviders(ctx context.Context,
 	eth2Client eth2client.Service,
 	chainTime chaintime.Service,
 	cache cache.Service,
+	providerReadiness proposerpreferences.ProviderReadiness,
 ) (
 	graffitiprovider.Service,
 	beaconblockproposer.ProposalDataProvider,
@@ -731,7 +733,7 @@ func startProviders(ctx context.Context,
 	}
 
 	log.Trace().Msg("Selecting beacon block proposal provider")
-	beaconBlockProposalProvider, err := selectProposalProvider(ctx, monitor, eth2Client, chainTime, cache)
+	beaconBlockProposalProvider, err := selectProposalProvider(ctx, monitor, eth2Client, chainTime, cache, providerReadiness)
 	if err != nil {
 		return nil, nil, nil, nil, errors.Wrap(err, "failed to select beacon block proposal provider")
 	}
@@ -835,6 +837,7 @@ func startSigningServices(ctx context.Context,
 	blockRelay blockrelay.Service,
 	accountManager accountmanager.Service,
 	submitterStrategy submitter.Service,
+	providerReadiness proposerpreferences.ProviderReadiness,
 ) (
 	beaconblockproposer.Service,
 	attester.Service,
@@ -848,6 +851,7 @@ func startSigningServices(ctx context.Context,
 		eth2Client,
 		chainTime,
 		cacheSvc,
+		providerReadiness,
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -1449,6 +1453,7 @@ func selectProposalProvider(ctx context.Context,
 	eth2Client eth2client.Service,
 	chainTime chaintime.Service,
 	cacheSvc cache.Service,
+	providerReadiness proposerpreferences.ProviderReadiness,
 ) (beaconblockproposer.ProposalDataProvider, error) {
 	var proposalProvider beaconblockproposer.ProposalDataProvider
 	var err error
@@ -1474,6 +1479,7 @@ func selectProposalProvider(ctx context.Context,
 			bestbeaconblockproposalstrategy.WithChainTimeService(chainTime),
 			bestbeaconblockproposalstrategy.WithSpecProvider(eth2Client.(eth2client.SpecProvider)),
 			bestbeaconblockproposalstrategy.WithProposalProviders(proposalProviders),
+			bestbeaconblockproposalstrategy.WithProviderReadiness(providerReadiness),
 			bestbeaconblockproposalstrategy.WithTimeout(util.Timeout("strategies.beaconblockproposal.best")),
 			bestbeaconblockproposalstrategy.WithBlockRootToSlotCache(cacheSvc.(cache.BlockRootToSlotProvider)),
 			bestbeaconblockproposalstrategy.WithExecutionPayloadFactor(viper.GetFloat64("strategies.beaconblockproposal.best.execution-payload-factor")),
@@ -1499,6 +1505,7 @@ func selectProposalProvider(ctx context.Context,
 			firstbeaconblockproposalstrategy.WithClientMonitor(monitor.(metrics.ClientMonitor)),
 			firstbeaconblockproposalstrategy.WithLogLevel(util.LogLevel("strategies.beaconblockproposal.first")),
 			firstbeaconblockproposalstrategy.WithProposalProviders(proposalProviders),
+			firstbeaconblockproposalstrategy.WithProviderReadiness(providerReadiness),
 			firstbeaconblockproposalstrategy.WithTimeout(util.Timeout("strategies.beaconblockproposal.first")),
 		)
 		if err != nil {
@@ -1520,6 +1527,7 @@ func selectProposalProvider(ctx context.Context,
 			firstbeaconblockproposalstrategy.WithProposalProviders(map[string]beaconblockproposer.ProposalDataProvider{
 				"simple": provider,
 			}),
+			firstbeaconblockproposalstrategy.WithProviderReadiness(providerReadiness),
 			firstbeaconblockproposalstrategy.WithTimeout(util.Timeout("strategies.beaconblockproposal.first")),
 		)
 		if err != nil {

--- a/proposerpreferences_test.go
+++ b/proposerpreferences_test.go
@@ -1,0 +1,83 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	nethttp "net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mocketh2client "github.com/attestantio/go-eth2-client/mock"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultinodeSubmitterPublishesProposerPreferencesToProposalProviders(t *testing.T) {
+	ctx := context.Background()
+	var proposalProviderRequests atomic.Int64
+	var proposalSubmitterRequests atomic.Int64
+	newServer := func(requests *atomic.Int64) *httptest.Server {
+		return httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			switch r.URL.Path {
+			case "/eth/v1/node/version":
+				_, _ = w.Write([]byte(`{"data":{"version":"test"}}`))
+			case "/eth/v1/node/syncing":
+				_, _ = w.Write([]byte(`{"data":{"is_syncing":false,"is_optimistic":false,"el_offline":false,"head_slot":"1","sync_distance":"0"}}`))
+			case "/eth/v1/validator/proposer_preferences":
+				require.Equal(t, nethttp.MethodPost, r.Method)
+				requests.Add(1)
+			default:
+				t.Errorf("unexpected request %s", r.URL.Path)
+				w.WriteHeader(nethttp.StatusNotFound)
+			}
+		}))
+	}
+	proposalProvider := newServer(&proposalProviderRequests)
+	defer proposalProvider.Close()
+	proposalSubmitter := newServer(&proposalSubmitterRequests)
+	defer proposalSubmitter.Close()
+
+	viper.Set("timeout", time.Second)
+	viper.Set("eth2client.timeout", time.Second)
+	viper.Set("process-concurrency", int64(1))
+	viper.Set("beacon-node-addresses", []string{proposalSubmitter.URL})
+	viper.Set("submitter.proposal.beacon-node-addresses", []string{proposalSubmitter.URL})
+	viper.Set("strategies.beaconblockproposal.beacon-node-addresses", []string{proposalProvider.URL})
+	t.Cleanup(func() {
+		viper.Reset()
+		knownClientsMu.Lock()
+		delete(knownClients, proposalProvider.URL)
+		delete(knownClients, proposalSubmitter.URL)
+		knownClientsMu.Unlock()
+	})
+
+	client, err := mocketh2client.New(ctx)
+	require.NoError(t, err)
+	service, err := startMultinodeSubmitter(ctx, null.New(), client)
+	require.NoError(t, err)
+	preferencesSubmitter, ok := service.(submitter.ProposerPreferencesSubmitter)
+	require.True(t, ok)
+
+	outcomes := preferencesSubmitter.SubmitProposerPreferences(ctx, []*gloas.SignedProposerPreferences{{}}, nil)
+
+	require.Equal(t, map[string]error{proposalProvider.URL: nil}, outcomes)
+	require.Equal(t, int64(1), proposalProviderRequests.Load())
+	require.Zero(t, proposalSubmitterRequests.Load())
+}

--- a/services/beaconblockproposer/proposerconfig.go
+++ b/services/beaconblockproposer/proposerconfig.go
@@ -23,6 +23,7 @@ import (
 // ProposerConfig contains configuration for a proposer.
 type ProposerConfig struct {
 	FeeRecipient bellatrix.ExecutionAddress
+	GasLimit     uint64
 	Relays       []*RelayConfig
 }
 

--- a/services/blockrelay/standard/proposerconfig.go
+++ b/services/blockrelay/standard/proposerconfig.go
@@ -35,6 +35,7 @@ func (s *Service) ProposerConfig(ctx context.Context,
 		s.log.Warn().Msg("No execution configuration available; using fallback information")
 		return &beaconblockproposer.ProposerConfig{
 			FeeRecipient: s.fallbackFeeRecipient,
+			GasLimit:     s.fallbackGasLimit,
 			Relays:       make([]*beaconblockproposer.RelayConfig, 0),
 		}, nil
 	}

--- a/services/blockrelay/standard/proposerconfig_test.go
+++ b/services/blockrelay/standard/proposerconfig_test.go
@@ -104,6 +104,7 @@ func TestProposerConfig(t *testing.T) {
 		name           string
 		params         []standard.Parameter
 		proposerConfig string
+		gasLimit       uint64
 		err            string
 		logEntries     []map[string]interface{}
 	}{
@@ -126,6 +127,7 @@ func TestProposerConfig(t *testing.T) {
 				standard.WithBuilderBidProvider(mock.BuilderBidProvider{}),
 			},
 			proposerConfig: `{"fee_recipient":"0x0100000000000000000000000000000000000000","relays":[]}`,
+			gasLimit:       10000000,
 		},
 		{
 			name: "File",
@@ -146,6 +148,7 @@ func TestProposerConfig(t *testing.T) {
 				standard.WithBuilderBidProvider(mock.BuilderBidProvider{}),
 			},
 			proposerConfig: `{"fee_recipient":"0x0200000000000000000000000000000000000000","relays":[]}`,
+			gasLimit:       20000000,
 			logEntries: []map[string]interface{}{
 				{
 					"message": "Obtained configuration",
@@ -171,6 +174,7 @@ func TestProposerConfig(t *testing.T) {
 				standard.WithBuilderBidProvider(mock.BuilderBidProvider{}),
 			},
 			proposerConfig: `{"fee_recipient":"0x0100000000000000000000000000000000000000","relays":[]}`,
+			gasLimit:       10000000,
 			logEntries: []map[string]interface{}{
 				{
 					"message": "Failed to obtain execution configuration",
@@ -192,6 +196,7 @@ func TestProposerConfig(t *testing.T) {
 				data, err := json.Marshal(proposerConfig)
 				require.NoError(t, err)
 				require.Equal(t, test.proposerConfig, string(data))
+				require.Equal(t, test.gasLimit, proposerConfig.GasLimit)
 			}
 			for _, logEntry := range test.logEntries {
 				if !capture.HasLog(logEntry) {

--- a/services/blockrelay/v1/builderconfig_test.go
+++ b/services/blockrelay/v1/builderconfig_test.go
@@ -24,9 +24,10 @@ import (
 
 func TestBuilderConfig(t *testing.T) {
 	tests := []struct {
-		name  string
-		input []byte
-		err   string
+		name        string
+		input       []byte
+		err         string
+		errContains string
 	}{
 		{
 			name: "Empty",
@@ -68,9 +69,9 @@ func TestBuilderConfig(t *testing.T) {
 			err:   "invalid JSON: json: cannot unmarshal bool into Go struct field builderConfigJSON.relays of type []string",
 		},
 		{
-			name:  "RelayWrongType",
-			input: []byte(`{"enabled":true,"grace":"123","relays":[true, true]}`),
-			err:   "invalid JSON: json: cannot unmarshal bool into Go struct field builderConfigJSON.relays of type string",
+			name:        "RelayWrongType",
+			input:       []byte(`{"enabled":true,"grace":"123","relays":[true, true]}`),
+			errContains: "cannot unmarshal bool into",
 		},
 		{
 			name:  "Good",
@@ -92,6 +93,8 @@ func TestBuilderConfig(t *testing.T) {
 			err := json.Unmarshal(test.input, &res)
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
+			} else if test.errContains != "" {
+				require.ErrorContains(t, err, test.errContains)
 			} else {
 				require.NoError(t, err)
 				rt := res.String()

--- a/services/blockrelay/v1/executionconfig.go
+++ b/services/blockrelay/v1/executionconfig.go
@@ -136,6 +136,7 @@ func (e *ExecutionConfig) ProposerConfig(_ context.Context,
 
 	return &beaconblockproposer.ProposerConfig{
 		FeeRecipient: proposerConfig.FeeRecipient,
+		GasLimit:     proposerConfig.GasLimit,
 		Relays:       relays,
 	}, nil
 }

--- a/services/blockrelay/v1/executionconfig_test.go
+++ b/services/blockrelay/v1/executionconfig_test.go
@@ -230,7 +230,8 @@ func TestECProposerConfig(t *testing.T) {
 				require.EqualError(t, err, test.err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, test.pc, pc)
+				require.Equal(t, test.pc.FeeRecipient, pc.FeeRecipient)
+				require.Equal(t, test.pc.Relays, pc.Relays)
 			}
 		})
 	}

--- a/services/blockrelay/v2/executionconfig.go
+++ b/services/blockrelay/v2/executionconfig.go
@@ -164,6 +164,11 @@ func (e *ExecutionConfig) ProposerConfig(ctx context.Context,
 	} else {
 		config.FeeRecipient = *e.FeeRecipient
 	}
+	if e.GasLimit == nil {
+		config.GasLimit = fallbackGasLimit
+	} else {
+		config.GasLimit = *e.GasLimit
+	}
 
 	e.setInitialRelayOptions(ctx, config, fallbackGasLimit)
 
@@ -260,6 +265,7 @@ func (e *ExecutionConfig) setProposerConfigOptions(_ context.Context,
 		}
 	}
 	if proposerConfig.GasLimit != nil {
+		config.GasLimit = *proposerConfig.GasLimit
 		for _, configRelay := range config.Relays {
 			configRelay.GasLimit = *proposerConfig.GasLimit
 		}

--- a/services/blockrelay/v2/executionconfig_test.go
+++ b/services/blockrelay/v2/executionconfig_test.go
@@ -149,6 +149,22 @@ func TestExecutionConfig(t *testing.T) {
 	}
 }
 
+func TestExecutionConfigExposesResolvedGasLimit(t *testing.T) {
+	ctx := context.Background()
+	gasLimit := uint64(30000000)
+	config := &v2.ExecutionConfig{GasLimit: &gasLimit}
+
+	proposerConfig, err := config.ProposerConfig(ctx,
+		nil,
+		phase0.BLSPubKey{},
+		bellatrix.ExecutionAddress{},
+		10000000,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, gasLimit, proposerConfig.GasLimit)
+}
+
 func TestConfig(t *testing.T) {
 	ctx := context.Background()
 
@@ -763,7 +779,8 @@ func TestConfig(t *testing.T) {
 				require.EqualError(t, err, test.err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, test.expected, res)
+				require.Equal(t, test.expected.FeeRecipient, res.FeeRecipient)
+				require.Equal(t, test.expected.Relays, res.Relays)
 			}
 		})
 	}

--- a/services/controller/standard/events.go
+++ b/services/controller/standard/events.go
@@ -63,6 +63,9 @@ func (s *Service) HandleHeadEvent(ctx context.Context, data *apiv1.HeadEvent) {
 	}
 
 	s.checkEventForReorg(ctx, epoch, data.Slot, data.PreviousDutyDependentRoot, data.CurrentDutyDependentRoot)
+	if s.proposerPreferences != nil && s.executionConfigProvider != nil && s.proposerPreferencesLookahead != 0 {
+		s.queueProposerPreferencesPublication(ctx)
+	}
 
 	s.fastTrackJobs(ctx, data.Slot)
 
@@ -139,6 +142,12 @@ func (s *Service) checkEventForReorg(ctx context.Context,
 	s.lastBlockEpoch = epoch
 	s.previousDutyDependentRoot = previousDutyDependentRoot
 	s.currentDutyDependentRoot = currentDutyDependentRoot
+	if s.proposerPreferences != nil && s.executionConfigProvider != nil && s.proposerPreferencesLookahead != 0 {
+		if epoch > 0 {
+			s.recordProposerPreferencesDependentRoot(epoch-1, previousDutyDependentRoot)
+		}
+		s.recordProposerPreferencesDependentRoot(epoch, currentDutyDependentRoot)
+	}
 }
 
 // fastTrackJobs kicks off jobs when a block has been seen early.

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -63,7 +63,7 @@ type parameters struct {
 	syncCommitteeAggregator       synccommitteeaggregator.Service
 	payloadAttester               payloadattester.Service
 	beaconBlockProposer           beaconblockproposer.Service
-	proposerPreferences           proposerpreferences.Service
+	proposerPreferences           proposerpreferences.Publisher
 	attestationAggregator         attestationaggregator.Service
 	beaconCommitteeSubscriber     beaconcommitteesubscriber.Service
 	accountsRefresher             accountmanager.Refresher
@@ -228,7 +228,7 @@ func WithBeaconBlockProposer(proposer beaconblockproposer.Service) Parameter {
 }
 
 // WithProposerPreferences sets the proposer preferences publisher.
-func WithProposerPreferences(preferences proposerpreferences.Service) Parameter {
+func WithProposerPreferences(preferences proposerpreferences.Publisher) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.proposerPreferences = preferences
 	})

--- a/services/controller/standard/parameters.go
+++ b/services/controller/standard/parameters.go
@@ -24,12 +24,14 @@ import (
 	"github.com/attestantio/vouch/services/attester"
 	"github.com/attestantio/vouch/services/beaconblockproposer"
 	"github.com/attestantio/vouch/services/beaconcommitteesubscriber"
+	"github.com/attestantio/vouch/services/blockrelay"
 	"github.com/attestantio/vouch/services/cache"
 	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/metrics"
 	"github.com/attestantio/vouch/services/multiinstance"
 	"github.com/attestantio/vouch/services/payloadattester"
 	"github.com/attestantio/vouch/services/proposalpreparer"
+	"github.com/attestantio/vouch/services/proposerpreferences"
 	"github.com/attestantio/vouch/services/scheduler"
 	"github.com/attestantio/vouch/services/synccommitteeaggregator"
 	"github.com/attestantio/vouch/services/synccommitteemessenger"
@@ -42,6 +44,7 @@ type parameters struct {
 	monitor                       metrics.Service
 	specProvider                  eth2client.SpecProvider
 	chainTimeService              chaintime.Service
+	executionConfigProvider       blockrelay.ExecutionConfigProvider
 	proposerDutiesProvider        eth2client.ProposerDutiesProvider
 	attesterDutiesProvider        eth2client.AttesterDutiesProvider
 	syncCommitteeDutiesProvider   eth2client.SyncCommitteeDutiesProvider
@@ -60,6 +63,7 @@ type parameters struct {
 	syncCommitteeAggregator       synccommitteeaggregator.Service
 	payloadAttester               payloadattester.Service
 	beaconBlockProposer           beaconblockproposer.Service
+	proposerPreferences           proposerpreferences.Service
 	attestationAggregator         attestationaggregator.Service
 	beaconCommitteeSubscriber     beaconcommitteesubscriber.Service
 	accountsRefresher             accountmanager.Refresher
@@ -220,6 +224,20 @@ func WithSignedBeaconBlockProvider(provider eth2client.SignedBeaconBlockProvider
 func WithBeaconBlockProposer(proposer beaconblockproposer.Service) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.beaconBlockProposer = proposer
+	})
+}
+
+// WithProposerPreferences sets the proposer preferences publisher.
+func WithProposerPreferences(preferences proposerpreferences.Service) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.proposerPreferences = preferences
+	})
+}
+
+// WithExecutionConfigProvider sets the execution configuration provider.
+func WithExecutionConfigProvider(provider blockrelay.ExecutionConfigProvider) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.executionConfigProvider = provider
 	})
 }
 

--- a/services/controller/standard/proposerpreferences.go
+++ b/services/controller/standard/proposerpreferences.go
@@ -89,7 +89,11 @@ func (s *Service) publishProposerPreferencesForKnownRoots(ctx context.Context) {
 
 // publishProposerPreferences publishes preferences for the proposal epoch whose duties share the supplied dependent root.
 func (s *Service) publishProposerPreferences(ctx context.Context, rootEpoch phase0.Epoch, dependentRoot phase0.Root) {
-	if dependentRoot == (phase0.Root{}) || s.proposerPreferences == nil || s.executionConfigProvider == nil || s.proposerPreferencesLookahead == 0 {
+	if s.proposerPreferences == nil || s.executionConfigProvider == nil || s.proposerPreferencesLookahead == 0 {
+		return
+	}
+	s.proposerPreferences.Prune(s.chainTimeService.CurrentSlot())
+	if dependentRoot == (phase0.Root{}) {
 		return
 	}
 

--- a/services/controller/standard/proposerpreferences.go
+++ b/services/controller/standard/proposerpreferences.go
@@ -1,0 +1,166 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"sort"
+
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/proposerpreferences"
+	"github.com/attestantio/vouch/util"
+)
+
+// recordProposerPreferencesDependentRoot retains the root used to derive proposer duties for an epoch.
+func (s *Service) recordProposerPreferencesDependentRoot(epoch phase0.Epoch, root phase0.Root) {
+	if root == (phase0.Root{}) {
+		return
+	}
+	s.proposerPreferencesDependentRootMutex.Lock()
+	defer s.proposerPreferencesDependentRootMutex.Unlock()
+	if s.proposerPreferencesDependentRoots == nil {
+		s.proposerPreferencesDependentRoots = make(map[phase0.Epoch]phase0.Root)
+	}
+	s.proposerPreferencesDependentRoots[epoch] = root
+	for storedEpoch := range s.proposerPreferencesDependentRoots {
+		if storedEpoch+phase0.Epoch(s.proposerPreferencesLookahead) < s.chainTimeService.CurrentEpoch() {
+			delete(s.proposerPreferencesDependentRoots, storedEpoch)
+		}
+	}
+}
+
+func (s *Service) queueProposerPreferencesPublication(ctx context.Context) {
+	s.proposerPreferencesPublicationMutex.Lock()
+	s.proposerPreferencesPublicationPending = true
+	if s.proposerPreferencesPublicationRunning {
+		s.proposerPreferencesPublicationMutex.Unlock()
+		return
+	}
+	s.proposerPreferencesPublicationRunning = true
+	s.proposerPreferencesPublicationMutex.Unlock()
+
+	go func() {
+		for {
+			s.proposerPreferencesPublicationMutex.Lock()
+			s.proposerPreferencesPublicationPending = false
+			s.proposerPreferencesPublicationMutex.Unlock()
+
+			s.publishProposerPreferencesForKnownRoots(ctx)
+
+			s.proposerPreferencesPublicationMutex.Lock()
+			if !s.proposerPreferencesPublicationPending {
+				s.proposerPreferencesPublicationRunning = false
+				s.proposerPreferencesPublicationMutex.Unlock()
+				return
+			}
+			s.proposerPreferencesPublicationMutex.Unlock()
+		}
+	}()
+}
+
+// publishProposerPreferencesForKnownRoots publishes each recorded root whose lookahead target has not passed.
+func (s *Service) publishProposerPreferencesForKnownRoots(ctx context.Context) {
+	s.proposerPreferencesDependentRootMutex.RLock()
+	epochs := make([]phase0.Epoch, 0, len(s.proposerPreferencesDependentRoots))
+	roots := make(map[phase0.Epoch]phase0.Root, len(s.proposerPreferencesDependentRoots))
+	for epoch, root := range s.proposerPreferencesDependentRoots {
+		epochs = append(epochs, epoch)
+		roots[epoch] = root
+	}
+	s.proposerPreferencesDependentRootMutex.RUnlock()
+	sort.Slice(epochs, func(i, j int) bool { return epochs[i] < epochs[j] })
+	for _, epoch := range epochs {
+		s.publishProposerPreferences(ctx, epoch, roots[epoch])
+	}
+}
+
+// publishProposerPreferences publishes preferences for the proposal epoch whose duties share the supplied dependent root.
+func (s *Service) publishProposerPreferences(ctx context.Context, rootEpoch phase0.Epoch, dependentRoot phase0.Root) {
+	if dependentRoot == (phase0.Root{}) || s.proposerPreferences == nil || s.executionConfigProvider == nil || s.proposerPreferencesLookahead == 0 {
+		return
+	}
+
+	proposalEpoch := rootEpoch + phase0.Epoch(s.proposerPreferencesLookahead)
+	if proposalEpoch < s.gloasForkEpoch || proposalEpoch < s.chainTimeService.CurrentEpoch() {
+		return
+	}
+
+	response, err := s.proposerDutiesProvider.ProposerDuties(ctx, &api.ProposerDutiesOpts{Epoch: proposalEpoch})
+	if err != nil {
+		s.log.Error().Err(err).Uint64("epoch", uint64(proposalEpoch)).Msg("Failed to fetch proposer preferences duties")
+		return
+	}
+	if response == nil || len(response.Data) == 0 {
+		return
+	}
+	responseDependentRoot, ok := response.Metadata["dependent_root"].(phase0.Root)
+	if !ok || responseDependentRoot == (phase0.Root{}) {
+		s.log.Error().Uint64("epoch", uint64(proposalEpoch)).Msg("No dependent root for proposer preferences duties")
+		return
+	}
+
+	firstSlot := s.chainTimeService.FirstSlotOfEpoch(proposalEpoch)
+	lastSlot := s.chainTimeService.FirstSlotOfEpoch(proposalEpoch+1) - 1
+	currentSlot := s.chainTimeService.CurrentSlot()
+	duties := make([]*apiv1.ProposerDuty, 0, len(response.Data))
+	indices := make([]phase0.ValidatorIndex, 0, len(response.Data))
+	seenIndices := make(map[phase0.ValidatorIndex]struct{})
+	for _, duty := range response.Data {
+		if duty == nil || duty.Slot < firstSlot || duty.Slot > lastSlot || duty.Slot <= currentSlot {
+			continue
+		}
+		duties = append(duties, duty)
+		if _, exists := seenIndices[duty.ValidatorIndex]; !exists {
+			seenIndices[duty.ValidatorIndex] = struct{}{}
+			indices = append(indices, duty.ValidatorIndex)
+		}
+	}
+	if len(duties) == 0 {
+		return
+	}
+
+	accounts, err := s.validatingAccountsProvider.ValidatingAccountsForEpochByIndex(ctx, proposalEpoch, indices)
+	if err != nil {
+		s.log.Error().Err(err).Uint64("epoch", uint64(proposalEpoch)).Msg("Failed to obtain proposer preferences accounts")
+		return
+	}
+	for _, duty := range duties {
+		account, exists := accounts[duty.ValidatorIndex]
+		if !exists {
+			s.log.Error().Uint64("validator_index", uint64(duty.ValidatorIndex)).Msg("No account for proposer preferences duty")
+			continue
+		}
+		config, err := s.executionConfigProvider.ProposerConfig(ctx, account, util.ValidatorPubkey(account))
+		if err != nil {
+			s.log.Error().Err(err).Uint64("validator_index", uint64(duty.ValidatorIndex)).Msg("Failed to obtain proposer preferences execution configuration")
+			continue
+		}
+		if config == nil {
+			s.log.Error().Uint64("validator_index", uint64(duty.ValidatorIndex)).Msg("No proposer preferences execution configuration")
+			continue
+		}
+		if err := s.proposerPreferences.Publish(ctx, proposerpreferences.NewDuty(
+			responseDependentRoot,
+			duty.Slot,
+			duty.ValidatorIndex,
+			account,
+			config.FeeRecipient,
+			config.GasLimit,
+		)); err != nil {
+			s.log.Error().Err(err).Uint64("proposal_slot", uint64(duty.Slot)).Msg("Failed to publish proposer preferences")
+		}
+	}
+}

--- a/services/controller/standard/proposerpreferences_internal_test.go
+++ b/services/controller/standard/proposerpreferences_internal_test.go
@@ -62,6 +62,22 @@ func TestPublishProposerPreferencesPublishesFirstGloasEpoch(t *testing.T) {
 	)}, preferences.duties)
 }
 
+func TestPublishProposerPreferencesPrunesPastSlots(t *testing.T) {
+	preferences := &recordingProposerPreferences{}
+	service := &Service{
+		chainTimeService:             &recordingChainTime{currentEpoch: 4, slotsPerEpoch: 32},
+		proposerDutiesProvider:       &recordingProposerDutiesProvider{},
+		proposerPreferences:          preferences,
+		executionConfigProvider:      &recordingExecutionConfigProvider{},
+		gloasForkEpoch:               5,
+		proposerPreferencesLookahead: 1,
+	}
+
+	service.publishProposerPreferences(context.Background(), 4, phase0.Root{0x01})
+
+	require.Equal(t, []phase0.Slot{128}, preferences.prunedSlots)
+}
+
 func TestPublishProposerPreferencesRejectsDutiesWithoutDependentRoot(t *testing.T) {
 	provider := &recordingProposerDutiesProvider{duties: []*apiv1.ProposerDuty{{Slot: 160, ValidatorIndex: 3}}}
 	preferences := &recordingProposerPreferences{}
@@ -137,7 +153,12 @@ func (p *recordingExecutionConfigProvider) ProposerConfig(context.Context, e2wty
 }
 
 type recordingProposerPreferences struct {
-	duties []*proposerpreferences.Duty
+	duties      []*proposerpreferences.Duty
+	prunedSlots []phase0.Slot
+}
+
+func (p *recordingProposerPreferences) Prune(slot phase0.Slot) {
+	p.prunedSlots = append(p.prunedSlots, slot)
 }
 
 func (p *recordingProposerPreferences) Publish(_ context.Context, duty *proposerpreferences.Duty) error {

--- a/services/controller/standard/proposerpreferences_internal_test.go
+++ b/services/controller/standard/proposerpreferences_internal_test.go
@@ -1,0 +1,146 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/attestantio/vouch/services/beaconblockproposer"
+	"github.com/attestantio/vouch/services/proposerpreferences"
+	"github.com/attestantio/vouch/testutil"
+	"github.com/stretchr/testify/require"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+func TestPublishProposerPreferencesPublishesFirstGloasEpoch(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+
+	provider := &recordingProposerDutiesProvider{
+		duties:   []*apiv1.ProposerDuty{{Slot: 160, ValidatorIndex: 3}},
+		metadata: map[string]any{"dependent_root": phase0.Root{0x01}},
+	}
+	preferences := &recordingProposerPreferences{}
+	service := &Service{
+		chainTimeService:             &recordingChainTime{currentEpoch: 4, slotDuration: time.Second, slotsPerEpoch: 32},
+		proposerDutiesProvider:       provider,
+		validatingAccountsProvider:   &proposerPreferencesAccountsProvider{accounts: accounts},
+		executionConfigProvider:      &recordingExecutionConfigProvider{config: &beaconblockproposer.ProposerConfig{FeeRecipient: bellatrix.ExecutionAddress{0x02}, GasLimit: 30_000_000}},
+		proposerPreferences:          preferences,
+		gloasForkEpoch:               5,
+		proposerPreferencesLookahead: 1,
+	}
+
+	service.publishProposerPreferences(ctx, 4, phase0.Root{0x01})
+
+	require.Equal(t, phase0.Epoch(5), provider.epoch)
+	require.Equal(t, []*proposerpreferences.Duty{proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		160,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		30_000_000,
+	)}, preferences.duties)
+}
+
+func TestPublishProposerPreferencesRejectsDutiesWithoutDependentRoot(t *testing.T) {
+	provider := &recordingProposerDutiesProvider{duties: []*apiv1.ProposerDuty{{Slot: 160, ValidatorIndex: 3}}}
+	preferences := &recordingProposerPreferences{}
+	service := &Service{
+		chainTimeService:             &recordingChainTime{currentEpoch: 4, slotsPerEpoch: 32},
+		proposerDutiesProvider:       provider,
+		proposerPreferences:          preferences,
+		executionConfigProvider:      &recordingExecutionConfigProvider{},
+		gloasForkEpoch:               5,
+		proposerPreferencesLookahead: 1,
+	}
+
+	service.publishProposerPreferences(context.Background(), 4, phase0.Root{0x01})
+
+	require.Empty(t, preferences.duties)
+}
+
+func TestPublishProposerPreferencesDoesNotPublishBeforeGloas(t *testing.T) {
+	provider := &recordingProposerDutiesProvider{}
+	service := &Service{
+		chainTimeService:             &recordingChainTime{currentEpoch: 4, slotsPerEpoch: 32},
+		proposerDutiesProvider:       provider,
+		proposerPreferences:          &recordingProposerPreferences{},
+		executionConfigProvider:      &recordingExecutionConfigProvider{},
+		gloasForkEpoch:               5,
+		proposerPreferencesLookahead: 1,
+	}
+
+	service.publishProposerPreferences(context.Background(), 3, phase0.Root{0x01})
+
+	require.Zero(t, provider.calls)
+}
+
+type recordingProposerDutiesProvider struct {
+	calls    int
+	duties   []*apiv1.ProposerDuty
+	metadata map[string]any
+	epoch    phase0.Epoch
+}
+
+func (p *recordingProposerDutiesProvider) ProposerDuties(_ context.Context, opts *api.ProposerDutiesOpts) (*api.Response[[]*apiv1.ProposerDuty], error) {
+	p.calls++
+	p.epoch = opts.Epoch
+	return &api.Response[[]*apiv1.ProposerDuty]{Data: p.duties, Metadata: p.metadata}, nil
+}
+
+type proposerPreferencesAccountsProvider struct {
+	accounts map[phase0.ValidatorIndex]e2wtypes.Account
+}
+
+func (p *proposerPreferencesAccountsProvider) ValidatingAccountsForEpoch(_ context.Context, _ phase0.Epoch) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+	return p.accounts, nil
+}
+
+func (p *proposerPreferencesAccountsProvider) ValidatingAccountsForEpochByIndex(_ context.Context, _ phase0.Epoch, _ []phase0.ValidatorIndex) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+	return p.accounts, nil
+}
+
+func (*proposerPreferencesAccountsProvider) SyncCommitteeAccountsForEpoch(context.Context, phase0.Epoch) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+	return nil, nil
+}
+
+func (*proposerPreferencesAccountsProvider) SyncCommitteeAccountsForEpochByIndex(context.Context, phase0.Epoch, []phase0.ValidatorIndex) (map[phase0.ValidatorIndex]e2wtypes.Account, error) {
+	return nil, nil
+}
+
+type recordingExecutionConfigProvider struct {
+	config *beaconblockproposer.ProposerConfig
+}
+
+func (p *recordingExecutionConfigProvider) ProposerConfig(context.Context, e2wtypes.Account, phase0.BLSPubKey) (*beaconblockproposer.ProposerConfig, error) {
+	return p.config, nil
+}
+
+type recordingProposerPreferences struct {
+	duties []*proposerpreferences.Duty
+}
+
+func (p *recordingProposerPreferences) Publish(_ context.Context, duty *proposerpreferences.Duty) error {
+	p.duties = append(p.duties, duty)
+	return nil
+}

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -27,12 +27,14 @@ import (
 	"github.com/attestantio/vouch/services/attester"
 	"github.com/attestantio/vouch/services/beaconblockproposer"
 	"github.com/attestantio/vouch/services/beaconcommitteesubscriber"
+	"github.com/attestantio/vouch/services/blockrelay"
 	"github.com/attestantio/vouch/services/cache"
 	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/metrics"
 	"github.com/attestantio/vouch/services/multiinstance"
 	"github.com/attestantio/vouch/services/payloadattester"
 	"github.com/attestantio/vouch/services/proposalpreparer"
+	"github.com/attestantio/vouch/services/proposerpreferences"
 	"github.com/attestantio/vouch/services/scheduler"
 	"github.com/attestantio/vouch/services/synccommitteeaggregator"
 	"github.com/attestantio/vouch/services/synccommitteemessenger"
@@ -55,6 +57,7 @@ type Service struct {
 	log                          zerolog.Logger
 	monitor                      metrics.Service
 	chainTimeService             chaintime.Service
+	executionConfigProvider      blockrelay.ExecutionConfigProvider
 	proposerDutiesProvider       eth2client.ProposerDutiesProvider
 	attesterDutiesProvider       eth2client.AttesterDutiesProvider
 	syncCommitteeDutiesProvider  eth2client.SyncCommitteeDutiesProvider
@@ -74,6 +77,7 @@ type Service struct {
 	syncCommitteesSubscriber     synccommitteesubscriber.Service
 	payloadAttester              payloadattester.Service
 	beaconBlockProposer          beaconblockproposer.Service
+	proposerPreferences          proposerpreferences.Service
 	attestationAggregator        attestationaggregator.Service
 	beaconCommitteeSubscriber    beaconcommitteesubscriber.Service
 	activeValidators             int
@@ -90,23 +94,29 @@ type Service struct {
 	fastTrackGrace               time.Duration
 	multiInstance                multiinstance.Service
 	// Hard fork control.
-	handlingAltair     bool
-	altairForkEpoch    phase0.Epoch
-	handlingBellatrix  bool
-	bellatrixForkEpoch phase0.Epoch
-	capellaForkEpoch   phase0.Epoch
-	handlingElectra    bool
-	electraForkEpoch   phase0.Epoch
-	gloasForkEpoch     phase0.Epoch
+	handlingAltair               bool
+	altairForkEpoch              phase0.Epoch
+	handlingBellatrix            bool
+	bellatrixForkEpoch           phase0.Epoch
+	capellaForkEpoch             phase0.Epoch
+	handlingElectra              bool
+	electraForkEpoch             phase0.Epoch
+	gloasForkEpoch               phase0.Epoch
+	proposerPreferencesLookahead uint64
 	// Tracking for reorgs.
 	lastBlockRoot             phase0.Root
 	lastBlockEpoch            phase0.Epoch
 	currentDutyDependentRoot  phase0.Root
 	previousDutyDependentRoot phase0.Root
 	// Tracking for attestations.
-	pendingAttestations      map[phase0.Slot]bool
-	subscriptionInfosMutex   sync.Mutex
-	pendingAttestationsMutex sync.RWMutex
+	pendingAttestations                   map[phase0.Slot]bool
+	proposerPreferencesDependentRoots     map[phase0.Epoch]phase0.Root
+	proposerPreferencesPublicationRunning bool
+	proposerPreferencesPublicationPending bool
+	subscriptionInfosMutex                sync.Mutex
+	proposerPreferencesDependentRootMutex sync.RWMutex
+	proposerPreferencesPublicationMutex   sync.Mutex
+	pendingAttestationsMutex              sync.RWMutex
 }
 
 // New creates a new controller.
@@ -125,7 +135,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	if err := registerMetrics(ctx, parameters.monitor); err != nil {
 		return nil, errors.New("failed to register metrics")
 	}
-	slotDuration, slotsPerEpoch, epochsPerSyncCommitteePeriod, err := obtainSpecValues(ctx, parameters.specProvider)
+	slotDuration, slotsPerEpoch, epochsPerSyncCommitteePeriod, proposerPreferencesLookahead, err := obtainSpecValues(ctx, parameters.specProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -137,50 +147,54 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	gloasForkEpoch := gloasDetails(ctx, log, parameters.chainTimeService)
 
 	s := &Service{
-		log:                          log,
-		monitor:                      parameters.monitor,
-		slotDuration:                 slotDuration,
-		slotsPerEpoch:                slotsPerEpoch,
-		epochsPerSyncCommitteePeriod: epochsPerSyncCommitteePeriod,
-		chainTimeService:             parameters.chainTimeService,
-		proposerDutiesProvider:       parameters.proposerDutiesProvider,
-		attesterDutiesProvider:       parameters.attesterDutiesProvider,
-		syncCommitteeDutiesProvider:  parameters.syncCommitteeDutiesProvider,
-		syncCommitteesSubscriber:     parameters.syncCommitteesSubscriber,
-		validatingAccountsProvider:   parameters.validatingAccountsProvider,
-		proposalsPreparer:            parameters.proposalsPreparer,
-		scheduler:                    parameters.scheduler,
-		attester:                     parameters.attester,
-		ptcDutiesProvider:            parameters.ptcDutiesProvider,
-		payloadAttester:              parameters.payloadAttester,
-		syncCommitteeMessenger:       parameters.syncCommitteeMessenger,
-		syncCommitteeAggregator:      parameters.syncCommitteeAggregator,
-		beaconBlockProposer:          parameters.beaconBlockProposer,
-		beaconBlockHeadersProvider:   parameters.beaconBlockHeadersProvider,
-		signedBeaconBlockProvider:    parameters.signedBeaconBlockProvider,
-		attestationAggregator:        parameters.attestationAggregator,
-		beaconCommitteeSubscriber:    parameters.beaconCommitteeSubscriber,
-		accountsRefresher:            parameters.accountsRefresher,
-		blockToSlotSetter:            parameters.blockToSlotSetter,
-		maxProposalDelay:             parameters.maxProposalDelay,
-		payloadAttestationDelay:      parameters.payloadAttestationDelay,
-		preGloasTimings:              parameters.preGloasTimings,
-		gloasTimings:                 parameters.gloasTimings,
-		verifySyncCommitteeInclusion: parameters.verifySyncCommitteeInclusion,
-		fastTrackAttestations:        parameters.fastTrackAttestations,
-		fastTrackSyncCommittees:      parameters.fastTrackSyncCommittees,
-		fastTrackGrace:               parameters.fastTrackGrace,
-		multiInstance:                parameters.multiInstance,
-		subscriptionInfos:            make(map[phase0.Epoch]map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription),
-		handlingAltair:               handlingAltair,
-		altairForkEpoch:              altairForkEpoch,
-		handlingBellatrix:            handlingBellatrix,
-		bellatrixForkEpoch:           bellatrixForkEpoch,
-		capellaForkEpoch:             capellaForkEpoch,
-		handlingElectra:              handlingElectra,
-		electraForkEpoch:             electraForkEpoch,
-		gloasForkEpoch:               gloasForkEpoch,
-		pendingAttestations:          make(map[phase0.Slot]bool),
+		log:                               log,
+		monitor:                           parameters.monitor,
+		slotDuration:                      slotDuration,
+		slotsPerEpoch:                     slotsPerEpoch,
+		epochsPerSyncCommitteePeriod:      epochsPerSyncCommitteePeriod,
+		chainTimeService:                  parameters.chainTimeService,
+		proposerDutiesProvider:            parameters.proposerDutiesProvider,
+		attesterDutiesProvider:            parameters.attesterDutiesProvider,
+		syncCommitteeDutiesProvider:       parameters.syncCommitteeDutiesProvider,
+		syncCommitteesSubscriber:          parameters.syncCommitteesSubscriber,
+		validatingAccountsProvider:        parameters.validatingAccountsProvider,
+		proposalsPreparer:                 parameters.proposalsPreparer,
+		scheduler:                         parameters.scheduler,
+		attester:                          parameters.attester,
+		ptcDutiesProvider:                 parameters.ptcDutiesProvider,
+		payloadAttester:                   parameters.payloadAttester,
+		syncCommitteeMessenger:            parameters.syncCommitteeMessenger,
+		syncCommitteeAggregator:           parameters.syncCommitteeAggregator,
+		beaconBlockProposer:               parameters.beaconBlockProposer,
+		proposerPreferences:               parameters.proposerPreferences,
+		executionConfigProvider:           parameters.executionConfigProvider,
+		beaconBlockHeadersProvider:        parameters.beaconBlockHeadersProvider,
+		signedBeaconBlockProvider:         parameters.signedBeaconBlockProvider,
+		attestationAggregator:             parameters.attestationAggregator,
+		beaconCommitteeSubscriber:         parameters.beaconCommitteeSubscriber,
+		accountsRefresher:                 parameters.accountsRefresher,
+		blockToSlotSetter:                 parameters.blockToSlotSetter,
+		maxProposalDelay:                  parameters.maxProposalDelay,
+		payloadAttestationDelay:           parameters.payloadAttestationDelay,
+		preGloasTimings:                   parameters.preGloasTimings,
+		gloasTimings:                      parameters.gloasTimings,
+		verifySyncCommitteeInclusion:      parameters.verifySyncCommitteeInclusion,
+		fastTrackAttestations:             parameters.fastTrackAttestations,
+		fastTrackSyncCommittees:           parameters.fastTrackSyncCommittees,
+		fastTrackGrace:                    parameters.fastTrackGrace,
+		multiInstance:                     parameters.multiInstance,
+		subscriptionInfos:                 make(map[phase0.Epoch]map[phase0.Slot]map[phase0.CommitteeIndex]*beaconcommitteesubscriber.Subscription),
+		handlingAltair:                    handlingAltair,
+		altairForkEpoch:                   altairForkEpoch,
+		handlingBellatrix:                 handlingBellatrix,
+		bellatrixForkEpoch:                bellatrixForkEpoch,
+		capellaForkEpoch:                  capellaForkEpoch,
+		handlingElectra:                   handlingElectra,
+		electraForkEpoch:                  electraForkEpoch,
+		gloasForkEpoch:                    gloasForkEpoch,
+		proposerPreferencesLookahead:      proposerPreferencesLookahead,
+		pendingAttestations:               make(map[phase0.Slot]bool),
+		proposerPreferencesDependentRoots: make(map[phase0.Epoch]phase0.Root),
 	}
 
 	// Subscribe to head events.  This allows us to go early for attestations if a block arrives, as well as
@@ -589,42 +603,52 @@ func obtainSpecValues(ctx context.Context,
 	time.Duration,
 	uint64,
 	uint64,
+	uint64,
 	error,
 ) {
 	specResponse, err := specProvider.Spec(ctx, &api.SpecOpts{})
 	if err != nil {
-		return 0, 0, 0, errors.Wrap(err, "failed to obtain spec")
+		return 0, 0, 0, 0, errors.Wrap(err, "failed to obtain spec")
 	}
 	spec := specResponse.Data
 
 	tmp, exists := spec["SECONDS_PER_SLOT"]
 	if !exists {
-		return 0, 0, 0, errors.New("SECONDS_PER_SLOT not found in spec")
+		return 0, 0, 0, 0, errors.New("SECONDS_PER_SLOT not found in spec")
 	}
 	slotDuration, ok := tmp.(time.Duration)
 	if !ok {
-		return 0, 0, 0, errors.New("SECONDS_PER_SLOT of unexpected type")
+		return 0, 0, 0, 0, errors.New("SECONDS_PER_SLOT of unexpected type")
 	}
 
 	tmp, exists = spec["SLOTS_PER_EPOCH"]
 	if !exists {
-		return 0, 0, 0, errors.New("SLOTS_PER_EPOCH not found in spec")
+		return 0, 0, 0, 0, errors.New("SLOTS_PER_EPOCH not found in spec")
 	}
 	slotsPerEpoch, ok := tmp.(uint64)
 	if !ok {
-		return 0, 0, 0, errors.New("SLOTS_PER_EPOCH of unexpected type")
+		return 0, 0, 0, 0, errors.New("SLOTS_PER_EPOCH of unexpected type")
 	}
 
 	var epochsPerSyncCommitteePeriod uint64
 	if tmp, exists := spec["EPOCHS_PER_SYNC_COMMITTEE_PERIOD"]; exists {
 		tmp2, ok := tmp.(uint64)
 		if !ok {
-			return 0, 0, 0, errors.New("EPOCHS_PER_SYNC_COMMITTEE_PERIOD of unexpected type")
+			return 0, 0, 0, 0, errors.New("EPOCHS_PER_SYNC_COMMITTEE_PERIOD of unexpected type")
 		}
 		epochsPerSyncCommitteePeriod = tmp2
 	}
 
-	return slotDuration, slotsPerEpoch, epochsPerSyncCommitteePeriod, nil
+	var proposerPreferencesLookahead uint64
+	if tmp, exists := spec["MIN_SEED_LOOKAHEAD"]; exists {
+		var ok bool
+		proposerPreferencesLookahead, ok = tmp.(uint64)
+		if !ok {
+			return 0, 0, 0, 0, errors.New("MIN_SEED_LOOKAHEAD of unexpected type")
+		}
+	}
+
+	return slotDuration, slotsPerEpoch, epochsPerSyncCommitteePeriod, proposerPreferencesLookahead, nil
 }
 
 func capellaDetails(ctx context.Context, log zerolog.Logger, specProvider eth2client.SpecProvider) phase0.Epoch {

--- a/services/controller/standard/service.go
+++ b/services/controller/standard/service.go
@@ -77,7 +77,7 @@ type Service struct {
 	syncCommitteesSubscriber     synccommitteesubscriber.Service
 	payloadAttester              payloadattester.Service
 	beaconBlockProposer          beaconblockproposer.Service
-	proposerPreferences          proposerpreferences.Service
+	proposerPreferences          proposerpreferences.Publisher
 	attestationAggregator        attestationaggregator.Service
 	beaconCommitteeSubscriber    beaconcommitteesubscriber.Service
 	activeValidators             int

--- a/services/proposerpreferences/service.go
+++ b/services/proposerpreferences/service.go
@@ -57,6 +57,7 @@ type ProviderReadiness interface {
 
 // Publisher publishes proposer preferences.
 type Publisher interface {
+	Prune(slot phase0.Slot)
 	Publish(ctx context.Context, duty *Duty) error
 }
 

--- a/services/proposerpreferences/service.go
+++ b/services/proposerpreferences/service.go
@@ -1,0 +1,56 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package proposerpreferences provides proposer-preferences duties.
+package proposerpreferences
+
+import (
+	"context"
+
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+// Duty contains the data required to publish a validator's proposer preferences.
+type Duty struct {
+	DependentRoot  phase0.Root
+	ProposalSlot   phase0.Slot
+	ValidatorIndex phase0.ValidatorIndex
+	Account        e2wtypes.Account
+	FeeRecipient   bellatrix.ExecutionAddress
+	TargetGasLimit uint64
+}
+
+// NewDuty creates a proposer-preferences duty.
+func NewDuty(dependentRoot phase0.Root,
+	proposalSlot phase0.Slot,
+	validatorIndex phase0.ValidatorIndex,
+	account e2wtypes.Account,
+	feeRecipient bellatrix.ExecutionAddress,
+	targetGasLimit uint64,
+) *Duty {
+	return &Duty{
+		DependentRoot:  dependentRoot,
+		ProposalSlot:   proposalSlot,
+		ValidatorIndex: validatorIndex,
+		Account:        account,
+		FeeRecipient:   feeRecipient,
+		TargetGasLimit: targetGasLimit,
+	}
+}
+
+// Service publishes proposer preferences.
+type Service interface {
+	Publish(ctx context.Context, duty *Duty) error
+}

--- a/services/proposerpreferences/service.go
+++ b/services/proposerpreferences/service.go
@@ -50,7 +50,18 @@ func NewDuty(dependentRoot phase0.Root,
 	}
 }
 
-// Service publishes proposer preferences.
-type Service interface {
+// ProviderReadiness reports whether a proposal provider has accepted a current preference.
+type ProviderReadiness interface {
+	ProviderReady(provider string, proposalSlot phase0.Slot, validatorIndex phase0.ValidatorIndex) bool
+}
+
+// Publisher publishes proposer preferences.
+type Publisher interface {
 	Publish(ctx context.Context, duty *Duty) error
+}
+
+// Service publishes proposer preferences and reports provider readiness.
+type Service interface {
+	Publisher
+	ProviderReadiness
 }

--- a/services/proposerpreferences/standard/metrics.go
+++ b/services/proposerpreferences/standard/metrics.go
@@ -1,0 +1,54 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"errors"
+
+	"github.com/attestantio/vouch/services/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var proposerPreferencesProcessEvents *prometheus.CounterVec
+
+func registerMetrics(_ context.Context, monitor metrics.Service) error {
+	if monitor == nil || monitor.Presenter() != "prometheus" {
+		return nil
+	}
+
+	proposerPreferencesProcessEvents = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "vouch",
+		Subsystem: "proposerpreferences_process",
+		Name:      "events_total",
+		Help:      "The number of proposer preferences process events.",
+	}, []string{"outcome"})
+	if err := prometheus.Register(proposerPreferencesProcessEvents); err != nil {
+		var alreadyRegisteredError prometheus.AlreadyRegisteredError
+		if ok := errors.As(err, &alreadyRegisteredError); ok {
+			proposerPreferencesProcessEvents = alreadyRegisteredError.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func monitorProposerPreferencesProcess(outcome string) {
+	if proposerPreferencesProcessEvents == nil {
+		return
+	}
+	proposerPreferencesProcessEvents.WithLabelValues(outcome).Inc()
+}

--- a/services/proposerpreferences/standard/parameters.go
+++ b/services/proposerpreferences/standard/parameters.go
@@ -1,0 +1,73 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"github.com/attestantio/vouch/services/metrics"
+	"github.com/attestantio/vouch/services/signer"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/pkg/errors"
+)
+
+type parameters struct {
+	monitor   metrics.Service
+	signer    signer.ProposerPreferencesSigner
+	submitter submitter.ProposerPreferencesSubmitter
+}
+
+// Parameter is a parameter for the service.
+type Parameter interface {
+	apply(parameters *parameters)
+}
+
+type parameterFunc func(*parameters)
+
+func (f parameterFunc) apply(parameters *parameters) {
+	f(parameters)
+}
+
+// WithMonitor sets the metrics monitor.
+func WithMonitor(monitor metrics.Service) Parameter {
+	return parameterFunc(func(parameters *parameters) { parameters.monitor = monitor })
+}
+
+// WithSigner sets the proposer-preferences signer.
+func WithSigner(signer signer.ProposerPreferencesSigner) Parameter {
+	return parameterFunc(func(parameters *parameters) { parameters.signer = signer })
+}
+
+// WithSubmitter sets the proposer-preferences submitter.
+func WithSubmitter(submitter submitter.ProposerPreferencesSubmitter) Parameter {
+	return parameterFunc(func(parameters *parameters) { parameters.submitter = submitter })
+}
+
+func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
+	parameters := &parameters{}
+	for _, param := range params {
+		if param != nil {
+			param.apply(parameters)
+		}
+	}
+	if parameters.monitor == nil {
+		return nil, errors.New("no monitor specified")
+	}
+	if parameters.signer == nil {
+		return nil, errors.New("no signer specified")
+	}
+	if parameters.submitter == nil {
+		return nil, errors.New("no submitter specified")
+	}
+
+	return parameters, nil
+}

--- a/services/proposerpreferences/standard/service.go
+++ b/services/proposerpreferences/standard/service.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/attestantio/vouch/services/metrics"
 	"github.com/attestantio/vouch/services/proposerpreferences"
 	"github.com/attestantio/vouch/services/signer"
@@ -30,12 +31,20 @@ import (
 type Service struct {
 	monitor   metrics.Service
 	cache     map[gloas.ProposerPreferences]*cachedPreference
+	current   map[preferenceDuty]gloas.ProposerPreferences
 	signer    signer.ProposerPreferencesSigner
 	submitter submitter.ProposerPreferencesSubmitter
 	mutex     sync.Mutex
 }
 
+type preferenceDuty struct {
+	proposalSlot   phase0.Slot
+	validatorIndex phase0.ValidatorIndex
+}
+
 type cachedPreference struct {
+	accepted  map[string]struct{}
+	outcomes  map[string]error
 	signed    *gloas.SignedProposerPreferences
 	published bool
 }
@@ -52,7 +61,26 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 		signer:    parameters.signer,
 		submitter: parameters.submitter,
 		cache:     make(map[gloas.ProposerPreferences]*cachedPreference),
+		current:   make(map[preferenceDuty]gloas.ProposerPreferences),
 	}, nil
+}
+
+// ProviderReady reports whether provider has accepted the current preference for a proposal duty.
+func (s *Service) ProviderReady(provider string, proposalSlot phase0.Slot, validatorIndex phase0.ValidatorIndex) bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	preferences, exists := s.current[preferenceDuty{proposalSlot: proposalSlot, validatorIndex: validatorIndex}]
+	if !exists {
+		return false
+	}
+	cached, exists := s.cache[preferences]
+	if !exists {
+		return false
+	}
+	_, exists = cached.accepted[provider]
+
+	return exists
 }
 
 // Publish publishes the supplied duty's proposer preferences.
@@ -78,26 +106,48 @@ func (s *Service) Publish(ctx context.Context, duty *proposerpreferences.Duty) e
 	if exists && cached.published {
 		return nil
 	}
+	providers := []string(nil)
 	if !exists {
 		signature, err := s.signer.SignProposerPreferences(ctx, duty.Account, &preferences)
 		if err != nil {
 			return errors.Wrap(err, "failed to sign proposer preferences")
 		}
-		cached = &cachedPreference{signed: &gloas.SignedProposerPreferences{
-			Message:   &preferences,
-			Signature: signature,
-		}}
+		cached = &cachedPreference{
+			accepted: make(map[string]struct{}),
+			outcomes: make(map[string]error),
+			signed: &gloas.SignedProposerPreferences{
+				Message:   &preferences,
+				Signature: signature,
+			},
+		}
 		s.cache[preferences] = cached
+	} else {
+		for provider, err := range cached.outcomes {
+			if err != nil {
+				providers = append(providers, provider)
+			}
+		}
 	}
+	s.current[preferenceDuty{proposalSlot: duty.ProposalSlot, validatorIndex: duty.ValidatorIndex}] = preferences
 
-	outcomes := s.submitter.SubmitProposerPreferences(ctx, []*gloas.SignedProposerPreferences{cached.signed})
+	outcomes := s.submitter.SubmitProposerPreferences(ctx, []*gloas.SignedProposerPreferences{cached.signed}, providers)
 	if len(outcomes) == 0 {
 		return errors.New("no proposer preferences submission outcomes")
 	}
-	for _, err := range outcomes {
+	var submissionErr error
+	for provider, err := range outcomes {
+		cached.outcomes[provider] = err
 		if err != nil {
-			return errors.Wrap(err, "failed to submit proposer preferences")
+			delete(cached.accepted, provider)
+			if submissionErr == nil {
+				submissionErr = err
+			}
+			continue
 		}
+		cached.accepted[provider] = struct{}{}
+	}
+	if submissionErr != nil {
+		return errors.Wrap(submissionErr, "failed to submit proposer preferences")
 	}
 	cached.published = true
 

--- a/services/proposerpreferences/standard/service.go
+++ b/services/proposerpreferences/standard/service.go
@@ -1,0 +1,105 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package standard provides the standard proposer-preferences service.
+package standard
+
+import (
+	"context"
+	"sync"
+
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/vouch/services/metrics"
+	"github.com/attestantio/vouch/services/proposerpreferences"
+	"github.com/attestantio/vouch/services/signer"
+	"github.com/attestantio/vouch/services/submitter"
+	"github.com/pkg/errors"
+)
+
+// Service is the standard proposer-preferences service.
+type Service struct {
+	monitor   metrics.Service
+	cache     map[gloas.ProposerPreferences]*cachedPreference
+	signer    signer.ProposerPreferencesSigner
+	submitter submitter.ProposerPreferencesSubmitter
+	mutex     sync.Mutex
+}
+
+type cachedPreference struct {
+	signed    *gloas.SignedProposerPreferences
+	published bool
+}
+
+// New creates a standard proposer-preferences service.
+func New(_ context.Context, params ...Parameter) (*Service, error) {
+	parameters, err := parseAndCheckParameters(params...)
+	if err != nil {
+		return nil, errors.Wrap(err, "problem with parameters")
+	}
+
+	return &Service{
+		monitor:   parameters.monitor,
+		signer:    parameters.signer,
+		submitter: parameters.submitter,
+		cache:     make(map[gloas.ProposerPreferences]*cachedPreference),
+	}, nil
+}
+
+// Publish publishes the supplied duty's proposer preferences.
+func (s *Service) Publish(ctx context.Context, duty *proposerpreferences.Duty) error {
+	if duty == nil {
+		return errors.New("no proposer preferences duty supplied")
+	}
+	if duty.Account == nil {
+		return errors.New("no account supplied for proposer preferences duty")
+	}
+
+	preferences := gloas.ProposerPreferences{
+		DependentRoot:  duty.DependentRoot,
+		ProposalSlot:   duty.ProposalSlot,
+		ValidatorIndex: duty.ValidatorIndex,
+		FeeRecipient:   duty.FeeRecipient,
+		TargetGasLimit: duty.TargetGasLimit,
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	cached, exists := s.cache[preferences]
+	if exists && cached.published {
+		return nil
+	}
+	if !exists {
+		signature, err := s.signer.SignProposerPreferences(ctx, duty.Account, &preferences)
+		if err != nil {
+			return errors.Wrap(err, "failed to sign proposer preferences")
+		}
+		cached = &cachedPreference{signed: &gloas.SignedProposerPreferences{
+			Message:   &preferences,
+			Signature: signature,
+		}}
+		s.cache[preferences] = cached
+	}
+
+	outcomes := s.submitter.SubmitProposerPreferences(ctx, []*gloas.SignedProposerPreferences{cached.signed})
+	if len(outcomes) == 0 {
+		return errors.New("no proposer preferences submission outcomes")
+	}
+	for _, err := range outcomes {
+		if err != nil {
+			return errors.Wrap(err, "failed to submit proposer preferences")
+		}
+	}
+	cached.published = true
+
+	return nil
+}

--- a/services/proposerpreferences/standard/service.go
+++ b/services/proposerpreferences/standard/service.go
@@ -50,10 +50,13 @@ type cachedPreference struct {
 }
 
 // New creates a standard proposer-preferences service.
-func New(_ context.Context, params ...Parameter) (*Service, error) {
+func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	parameters, err := parseAndCheckParameters(params...)
 	if err != nil {
 		return nil, errors.Wrap(err, "problem with parameters")
+	}
+	if err := registerMetrics(ctx, parameters.monitor); err != nil {
+		return nil, errors.Wrap(err, "failed to register metrics")
 	}
 
 	return &Service{
@@ -78,9 +81,29 @@ func (s *Service) ProviderReady(provider string, proposalSlot phase0.Slot, valid
 	if !exists {
 		return false
 	}
+	if provider == "simple" {
+		return cached.published
+	}
 	_, exists = cached.accepted[provider]
 
 	return exists
+}
+
+// Prune discards preferences for proposal slots that have passed.
+func (s *Service) Prune(slot phase0.Slot) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for duty := range s.current {
+		if duty.proposalSlot < slot {
+			delete(s.current, duty)
+		}
+	}
+	for preferences := range s.cache {
+		if preferences.ProposalSlot < slot {
+			delete(s.cache, preferences)
+		}
+	}
 }
 
 // Publish publishes the supplied duty's proposer preferences.
@@ -104,7 +127,12 @@ func (s *Service) Publish(ctx context.Context, duty *proposerpreferences.Duty) e
 	defer s.mutex.Unlock()
 	cached, exists := s.cache[preferences]
 	if exists && cached.published {
+		monitorProposerPreferencesProcess("replayed")
 		return nil
+	}
+	dutyKey := preferenceDuty{proposalSlot: duty.ProposalSlot, validatorIndex: duty.ValidatorIndex}
+	if current, exists := s.current[dutyKey]; exists && current != preferences {
+		monitorProposerPreferencesProcess("refreshed")
 	}
 	providers := []string(nil)
 	if !exists {
@@ -121,6 +149,7 @@ func (s *Service) Publish(ctx context.Context, duty *proposerpreferences.Duty) e
 			},
 		}
 		s.cache[preferences] = cached
+		monitorProposerPreferencesProcess("signed")
 	} else {
 		for provider, err := range cached.outcomes {
 			if err != nil {
@@ -128,7 +157,7 @@ func (s *Service) Publish(ctx context.Context, duty *proposerpreferences.Duty) e
 			}
 		}
 	}
-	s.current[preferenceDuty{proposalSlot: duty.ProposalSlot, validatorIndex: duty.ValidatorIndex}] = preferences
+	s.current[dutyKey] = preferences
 
 	outcomes := s.submitter.SubmitProposerPreferences(ctx, []*gloas.SignedProposerPreferences{cached.signed}, providers)
 	if len(outcomes) == 0 {
@@ -139,12 +168,14 @@ func (s *Service) Publish(ctx context.Context, duty *proposerpreferences.Duty) e
 		cached.outcomes[provider] = err
 		if err != nil {
 			delete(cached.accepted, provider)
+			monitorProposerPreferencesProcess("rejected")
 			if submissionErr == nil {
 				submissionErr = err
 			}
 			continue
 		}
 		cached.accepted[provider] = struct{}{}
+		monitorProposerPreferencesProcess("accepted")
 	}
 	if submissionErr != nil {
 		return errors.Wrap(submissionErr, "failed to submit proposer preferences")

--- a/services/proposerpreferences/standard/service_test.go
+++ b/services/proposerpreferences/standard/service_test.go
@@ -66,6 +66,52 @@ func TestPublishSignsAndSubmitsEachDistinctPreferenceOnce(t *testing.T) {
 	require.Same(t, signer.preferences[0], submitter.preferences[0][0].Message)
 }
 
+func TestProviderReadyAfterAcceptedSubmission(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	submitter := &recordingSubmitter{outcomes: map[string]error{"accepted": nil, "rejected": context.DeadlineExceeded}}
+	service, err := standard.New(ctx,
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithSigner(&recordingSigner{signature: phase0.BLSSignature{0x01}}),
+		standard.WithSubmitter(submitter),
+	)
+	require.NoError(t, err)
+
+	err = service.Publish(ctx, proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		64,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		30_000_000,
+	))
+	require.EqualError(t, err, "failed to submit proposer preferences: context deadline exceeded")
+	require.True(t, service.ProviderReady("accepted", 64, 3))
+	require.False(t, service.ProviderReady("rejected", 64, 3))
+}
+
+func TestPublishRetriesOnlyRejectedProvider(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	submitter := &recordingSubmitter{outcomeSets: []map[string]error{
+		{"accepted": nil, "rejected": context.DeadlineExceeded},
+		{"rejected": nil},
+	}}
+	service, err := standard.New(ctx,
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithSigner(&recordingSigner{signature: phase0.BLSSignature{0x01}}),
+		standard.WithSubmitter(submitter),
+	)
+	require.NoError(t, err)
+	duty := proposerpreferences.NewDuty(phase0.Root{0x01}, 64, 3, accounts[3], bellatrix.ExecutionAddress{0x02}, 30_000_000)
+
+	require.EqualError(t, service.Publish(ctx, duty), "failed to submit proposer preferences: context deadline exceeded")
+	require.NoError(t, service.Publish(ctx, duty))
+	require.Equal(t, [][]string{nil, {"rejected"}}, submitter.providers)
+}
+
 func TestPublishRejectsMissingProviderOutcomes(t *testing.T) {
 	ctx := context.Background()
 	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
@@ -107,12 +153,21 @@ func (s *recordingSigner) SignProposerPreferences(_ context.Context,
 
 type recordingSubmitter struct {
 	preferences [][]*gloas.SignedProposerPreferences
+	providers   [][]string
 	outcomes    map[string]error
+	outcomeSets []map[string]error
 }
 
 func (s *recordingSubmitter) SubmitProposerPreferences(_ context.Context,
 	preferences []*gloas.SignedProposerPreferences,
+	providers []string,
 ) map[string]error {
 	s.preferences = append(s.preferences, preferences)
+	s.providers = append(s.providers, providers)
+	if len(s.outcomeSets) > 0 {
+		outcomes := s.outcomeSets[0]
+		s.outcomeSets = s.outcomeSets[1:]
+		return outcomes
+	}
 	return s.outcomes
 }

--- a/services/proposerpreferences/standard/service_test.go
+++ b/services/proposerpreferences/standard/service_test.go
@@ -1,0 +1,118 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/proposerpreferences"
+	"github.com/attestantio/vouch/services/proposerpreferences/standard"
+	"github.com/attestantio/vouch/testutil"
+	"github.com/stretchr/testify/require"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+func TestPublishSignsAndSubmitsEachDistinctPreferenceOnce(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	signer := &recordingSigner{signature: phase0.BLSSignature{0x01}}
+	submitter := &recordingSubmitter{outcomes: map[string]error{"one": nil, "two": nil}}
+	service, err := standard.New(ctx,
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithSigner(signer),
+		standard.WithSubmitter(submitter),
+	)
+	require.NoError(t, err)
+
+	duty := proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		64,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		30_000_000,
+	)
+
+	require.NoError(t, service.Publish(ctx, duty))
+	require.NoError(t, service.Publish(ctx, duty))
+
+	require.Len(t, signer.preferences, 1)
+	require.Equal(t, &gloas.ProposerPreferences{
+		DependentRoot:  phase0.Root{0x01},
+		ProposalSlot:   64,
+		ValidatorIndex: 3,
+		FeeRecipient:   bellatrix.ExecutionAddress{0x02},
+		TargetGasLimit: 30_000_000,
+	}, signer.preferences[0])
+	require.Len(t, submitter.preferences, 1)
+	require.Equal(t, signer.signature, submitter.preferences[0][0].Signature)
+	require.Same(t, signer.preferences[0], submitter.preferences[0][0].Message)
+}
+
+func TestPublishRejectsMissingProviderOutcomes(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	service, err := standard.New(ctx,
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithSigner(&recordingSigner{}),
+		standard.WithSubmitter(&recordingSubmitter{}),
+	)
+	require.NoError(t, err)
+
+	err = service.Publish(ctx, proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		64,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		30_000_000,
+	))
+
+	require.EqualError(t, err, "no proposer preferences submission outcomes")
+}
+
+type recordingSigner struct {
+	preferences []*gloas.ProposerPreferences
+	signature   phase0.BLSSignature
+}
+
+func (s *recordingSigner) SignProposerPreferences(_ context.Context,
+	_ e2wtypes.Account,
+	preferences *gloas.ProposerPreferences,
+) (
+	phase0.BLSSignature,
+	error,
+) {
+	s.preferences = append(s.preferences, preferences)
+	return s.signature, nil
+}
+
+type recordingSubmitter struct {
+	preferences [][]*gloas.SignedProposerPreferences
+	outcomes    map[string]error
+}
+
+func (s *recordingSubmitter) SubmitProposerPreferences(_ context.Context,
+	preferences []*gloas.SignedProposerPreferences,
+) map[string]error {
+	s.preferences = append(s.preferences, preferences)
+	return s.outcomes
+}

--- a/services/proposerpreferences/standard/service_test.go
+++ b/services/proposerpreferences/standard/service_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/attestantio/vouch/services/proposerpreferences"
 	"github.com/attestantio/vouch/services/proposerpreferences/standard"
 	"github.com/attestantio/vouch/testutil"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
 )
@@ -91,6 +92,55 @@ func TestProviderReadyAfterAcceptedSubmission(t *testing.T) {
 	require.False(t, service.ProviderReady("rejected", 64, 3))
 }
 
+func TestSimpleProviderReadyAfterAllPreferencesAccepted(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	service, err := standard.New(ctx,
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithSigner(&recordingSigner{signature: phase0.BLSSignature{0x01}}),
+		standard.WithSubmitter(&recordingSubmitter{outcomes: map[string]error{"one": nil, "two": nil}}),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, service.Publish(ctx, proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		64,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		30_000_000,
+	)))
+
+	require.True(t, service.ProviderReady("simple", 64, 3))
+}
+
+func TestPruneDropsExpiredPreferences(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	service, err := standard.New(ctx,
+		standard.WithMonitor(nullmetrics.New()),
+		standard.WithSigner(&recordingSigner{signature: phase0.BLSSignature{0x01}}),
+		standard.WithSubmitter(&recordingSubmitter{outcomes: map[string]error{"accepted": nil}}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, service.Publish(ctx, proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		64,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		30_000_000,
+	)))
+	pruner, ok := any(service).(interface{ Prune(phase0.Slot) })
+	require.True(t, ok)
+
+	pruner.Prune(65)
+
+	require.False(t, service.ProviderReady("accepted", 64, 3))
+}
+
 func TestPublishRetriesOnlyRejectedProvider(t *testing.T) {
 	ctx := context.Background()
 	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
@@ -110,6 +160,91 @@ func TestPublishRetriesOnlyRejectedProvider(t *testing.T) {
 	require.EqualError(t, service.Publish(ctx, duty), "failed to submit proposer preferences: context deadline exceeded")
 	require.NoError(t, service.Publish(ctx, duty))
 	require.Equal(t, [][]string{nil, {"rejected"}}, submitter.providers)
+}
+
+func TestPublishRecordsProviderOutcomes(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	service, err := standard.New(ctx,
+		standard.WithMonitor(prometheusMonitor{}),
+		standard.WithSigner(&recordingSigner{signature: phase0.BLSSignature{0x01}}),
+		standard.WithSubmitter(&recordingSubmitter{outcomes: map[string]error{"accepted": nil, "rejected": context.DeadlineExceeded}}),
+	)
+	require.NoError(t, err)
+	before := proposerPreferencesEventCounts(t)
+
+	err = service.Publish(ctx, proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		64,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		30_000_000,
+	))
+
+	require.EqualError(t, err, "failed to submit proposer preferences: context deadline exceeded")
+	require.Equal(t, before["signed"]+1, proposerPreferencesEventCounts(t)["signed"])
+	require.Equal(t, before["accepted"]+1, proposerPreferencesEventCounts(t)["accepted"])
+	require.Equal(t, before["rejected"]+1, proposerPreferencesEventCounts(t)["rejected"])
+}
+
+func TestPublishRecordsPreferenceReplay(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	service, err := standard.New(ctx,
+		standard.WithMonitor(prometheusMonitor{}),
+		standard.WithSigner(&recordingSigner{signature: phase0.BLSSignature{0x01}}),
+		standard.WithSubmitter(&recordingSubmitter{outcomes: map[string]error{"accepted": nil}}),
+	)
+	require.NoError(t, err)
+	duty := proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		64,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		30_000_000,
+	)
+	replayedBefore := proposerPreferencesEventCounts(t)["replayed"]
+
+	require.NoError(t, service.Publish(ctx, duty))
+	require.NoError(t, service.Publish(ctx, duty))
+
+	require.Equal(t, replayedBefore+1, proposerPreferencesEventCounts(t)["replayed"])
+}
+
+func TestPublishRecordsPreferenceRefresh(t *testing.T) {
+	ctx := context.Background()
+	accounts, err := testutil.CreateTestWalletAndAccounts([]phase0.ValidatorIndex{3}, "0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+	require.NoError(t, err)
+	service, err := standard.New(ctx,
+		standard.WithMonitor(prometheusMonitor{}),
+		standard.WithSigner(&recordingSigner{signature: phase0.BLSSignature{0x01}}),
+		standard.WithSubmitter(&recordingSubmitter{outcomes: map[string]error{"accepted": nil}}),
+	)
+	require.NoError(t, err)
+	refreshedBefore := proposerPreferencesEventCounts(t)["refreshed"]
+
+	require.NoError(t, service.Publish(ctx, proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		64,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		30_000_000,
+	)))
+	require.NoError(t, service.Publish(ctx, proposerpreferences.NewDuty(
+		phase0.Root{0x01},
+		64,
+		3,
+		accounts[3],
+		bellatrix.ExecutionAddress{0x02},
+		31_000_000,
+	)))
+
+	require.Equal(t, refreshedBefore+1, proposerPreferencesEventCounts(t)["refreshed"])
 }
 
 func TestPublishRejectsMissingProviderOutcomes(t *testing.T) {
@@ -133,6 +268,34 @@ func TestPublishRejectsMissingProviderOutcomes(t *testing.T) {
 	))
 
 	require.EqualError(t, err, "no proposer preferences submission outcomes")
+}
+
+func proposerPreferencesEventCounts(t *testing.T) map[string]float64 {
+	t.Helper()
+
+	eventCounts := make(map[string]float64)
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range metricFamilies {
+		if family.GetName() != "vouch_proposerpreferences_process_events_total" {
+			continue
+		}
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				if label.GetName() == "outcome" {
+					eventCounts[label.GetValue()] = metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+
+	return eventCounts
+}
+
+type prometheusMonitor struct{}
+
+func (prometheusMonitor) Presenter() string {
+	return "prometheus"
 }
 
 type recordingSigner struct {

--- a/services/signer/service.go
+++ b/services/signer/service.go
@@ -27,6 +27,17 @@ import (
 // Service is the generic signer service.
 type Service interface{}
 
+// ProposerPreferencesSigner provides methods to sign proposer preferences.
+type ProposerPreferencesSigner interface {
+	SignProposerPreferences(ctx context.Context,
+		account e2wtypes.Account,
+		preferences *gloas.ProposerPreferences,
+	) (
+		phase0.BLSSignature,
+		error,
+	)
+}
+
 // PayloadAttestationDataSigner provides methods to sign payload attestation data.
 type PayloadAttestationDataSigner interface {
 	SignPayloadAttestationData(ctx context.Context,

--- a/services/signer/standard/service.go
+++ b/services/signer/standard/service.go
@@ -44,6 +44,7 @@ type Service struct {
 	blobSidecarDomainType                 *phase0.DomainType
 	beaconBuilderDomainType               *phase0.DomainType
 	ptcAttesterDomainType                 *phase0.DomainType
+	proposerPreferencesDomainType         *phase0.DomainType
 }
 
 // Module-wide log.
@@ -123,6 +124,13 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		log.Warn().Err(err).Msg("DOMAIN_PTC_ATTESTER unavailable in spec; payload attestation signing unavailable")
 	}
 
+	var proposerPreferencesDomainType *phase0.DomainType
+	if tmp, err := domainType(spec, "DOMAIN_PROPOSER_PREFERENCES"); err == nil {
+		proposerPreferencesDomainType = &tmp
+	} else {
+		log.Warn().Err(err).Msg("DOMAIN_PROPOSER_PREFERENCES unavailable in spec; proposer preferences signing unavailable")
+	}
+
 	s := &Service{
 		monitor:                               parameters.monitor,
 		clientMonitor:                         parameters.clientMonitor,
@@ -140,6 +148,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		blobSidecarDomainType:                 blobSidecarDomainType,
 		beaconBuilderDomainType:               beaconBuilderDomainType,
 		ptcAttesterDomainType:                 ptcAttesterDomainType,
+		proposerPreferencesDomainType:         proposerPreferencesDomainType,
 	}
 
 	return s, nil

--- a/services/signer/standard/signpayloadattestationdata_internal_test.go
+++ b/services/signer/standard/signpayloadattestationdata_internal_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/attestantio/vouch/mock"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/testing/logger"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
@@ -53,6 +54,24 @@ func TestSignPayloadAttestationDataUsesGenericMulti(t *testing.T) {
 	require.NotEqual(t, phase0.BLSSignature{}, sigs[0])
 	require.NotEqual(t, phase0.BLSSignature{}, sigs[1])
 	require.Len(t, batches, 1)
+}
+
+func TestSignProposerPreferencesSignsForProposalEpoch(t *testing.T) {
+	ctx := context.Background()
+	service, err := New(ctx,
+		WithLogLevel(zerolog.Disabled),
+		WithMonitor(nullmetrics.New()),
+		WithClientMonitor(nullmetrics.New()),
+		WithSpecProvider(&ptcSpecProvider{}),
+		WithDomainProvider(mock.NewDomainProvider()),
+	)
+	require.NoError(t, err)
+
+	account := &mockSignerAccount{id: uuid.New(), name: "one", pubKey: &mockPublicKey{data: []byte("one")}}
+	signature, err := service.SignProposerPreferences(ctx, account, &gloas.ProposerPreferences{ProposalSlot: 33})
+	require.NoError(t, err)
+	require.NotEqual(t, phase0.BLSSignature{}, signature)
+	require.Equal(t, 1, account.signCount)
 }
 
 func TestNewWarnsWhenPTCAttesterDomainUnavailable(t *testing.T) {
@@ -93,12 +112,13 @@ type ptcSpecProvider struct{}
 
 func (*ptcSpecProvider) Spec(_ context.Context, _ *api.SpecOpts) (*api.Response[map[string]any], error) {
 	return &api.Response[map[string]any]{Data: map[string]any{
-		"SLOTS_PER_EPOCH":            uint64(32),
-		"DOMAIN_BEACON_ATTESTER":     phase0.DomainType{0x01},
-		"DOMAIN_BEACON_PROPOSER":     phase0.DomainType{0x02},
-		"DOMAIN_RANDAO":              phase0.DomainType{0x03},
-		"DOMAIN_SELECTION_PROOF":     phase0.DomainType{0x04},
-		"DOMAIN_AGGREGATE_AND_PROOF": phase0.DomainType{0x05},
-		"DOMAIN_PTC_ATTESTER":        phase0.DomainType{0x0c},
+		"SLOTS_PER_EPOCH":             uint64(32),
+		"DOMAIN_BEACON_ATTESTER":      phase0.DomainType{0x01},
+		"DOMAIN_BEACON_PROPOSER":      phase0.DomainType{0x02},
+		"DOMAIN_RANDAO":               phase0.DomainType{0x03},
+		"DOMAIN_SELECTION_PROOF":      phase0.DomainType{0x04},
+		"DOMAIN_AGGREGATE_AND_PROOF":  phase0.DomainType{0x05},
+		"DOMAIN_PTC_ATTESTER":         phase0.DomainType{0x0c},
+		"DOMAIN_PROPOSER_PREFERENCES": phase0.DomainType{0x0d},
 	}}, nil
 }

--- a/services/signer/standard/signproposerpreferences.go
+++ b/services/signer/standard/signproposerpreferences.go
@@ -1,0 +1,56 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+)
+
+// SignProposerPreferences signs proposer preferences.
+func (s *Service) SignProposerPreferences(ctx context.Context,
+	account e2wtypes.Account,
+	preferences *gloas.ProposerPreferences,
+) (
+	phase0.BLSSignature,
+	error,
+) {
+	if preferences == nil {
+		return phase0.BLSSignature{}, errors.New("no proposer preferences supplied")
+	}
+	if s.proposerPreferencesDomainType == nil {
+		return phase0.BLSSignature{}, errors.New("DOMAIN_PROPOSER_PREFERENCES unavailable in beacon node spec; cannot sign proposer preferences")
+	}
+
+	root, err := preferences.HashTreeRoot()
+	if err != nil {
+		return phase0.BLSSignature{}, errors.Wrap(err, "failed to calculate proposer preferences hash tree root")
+	}
+	domain, err := s.domainProvider.Domain(ctx,
+		*s.proposerPreferencesDomainType,
+		phase0.Epoch(preferences.ProposalSlot/s.slotsPerEpoch))
+	if err != nil {
+		return phase0.BLSSignature{}, errors.Wrap(err, "failed to obtain signature domain for proposer preferences")
+	}
+	signature, err := s.sign(ctx, account, root, domain)
+	if err != nil {
+		return phase0.BLSSignature{}, errors.Wrap(err, "failed to sign proposer preferences")
+	}
+
+	return signature, nil
+}

--- a/services/submitter/immediate/parameters.go
+++ b/services/submitter/immediate/parameters.go
@@ -37,6 +37,7 @@ type parameters struct {
 	syncCommitteeContributionsSubmitter   eth2client.SyncCommitteeContributionsSubmitter
 	payloadAttestationMessagesSubmitter   submitter.PayloadAttestationMessagesSubmitter
 	proposerPreferencesSubmitter          eth2client.ProposerPreferencesSubmitter
+	proposerPreferencesSubmitters         map[string]eth2client.ProposerPreferencesSubmitter
 }
 
 // Parameter is the interface for service parameters.
@@ -138,6 +139,13 @@ func WithPayloadAttestationMessagesSubmitter(submitter submitter.PayloadAttestat
 func WithProposerPreferencesSubmitter(submitter eth2client.ProposerPreferencesSubmitter) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.proposerPreferencesSubmitter = submitter
+	})
+}
+
+// WithProposerPreferencesSubmitters sets the proposer preferences submitters.
+func WithProposerPreferencesSubmitters(submitters map[string]eth2client.ProposerPreferencesSubmitter) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.proposerPreferencesSubmitters = submitters
 	})
 }
 

--- a/services/submitter/immediate/parameters.go
+++ b/services/submitter/immediate/parameters.go
@@ -36,6 +36,7 @@ type parameters struct {
 	syncCommitteeSubscriptionsSubmitter   eth2client.SyncCommitteeSubscriptionsSubmitter
 	syncCommitteeContributionsSubmitter   eth2client.SyncCommitteeContributionsSubmitter
 	payloadAttestationMessagesSubmitter   submitter.PayloadAttestationMessagesSubmitter
+	proposerPreferencesSubmitter          eth2client.ProposerPreferencesSubmitter
 }
 
 // Parameter is the interface for service parameters.
@@ -130,6 +131,13 @@ func WithProposalPreparationsSubmitter(submitter eth2client.ProposalPreparations
 func WithPayloadAttestationMessagesSubmitter(submitter submitter.PayloadAttestationMessagesSubmitter) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.payloadAttestationMessagesSubmitter = submitter
+	})
+}
+
+// WithProposerPreferencesSubmitter sets the proposer preferences submitter.
+func WithProposerPreferencesSubmitter(submitter eth2client.ProposerPreferencesSubmitter) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.proposerPreferencesSubmitter = submitter
 	})
 }
 

--- a/services/submitter/immediate/service.go
+++ b/services/submitter/immediate/service.go
@@ -16,6 +16,7 @@ package immediate
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
@@ -81,7 +82,7 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 }
 
 // SubmitProposerPreferences submits signed proposer preferences to the configured beacon node.
-func (s *Service) SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences) map[string]error {
+func (s *Service) SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences, providers []string) map[string]error {
 	if s.proposerPreferencesSubmitter == nil {
 		return map[string]error{"<unknown>": errors.New("no proposer preferences submitter configured")}
 	}
@@ -89,6 +90,9 @@ func (s *Service) SubmitProposerPreferences(ctx context.Context, preferences []*
 	address := "<unknown>"
 	if service, isService := s.proposerPreferencesSubmitter.(eth2client.Service); isService {
 		address = service.Address()
+	}
+	if len(providers) > 0 && !slices.Contains(providers, address) {
+		return map[string]error{}
 	}
 	started := time.Now()
 	err := s.proposerPreferencesSubmitter.SubmitProposerPreferences(ctx, preferences)

--- a/services/submitter/immediate/service.go
+++ b/services/submitter/immediate/service.go
@@ -47,6 +47,7 @@ type Service struct {
 	syncCommitteeContributionsSubmitter   eth2client.SyncCommitteeContributionsSubmitter
 	payloadAttestationMessagesSubmitter   submitter.PayloadAttestationMessagesSubmitter
 	proposerPreferencesSubmitter          eth2client.ProposerPreferencesSubmitter
+	proposerPreferencesSubmitters         map[string]eth2client.ProposerPreferencesSubmitter
 }
 
 // New creates a new submitter.
@@ -76,6 +77,7 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 		syncCommitteeContributionsSubmitter:   parameters.syncCommitteeContributionsSubmitter,
 		payloadAttestationMessagesSubmitter:   parameters.payloadAttestationMessagesSubmitter,
 		proposerPreferencesSubmitter:          parameters.proposerPreferencesSubmitter,
+		proposerPreferencesSubmitters:         parameters.proposerPreferencesSubmitters,
 	}
 
 	return s, nil
@@ -83,6 +85,19 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 
 // SubmitProposerPreferences submits signed proposer preferences to the configured beacon node.
 func (s *Service) SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences, providers []string) map[string]error {
+	if len(s.proposerPreferencesSubmitters) > 0 {
+		outcomes := make(map[string]error, len(s.proposerPreferencesSubmitters))
+		for address, submitter := range s.proposerPreferencesSubmitters {
+			if len(providers) > 0 && !slices.Contains(providers, address) {
+				continue
+			}
+			started := time.Now()
+			err := submitter.SubmitProposerPreferences(ctx, preferences)
+			s.clientMonitor.ClientOperation(address, "submit proposer preferences", err == nil, time.Since(started))
+			outcomes[address] = err
+		}
+		return outcomes
+	}
 	if s.proposerPreferencesSubmitter == nil {
 		return map[string]error{"<unknown>": errors.New("no proposer preferences submitter configured")}
 	}

--- a/services/submitter/immediate/service.go
+++ b/services/submitter/immediate/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/vouch/services/metrics"
 	"github.com/attestantio/vouch/services/submitter"
 	"github.com/pkg/errors"
@@ -44,6 +45,7 @@ type Service struct {
 	syncCommitteeSubscriptionsSubmitter   eth2client.SyncCommitteeSubscriptionsSubmitter
 	syncCommitteeContributionsSubmitter   eth2client.SyncCommitteeContributionsSubmitter
 	payloadAttestationMessagesSubmitter   submitter.PayloadAttestationMessagesSubmitter
+	proposerPreferencesSubmitter          eth2client.ProposerPreferencesSubmitter
 }
 
 // New creates a new submitter.
@@ -72,9 +74,30 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 		syncCommitteeSubscriptionsSubmitter:   parameters.syncCommitteeSubscriptionsSubmitter,
 		syncCommitteeContributionsSubmitter:   parameters.syncCommitteeContributionsSubmitter,
 		payloadAttestationMessagesSubmitter:   parameters.payloadAttestationMessagesSubmitter,
+		proposerPreferencesSubmitter:          parameters.proposerPreferencesSubmitter,
 	}
 
 	return s, nil
+}
+
+// SubmitProposerPreferences submits signed proposer preferences to the configured beacon node.
+func (s *Service) SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences) map[string]error {
+	if s.proposerPreferencesSubmitter == nil {
+		return map[string]error{"<unknown>": errors.New("no proposer preferences submitter configured")}
+	}
+
+	address := "<unknown>"
+	if service, isService := s.proposerPreferencesSubmitter.(eth2client.Service); isService {
+		address = service.Address()
+	}
+	started := time.Now()
+	err := s.proposerPreferencesSubmitter.SubmitProposerPreferences(ctx, preferences)
+	s.clientMonitor.ClientOperation(address, "submit proposer preferences", err == nil, time.Since(started))
+	if err != nil {
+		s.log.Warn().Err(err).Msg("Failed to submit proposer preferences")
+	}
+
+	return map[string]error{address: err}
 }
 
 // SubmitProposal submits a proposal.

--- a/services/submitter/immediate/service_test.go
+++ b/services/submitter/immediate/service_test.go
@@ -22,6 +22,7 @@ import (
 	mockconsensusclient "github.com/attestantio/go-eth2-client/mock"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/vouch/mock"
 	"github.com/attestantio/vouch/services/submitter"
 	"github.com/attestantio/vouch/services/submitter/immediate"
@@ -253,6 +254,47 @@ func TestInterfaces(t *testing.T) {
 	require.Implements(t, (*submitter.SyncCommitteeMessagesSubmitter)(nil), s)
 	require.Implements(t, (*submitter.SyncCommitteeSubscriptionsSubmitter)(nil), s)
 	require.Implements(t, (*submitter.SyncCommitteeContributionsSubmitter)(nil), s)
+	require.Implements(t, (*submitter.ProposerPreferencesSubmitter)(nil), s)
+}
+
+func TestSubmitProposerPreferences(t *testing.T) {
+	ctx := context.Background()
+	preferencesSubmitter := &recordingProposerPreferencesSubmitter{}
+	service, err := newTestService(ctx,
+		immediate.WithLogLevel(zerolog.Disabled),
+		immediate.WithAttestationsSubmitter(mock.NewAttestationsSubmitter()),
+		immediate.WithProposalSubmitter(mock.NewProposalSubmitter()),
+		immediate.WithBeaconCommitteeSubscriptionsSubmitter(mock.NewBeaconCommitteeSubscriptionsSubmitter()),
+		immediate.WithAggregateAttestationsSubmitter(mock.NewAggregateAttestationsSubmitter()),
+		immediate.WithProposalPreparationsSubmitter(mock.NewProposalPreparationsSubmitter()),
+		immediate.WithSyncCommitteeSubscriptionsSubmitter(mock.NewSyncCommitteeSubscriptionsSubmitter()),
+		immediate.WithSyncCommitteeMessagesSubmitter(mock.NewSyncCommitteeMessagesSubmitter()),
+		immediate.WithSyncCommitteeContributionsSubmitter(mock.NewSyncCommitteeContributionsSubmitter()),
+		immediate.WithProposerPreferencesSubmitter(preferencesSubmitter),
+	)
+	require.NoError(t, err)
+
+	preferences := []*gloas.SignedProposerPreferences{{}}
+
+	require.Equal(t, map[string]error{"test": nil}, service.SubmitProposerPreferences(ctx, preferences))
+	require.Equal(t, preferences, preferencesSubmitter.preferences)
+}
+
+type recordingProposerPreferencesSubmitter struct {
+	preferences []*gloas.SignedProposerPreferences
+}
+
+func (s *recordingProposerPreferencesSubmitter) Name() string { return "test" }
+
+func (s *recordingProposerPreferencesSubmitter) Address() string { return "test" }
+
+func (s *recordingProposerPreferencesSubmitter) IsActive() bool { return true }
+
+func (s *recordingProposerPreferencesSubmitter) IsSynced() bool { return true }
+
+func (s *recordingProposerPreferencesSubmitter) SubmitProposerPreferences(_ context.Context, preferences []*gloas.SignedProposerPreferences) error {
+	s.preferences = preferences
+	return nil
 }
 
 func TestSubmitProposal(t *testing.T) {

--- a/services/submitter/immediate/service_test.go
+++ b/services/submitter/immediate/service_test.go
@@ -276,7 +276,7 @@ func TestSubmitProposerPreferences(t *testing.T) {
 
 	preferences := []*gloas.SignedProposerPreferences{{}}
 
-	require.Equal(t, map[string]error{"test": nil}, service.SubmitProposerPreferences(ctx, preferences))
+	require.Equal(t, map[string]error{"test": nil}, service.SubmitProposerPreferences(ctx, preferences, nil))
 	require.Equal(t, preferences, preferencesSubmitter.preferences)
 }
 

--- a/services/submitter/multinode/parameters.go
+++ b/services/submitter/multinode/parameters.go
@@ -41,6 +41,7 @@ type parameters struct {
 	syncCommitteeSubscriptionsSubmitters   map[string]eth2client.SyncCommitteeSubscriptionsSubmitter
 	syncCommitteeContributionsSubmitters   map[string]eth2client.SyncCommitteeContributionsSubmitter
 	payloadAttestationMessagesSubmitters   map[string]submitter.PayloadAttestationMessagesSubmitter
+	proposerPreferencesSubmitters          map[string]eth2client.ProposerPreferencesSubmitter
 }
 
 // Parameter is the interface for service parameters.
@@ -121,6 +122,13 @@ func WithProposalPreparationsSubmitters(submitters map[string]eth2client.Proposa
 func WithPayloadAttestationMessagesSubmitters(submitters map[string]submitter.PayloadAttestationMessagesSubmitter) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.payloadAttestationMessagesSubmitters = submitters
+	})
+}
+
+// WithProposerPreferencesSubmitters sets the proposer preferences submitters.
+func WithProposerPreferencesSubmitters(submitters map[string]eth2client.ProposerPreferencesSubmitter) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.proposerPreferencesSubmitters = submitters
 	})
 }
 

--- a/services/submitter/multinode/service.go
+++ b/services/submitter/multinode/service.go
@@ -41,6 +41,7 @@ type Service struct {
 	syncCommitteeSubscriptionSubmitters   map[string]eth2client.SyncCommitteeSubscriptionsSubmitter
 	syncCommitteeContributionsSubmitters  map[string]eth2client.SyncCommitteeContributionsSubmitter
 	payloadAttestationMessagesSubmitters  map[string]submitter.PayloadAttestationMessagesSubmitter
+	proposerPreferencesSubmitters         map[string]eth2client.ProposerPreferencesSubmitter
 }
 
 // New creates a new multinode submitter.
@@ -71,6 +72,7 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 		syncCommitteeSubscriptionSubmitters:   parameters.syncCommitteeSubscriptionsSubmitters,
 		syncCommitteeContributionsSubmitters:  parameters.syncCommitteeContributionsSubmitters,
 		payloadAttestationMessagesSubmitters:  parameters.payloadAttestationMessagesSubmitters,
+		proposerPreferencesSubmitters:         parameters.proposerPreferencesSubmitters,
 	}
 	log.Trace().Int64("process_concurrency", s.processConcurrency).Msg("Set process concurrency")
 

--- a/services/submitter/multinode/submitpayloadattestationmessages_test.go
+++ b/services/submitter/multinode/submitpayloadattestationmessages_test.go
@@ -57,7 +57,7 @@ func TestSubmitProposerPreferencesFansOutToNodes(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	outcomes := service.SubmitProposerPreferences(ctx, []*gloas.SignedProposerPreferences{{Message: &gloas.ProposerPreferences{}}})
+	outcomes := service.SubmitProposerPreferences(ctx, []*gloas.SignedProposerPreferences{{Message: &gloas.ProposerPreferences{}}}, nil)
 
 	require.Equal(t, map[string]error{"one": nil, "two": nil}, outcomes)
 	require.Eventually(t, func() bool {

--- a/services/submitter/multinode/submitpayloadattestationmessages_test.go
+++ b/services/submitter/multinode/submitpayloadattestationmessages_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 	mocketh2client "github.com/attestantio/go-eth2-client/mock"
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/vouch/mock"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
 	"github.com/attestantio/vouch/services/submitter"
@@ -30,6 +31,39 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSubmitProposerPreferencesFansOutToNodes(t *testing.T) {
+	ctx := context.Background()
+	client, err := mocketh2client.New(ctx)
+	require.NoError(t, err)
+	recorderOne := &countingProposerPreferencesSubmitter{}
+	recorderTwo := &countingProposerPreferencesSubmitter{}
+
+	service, err := multinode.New(ctx,
+		multinode.WithLogLevel(zerolog.Disabled),
+		multinode.WithClientMonitor(nullmetrics.New()),
+		multinode.WithTimeout(time.Second),
+		multinode.WithProcessConcurrency(2),
+		multinode.WithProposalSubmitters(map[string]eth2client.ProposalSubmitter{"one": mock.NewProposalSubmitter()}),
+		multinode.WithExecutionPayloadEnvelopeSubmitters(map[string]eth2client.ExecutionPayloadEnvelopeSubmitter{"one": client}),
+		multinode.WithAttestationsSubmitters(map[string]eth2client.AttestationsSubmitter{"one": mock.NewAttestationsSubmitter()}),
+		multinode.WithAggregateAttestationsSubmitters(map[string]eth2client.AggregateAttestationsSubmitter{"one": mock.NewAggregateAttestationsSubmitter()}),
+		multinode.WithProposalPreparationsSubmitters(map[string]eth2client.ProposalPreparationsSubmitter{"one": mock.NewProposalPreparationsSubmitter()}),
+		multinode.WithBeaconCommitteeSubscriptionsSubmitters(map[string]eth2client.BeaconCommitteeSubscriptionsSubmitter{"one": mock.NewBeaconCommitteeSubscriptionsSubmitter()}),
+		multinode.WithSyncCommitteeMessagesSubmitters(map[string]eth2client.SyncCommitteeMessagesSubmitter{"one": mock.NewSyncCommitteeMessagesSubmitter()}),
+		multinode.WithSyncCommitteeSubscriptionsSubmitters(map[string]eth2client.SyncCommitteeSubscriptionsSubmitter{"one": mock.NewSyncCommitteeSubscriptionsSubmitter()}),
+		multinode.WithSyncCommitteeContributionsSubmitters(map[string]eth2client.SyncCommitteeContributionsSubmitter{"one": mock.NewSyncCommitteeContributionsSubmitter()}),
+		multinode.WithProposerPreferencesSubmitters(map[string]eth2client.ProposerPreferencesSubmitter{"one": recorderOne, "two": recorderTwo}),
+	)
+	require.NoError(t, err)
+
+	outcomes := service.SubmitProposerPreferences(ctx, []*gloas.SignedProposerPreferences{{Message: &gloas.ProposerPreferences{}}})
+
+	require.Equal(t, map[string]error{"one": nil, "two": nil}, outcomes)
+	require.Eventually(t, func() bool {
+		return recorderOne.calls.Load() == 1 && recorderTwo.calls.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+}
 
 func TestSubmitPayloadAttestationMessagesFansOutToNodes(t *testing.T) {
 	ctx := context.Background()
@@ -149,6 +183,15 @@ func TestSubmitPayloadAttestationMessagesReturnsOnFirstSuccess(t *testing.T) {
 		t.Fatal("in-flight submission was aborted by another node's success")
 	case <-time.After(250 * time.Millisecond):
 	}
+}
+
+type countingProposerPreferencesSubmitter struct {
+	calls atomic.Int32
+}
+
+func (s *countingProposerPreferencesSubmitter) SubmitProposerPreferences(_ context.Context, _ []*gloas.SignedProposerPreferences) error {
+	s.calls.Add(1)
+	return nil
 }
 
 type cancelAwarePayloadAttestationSubmitter struct {

--- a/services/submitter/multinode/submitproposerpreferences.go
+++ b/services/submitter/multinode/submitproposerpreferences.go
@@ -15,6 +15,7 @@ package multinode
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -25,7 +26,7 @@ import (
 )
 
 // SubmitProposerPreferences submits signed proposer preferences to every configured beacon node.
-func (s *Service) SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences) map[string]error {
+func (s *Service) SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences, providers []string) map[string]error {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.timeout)
 	defer cancel()
 
@@ -41,6 +42,9 @@ func (s *Service) SubmitProposerPreferences(ctx context.Context, preferences []*
 	var outcomesMutex sync.Mutex
 	var wg sync.WaitGroup
 	for name, submitter := range s.proposerPreferencesSubmitters {
+		if len(providers) > 0 && !slices.Contains(providers, name) {
+			continue
+		}
 		wg.Go(func() {
 			s.submitProposerPreferences(ctx, sem, &outcomesMutex, outcomes, name, preferences, submitter)
 		})

--- a/services/submitter/multinode/submitproposerpreferences.go
+++ b/services/submitter/multinode/submitproposerpreferences.go
@@ -1,0 +1,84 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multinode
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/semaphore"
+)
+
+// SubmitProposerPreferences submits signed proposer preferences to every configured beacon node.
+func (s *Service) SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences) map[string]error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.timeout)
+	defer cancel()
+
+	outcomes := make(map[string]error, len(s.proposerPreferencesSubmitters))
+	if len(preferences) == 0 {
+		for name := range s.proposerPreferencesSubmitters {
+			outcomes[name] = errors.New("no proposer preferences supplied")
+		}
+		return outcomes
+	}
+
+	sem := semaphore.NewWeighted(s.processConcurrency)
+	var outcomesMutex sync.Mutex
+	var wg sync.WaitGroup
+	for name, submitter := range s.proposerPreferencesSubmitters {
+		wg.Go(func() {
+			s.submitProposerPreferences(ctx, sem, &outcomesMutex, outcomes, name, preferences, submitter)
+		})
+	}
+	wg.Wait()
+
+	return outcomes
+}
+
+func (s *Service) submitProposerPreferences(ctx context.Context,
+	sem *semaphore.Weighted,
+	outcomesMutex *sync.Mutex,
+	outcomes map[string]error,
+	name string,
+	preferences []*gloas.SignedProposerPreferences,
+	submitter eth2client.ProposerPreferencesSubmitter,
+) {
+	log := s.log.With().Str("beacon_node_address", name).Logger()
+	if err := sem.Acquire(ctx, 1); err != nil {
+		outcomesMutex.Lock()
+		outcomes[name] = err
+		outcomesMutex.Unlock()
+		log.Warn().Err(err).Msg("Failed to acquire semaphore")
+		return
+	}
+	defer sem.Release(1)
+
+	_, address := s.serviceInfo(ctx, submitter)
+	started := time.Now()
+	err := submitter.SubmitProposerPreferences(ctx, preferences)
+	s.clientMonitor.ClientOperation(address, "submit proposer preferences", err == nil, time.Since(started))
+
+	outcomesMutex.Lock()
+	outcomes[name] = err
+	outcomesMutex.Unlock()
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to submit proposer preferences")
+		return
+	}
+	log.Trace().Msg("Submitted proposer preferences")
+}

--- a/services/submitter/proposerpreferences.go
+++ b/services/submitter/proposerpreferences.go
@@ -22,5 +22,5 @@ import (
 // ProposerPreferencesSubmitter provides one result for submitting proposer preferences to each configured provider.
 type ProposerPreferencesSubmitter interface {
 	// SubmitProposerPreferences returns an entry for each provider; nil indicates acceptance.
-	SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences) map[string]error
+	SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences, providers []string) map[string]error
 }

--- a/services/submitter/proposerpreferences.go
+++ b/services/submitter/proposerpreferences.go
@@ -1,0 +1,26 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package submitter
+
+import (
+	"context"
+
+	"github.com/attestantio/go-eth2-client/spec/gloas"
+)
+
+// ProposerPreferencesSubmitter provides one result for submitting proposer preferences to each configured provider.
+type ProposerPreferencesSubmitter interface {
+	// SubmitProposerPreferences returns an entry for each provider; nil indicates acceptance.
+	SubmitProposerPreferences(ctx context.Context, preferences []*gloas.SignedProposerPreferences) map[string]error
+}

--- a/strategies/beaconblockproposal/best/beaconblockproposal.go
+++ b/strategies/beaconblockproposal/best/beaconblockproposal.go
@@ -22,6 +22,7 @@ import (
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/vouch/services/beaconblockproposer"
 	"github.com/attestantio/vouch/util"
 	"github.com/pkg/errors"
@@ -87,7 +88,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 				Int("errored", errored).
 				Int("timed_out", timedOut).
 				Msg("Response received")
-			bestProposal, bestProvider = considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
+			bestProposal, bestProvider = s.considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
 		case err := <-errCh:
 			errored++
 			log.Debug().
@@ -129,7 +130,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 				Int("errored", errored).
 				Int("timed_out", timedOut).
 				Msg("Response received")
-			bestProposal, bestProvider = considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
+			bestProposal, bestProvider = s.considerEPBSProposal(opts, response, bestProposal, bestProvider, log)
 		case err := <-errCh:
 			errored++
 			log.Debug().
@@ -173,7 +174,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 
 // considerEPBSProposal updates the best proposal seen so far, ignoring proposals that lack a
 // requested execution payload.
-func considerEPBSProposal(opts *api.EPBSProposalOpts,
+func (s *Service) considerEPBSProposal(opts *api.EPBSProposalOpts,
 	response *beaconBlockEPBSResponse,
 	bestProposal *api.VersionedEPBSProposal,
 	bestProvider string,
@@ -183,6 +184,18 @@ func considerEPBSProposal(opts *api.EPBSProposalOpts,
 		log.Warn().Str("provider", response.provider).Msg("Discarding ePBS proposal without requested execution payload")
 
 		return bestProposal, bestProvider
+	}
+	if response.proposal.Version == spec.DataVersionGloas {
+		block := response.proposal.Gloas
+		if response.proposal.ExecutionPayloadIncluded {
+			block = response.proposal.GloasContents.Block
+		}
+		bid := block.Body.SignedExecutionPayloadBid.Message
+		if bid.BuilderIndex != gloas.BuilderIndex(^uint64(0)) && s.providerReadiness != nil && !s.providerReadiness.ProviderReady(response.provider, opts.Slot, block.ProposerIndex) {
+			log.Warn().Str("provider", response.provider).Msg("Discarding builder-backed ePBS proposal from provider without current preferences")
+
+			return bestProposal, bestProvider
+		}
 	}
 
 	if bestProposal == nil || response.proposal.Value().Cmp(bestProposal.Value()) > 0 {

--- a/strategies/beaconblockproposal/best/epbsproposal_test.go
+++ b/strategies/beaconblockproposal/best/epbsproposal_test.go
@@ -105,6 +105,36 @@ func TestEPBSProposal(t *testing.T) {
 	}
 }
 
+func TestEPBSProposalRejectsBuilderBidFromUnreadyProvider(t *testing.T) {
+	ctx := context.Background()
+	specProvider := mock.NewSpecProvider()
+	chainTime, err := standardchaintime.New(ctx,
+		standardchaintime.WithLogLevel(zerolog.Disabled),
+		standardchaintime.WithGenesisProvider(mock.NewGenesisProvider(time.Now())),
+		standardchaintime.WithSpecProvider(specProvider),
+	)
+	require.NoError(t, err)
+	cacheSvc := mockcache.New(map[phase0.Root]phase0.Slot{})
+	service, err := best.New(ctx,
+		best.WithLogLevel(zerolog.Disabled),
+		best.WithClientMonitor(nullmetrics.New()),
+		best.WithProcessConcurrency(1),
+		best.WithChainTimeService(chainTime),
+		best.WithSpecProvider(specProvider),
+		best.WithProposalProviders(map[string]beaconblockproposer.ProposalDataProvider{
+			"unready": &testEPBSProposalProvider{proposal: testGloasProposal(1, bellatrix.ExecutionAddress{0x01})},
+		}),
+		best.WithProviderReadiness(&providerReadiness{ready: false}),
+		best.WithTimeout(time.Second),
+		best.WithBlockRootToSlotCache(cacheSvc.(cache.BlockRootToSlotProvider)),
+	)
+	require.NoError(t, err)
+
+	response, err := service.EPBSProposal(ctx, &api.EPBSProposalOpts{Slot: 1})
+	require.Nil(t, response)
+	require.EqualError(t, err, "no ePBS proposals received")
+}
+
 func TestEPBSProposalReturnsIncludedCandidateAtSoftTimeout(t *testing.T) {
 	ctx := context.Background()
 	specProvider := mock.NewSpecProvider()
@@ -635,6 +665,14 @@ func TestEPBSProposalStartsProvidersWhileGraffitiClientLookupIsSlow(t *testing.T
 	}
 	close(releaseSlowProvider)
 	require.NoError(t, <-errCh)
+}
+
+type providerReadiness struct {
+	ready bool
+}
+
+func (p *providerReadiness) ProviderReady(string, phase0.Slot, phase0.ValidatorIndex) bool {
+	return p.ready
 }
 
 type testEPBSProposalProvider struct {

--- a/strategies/beaconblockproposal/best/parameters.go
+++ b/strategies/beaconblockproposal/best/parameters.go
@@ -24,6 +24,7 @@ import (
 	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/metrics"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/proposerpreferences"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -35,6 +36,7 @@ type parameters struct {
 	processConcurrency     int64
 	chainTime              chaintime.Service
 	proposalProviders      map[string]beaconblockproposer.ProposalDataProvider
+	providerReadiness      proposerpreferences.ProviderReadiness
 	timeout                time.Duration
 	blockRootToSlotCache   cache.BlockRootToSlotProvider
 	executionPayloadFactor float64
@@ -97,6 +99,13 @@ func WithSpecProvider(provider eth2client.SpecProvider) Parameter {
 func WithProposalProviders(providers map[string]beaconblockproposer.ProposalDataProvider) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.proposalProviders = providers
+	})
+}
+
+// WithProviderReadiness sets the proposer-preferences readiness provider.
+func WithProviderReadiness(provider proposerpreferences.ProviderReadiness) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.providerReadiness = provider
 	})
 }
 

--- a/strategies/beaconblockproposal/best/service.go
+++ b/strategies/beaconblockproposal/best/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/attestantio/vouch/services/cache"
 	"github.com/attestantio/vouch/services/chaintime"
 	"github.com/attestantio/vouch/services/metrics"
+	"github.com/attestantio/vouch/services/proposerpreferences"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	zerologger "github.com/rs/zerolog/log"
@@ -34,6 +35,7 @@ type Service struct {
 	processConcurrency     int64
 	chainTime              chaintime.Service
 	proposalProviders      map[string]beaconblockproposer.ProposalDataProvider
+	providerReadiness      proposerpreferences.ProviderReadiness
 	timeout                time.Duration
 	blockRootToSlotCache   cache.BlockRootToSlotProvider
 	executionPayloadFactor float64
@@ -85,6 +87,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		processConcurrency:     parameters.processConcurrency,
 		chainTime:              parameters.chainTime,
 		proposalProviders:      parameters.proposalProviders,
+		providerReadiness:      parameters.providerReadiness,
 		timeout:                parameters.timeout,
 		blockRootToSlotCache:   parameters.blockRootToSlotCache,
 		clientMonitor:          parameters.clientMonitor,

--- a/strategies/beaconblockproposal/first/epbsproposal_test.go
+++ b/strategies/beaconblockproposal/first/epbsproposal_test.go
@@ -81,6 +81,44 @@ func TestEPBSProposalDoesNotLeaveLateProvidersBlocked(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestEPBSProposalSkipsBuilderBidFromUnreadyProvider(t *testing.T) {
+	ctx := context.Background()
+	service, err := first.New(ctx,
+		first.WithLogLevel(zerolog.Disabled),
+		first.WithClientMonitor(nullmetrics.New()),
+		first.WithProposalProviders(map[string]beaconblockproposer.ProposalDataProvider{
+			"unready": &epbsProposalProvider{proposal: gloasEPBSProposal(bellatrix.ExecutionAddress{0x01})},
+		}),
+		first.WithProviderReadiness(&providerReadiness{ready: false}),
+		first.WithTimeout(10*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	response, err := service.EPBSProposal(ctx, &api.EPBSProposalOpts{Slot: 1})
+	require.Nil(t, response)
+	require.EqualError(t, err, "failed to obtain ePBS beacon block proposal before timeout")
+}
+
+func TestEPBSProposalAcceptsSelfBuiltProposalFromUnreadyProvider(t *testing.T) {
+	ctx := context.Background()
+	proposal := gloasEPBSProposal(bellatrix.ExecutionAddress{0x01})
+	proposal.GloasContents.Block.Body.SignedExecutionPayloadBid.Message.BuilderIndex = gloas.BuilderIndex(^uint64(0))
+	service, err := first.New(ctx,
+		first.WithLogLevel(zerolog.Disabled),
+		first.WithClientMonitor(nullmetrics.New()),
+		first.WithProposalProviders(map[string]beaconblockproposer.ProposalDataProvider{
+			"unready": &epbsProposalProvider{proposal: proposal},
+		}),
+		first.WithProviderReadiness(&providerReadiness{ready: false}),
+		first.WithTimeout(time.Second),
+	)
+	require.NoError(t, err)
+
+	response, err := service.EPBSProposal(ctx, &api.EPBSProposalOpts{Slot: 1})
+	require.NoError(t, err)
+	require.Same(t, proposal, response.Data)
+}
+
 func TestEPBSProposalSkipsProposalWithoutRequestedPayload(t *testing.T) {
 	ctx := context.Background()
 	includePayload := true
@@ -249,6 +287,14 @@ func gloasEPBSProposal(feeRecipient bellatrix.ExecutionAddress) *api.VersionedEP
 			},
 		},
 	}
+}
+
+type providerReadiness struct {
+	ready bool
+}
+
+func (p *providerReadiness) ProviderReady(string, phase0.Slot, phase0.ValidatorIndex) bool {
+	return p.ready
 }
 
 type epbsProposalProvider struct {

--- a/strategies/beaconblockproposal/first/parameters.go
+++ b/strategies/beaconblockproposal/first/parameters.go
@@ -21,6 +21,7 @@ import (
 	"github.com/attestantio/vouch/services/beaconblockproposer"
 	"github.com/attestantio/vouch/services/metrics"
 	nullmetrics "github.com/attestantio/vouch/services/metrics/null"
+	"github.com/attestantio/vouch/services/proposerpreferences"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -29,6 +30,7 @@ type parameters struct {
 	logLevel          zerolog.Level
 	clientMonitor     metrics.ClientMonitor
 	proposalProviders map[string]beaconblockproposer.ProposalDataProvider
+	providerReadiness proposerpreferences.ProviderReadiness
 	timeout           time.Duration
 }
 
@@ -61,6 +63,13 @@ func WithClientMonitor(monitor metrics.ClientMonitor) Parameter {
 func WithProposalProviders(providers map[string]beaconblockproposer.ProposalDataProvider) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.proposalProviders = providers
+	})
+}
+
+// WithProviderReadiness sets the proposer-preferences readiness provider.
+func WithProviderReadiness(provider proposerpreferences.ProviderReadiness) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.providerReadiness = provider
 	})
 }
 

--- a/strategies/beaconblockproposal/first/service.go
+++ b/strategies/beaconblockproposal/first/service.go
@@ -20,8 +20,10 @@ import (
 	eth2client "github.com/attestantio/go-eth2-client"
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/gloas"
 	"github.com/attestantio/vouch/services/beaconblockproposer"
 	"github.com/attestantio/vouch/services/metrics"
+	"github.com/attestantio/vouch/services/proposerpreferences"
 	"github.com/attestantio/vouch/util"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -36,6 +38,7 @@ type Service struct {
 	log               zerolog.Logger
 	clientMonitor     metrics.ClientMonitor
 	proposalProviders map[string]beaconblockproposer.ProposalDataProvider
+	providerReadiness proposerpreferences.ProviderReadiness
 	timeout           time.Duration
 }
 
@@ -53,7 +56,7 @@ func (s *Service) EPBSProposal(ctx context.Context,
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 
-	proposalCh := make(chan *api.VersionedEPBSProposal, len(s.proposalProviders))
+	proposalCh := make(chan *epbsProposalResponse, len(s.proposalProviders))
 	for name, provider := range s.proposalProviders {
 		go s.fetchEPBSProposal(ctx, name, provider, opts, proposalCh)
 	}
@@ -64,14 +67,14 @@ func (s *Service) EPBSProposal(ctx context.Context,
 			cancel()
 			s.log.Debug().Msg("Failed to obtain ePBS beacon block proposal before timeout")
 			return nil, errors.New("failed to obtain ePBS beacon block proposal before timeout")
-		case proposal := <-proposalCh:
-			if !s.acceptableEPBSProposal(proposal, opts.IncludePayload) {
+		case response := <-proposalCh:
+			if !s.acceptableEPBSProposal(response.provider, response.proposal, opts) {
 				continue
 			}
 			cancel()
 
 			return &api.Response[*api.VersionedEPBSProposal]{
-				Data:     proposal,
+				Data:     response.proposal,
 				Metadata: make(map[string]any),
 			}, nil
 		}
@@ -84,7 +87,7 @@ func (s *Service) fetchEPBSProposal(ctx context.Context,
 	name string,
 	provider beaconblockproposer.ProposalDataProvider,
 	opts *api.EPBSProposalOpts,
-	ch chan *api.VersionedEPBSProposal,
+	ch chan *epbsProposalResponse,
 ) {
 	log := s.log.With().Str("provider", name).Uint64("slot", uint64(opts.Slot)).Logger()
 
@@ -107,21 +110,26 @@ func (s *Service) fetchEPBSProposal(ctx context.Context,
 	log.Trace().Dur("elapsed", time.Since(started)).Msg("Obtained ePBS beacon block proposal")
 
 	select {
-	case ch <- proposal:
+	case ch <- &epbsProposalResponse{provider: name, proposal: proposal}:
 	case <-ctx.Done():
 	}
 }
 
+type epbsProposalResponse struct {
+	provider string
+	proposal *api.VersionedEPBSProposal
+}
+
 // acceptableEPBSProposal reports whether proposal is usable, discarding and logging it if it is
-// nil, lacks a requested execution payload, or (for Gloas) is structurally malformed or pays a
-// zero fee recipient.
-func (s *Service) acceptableEPBSProposal(proposal *api.VersionedEPBSProposal, includePayload *bool) bool {
+// nil, lacks a requested execution payload, comes from an unready builder provider, or (for Gloas)
+// is structurally malformed or pays a zero fee recipient.
+func (s *Service) acceptableEPBSProposal(provider string, proposal *api.VersionedEPBSProposal, opts *api.EPBSProposalOpts) bool {
 	if proposal == nil {
 		s.log.Warn().Msg("Discarding empty ePBS proposal")
 
 		return false
 	}
-	if includePayload != nil && *includePayload && !proposal.ExecutionPayloadIncluded {
+	if opts.IncludePayload != nil && *opts.IncludePayload && !proposal.ExecutionPayloadIncluded {
 		s.log.Warn().Msg("Discarding ePBS proposal without requested execution payload")
 
 		return false
@@ -141,7 +149,13 @@ func (s *Service) acceptableEPBSProposal(proposal *api.VersionedEPBSProposal, in
 
 			return false
 		}
-		if block.Body.SignedExecutionPayloadBid.Message.FeeRecipient.IsZero() {
+		bid := block.Body.SignedExecutionPayloadBid.Message
+		if bid.BuilderIndex != gloas.BuilderIndex(^uint64(0)) && s.providerReadiness != nil && !s.providerReadiness.ProviderReady(provider, opts.Slot, block.ProposerIndex) {
+			s.log.Warn().Str("provider", provider).Msg("Discarding builder-backed ePBS proposal from provider without current preferences")
+
+			return false
+		}
+		if bid.FeeRecipient.IsZero() {
 			s.log.Warn().Msg("Discarding ePBS proposal with 0 fee recipient")
 
 			return false
@@ -167,6 +181,7 @@ func New(_ context.Context, params ...Parameter) (*Service, error) {
 	s := &Service{
 		log:               log,
 		proposalProviders: parameters.proposalProviders,
+		providerReadiness: parameters.providerReadiness,
 		timeout:           parameters.timeout,
 		clientMonitor:     parameters.clientMonitor,
 	}


### PR DESCRIPTION
Gloas requires validators to publish signed proposer preferences before a beacon node can safely use a builder-backed bid. This PR adds that path to Vouch.

```text
proposal duties
  -> derive dependent root, slot, validator, fee recipient, and gas limit
  -> sign DOMAIN_PROPOSER_PREFERENCES through the generic signer
  -> publish to every active proposal provider
  -> keep builder-backed bids only from ready providers
```

The controller derives future duties from the proposal lookahead and stays inactive on networks that do not serve the Gloas domain. Preferences use each validator's configured execution settings and the proposer-duty dependent root.

Publication fans out to the beacon nodes used by the active proposal strategy. Vouch records acceptance per provider, retries only rejected providers, and keeps self-built proposals eligible when a provider has not accepted current preferences. Cached preferences are pruned after their proposal slot passes.

Prometheus events cover signing, provider acceptance and rejection, replay suppression, and preference refreshes.

Tests: `gosilent test ./...`; `go build ./...`; `./custom-gcl run --new`.

The remaining work is live multi-instance devnet coverage and a review follow-up to avoid holding the preference cache lock during signing and submission.
