### PR TITLE
Optionally pre-warm beacon nodes at the start of a proposal slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.13.2:
+  - optionally pre-warm beacon nodes at the start of a proposal slot
+
 1.13.1:
   - initialise sync committee verification metrics to 0
   - use dynssz v1.3.2 and corresponding lib updates

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,13 @@ beaconblockproposer:
   # -  91: `builder value` must be more than ~10% higher than the local value (`local value*(100/91)`) to be used
   # - 100: `builder value` must be more than the local value (`local value*(100/100)`) to be used
   builder-boost-factor: 91
+  # If prewarm is true then at the start of a slot in which Vouch is due to propose it asks each
+  # beacon node used for beacon block proposals to produce a block, discarding the result.  Beacon
+  # nodes can carry per-slot work that only block production triggers, for example aggregating the
+  # attestation pool; pre-warming moves that work off the critical path of the proposal, at the cost
+  # of the beacon nodes producing an additional block per proposal slot.  The request is made to the
+  # non-blinded endpoint, so it does not trigger a builder auction.
+  prewarm: false
 
 # attester provides control of the attester process.
 attester:

--- a/docs/metrics/prometheus.md
+++ b/docs/metrics/prometheus.md
@@ -67,6 +67,8 @@ Performance metrics provide a mechanism to understand how quickly Vouch is carry
 
 These metrics are provided as histograms, with buckets in increments of 0.1 seconds up to 2 seconds.
 
+If `beaconblockproposer.prewarm` is enabled then `vouch_beaconblockproposer_prewarm_duration_seconds` provides the time taken to pre-warm each beacon node at the start of a proposal slot.  It has two labels: `address`, the beacon node that was pre-warmed, and `result`, either "succeeded" or "failed".  A failed pre-warm does not affect the proposal, but a pre-warm that regularly takes longer than the rest of the proposal process leaves its work on the critical path.
+
 A major part of Vouch's work is in the strategy section, where it selects the appropriate data to sign.  Data that combines the provider of the data along with the time taken to obtain and evaluate it contained in the `vouch_strategy_operation_duration_seconds` metric.  This is a histogram with buckets in increments of 0.1 seconds up to 4 seconds.  It has three labels:
 
   - `strategy` is the strategy for the operation

--- a/main.go
+++ b/main.go
@@ -263,6 +263,7 @@ func fetchConfig() error {
 	viper.SetDefault("accountmanager.dirk.timeout", 30*time.Second)
 	viper.SetDefault("strategies.beaconblockproposal.best.execution-payload-factor", float64(0.0005))
 	viper.SetDefault("beaconblockproposer.builder-boost-factor", 91)
+	viper.SetDefault("beaconblockproposer.prewarm", false)
 	viper.SetDefault("strategies.builderbid.deadline.deadline", time.Second)
 	viper.SetDefault("strategies.builderbid.deadline.bid-gap", 100*time.Millisecond)
 	viper.SetDefault("submitter.style", "multinode")
@@ -804,6 +805,11 @@ func startSigningServices(ctx context.Context,
 		return nil, nil, nil, nil, err
 	}
 
+	// Pre-warming targets the same beacon nodes that will be asked for the block.
+	var prewarmAddresses []string
+	if viper.GetBool("beaconblockproposer.prewarm") {
+		prewarmAddresses = util.BeaconNodeAddressesForBeaconBlockProposal()
+	}
 	beaconBlockProposer, err := standardbeaconblockproposer.New(ctx,
 		standardbeaconblockproposer.WithLogLevel(util.LogLevel("beaconblockproposer")),
 		standardbeaconblockproposer.WithChainTime(chainTime),
@@ -819,6 +825,7 @@ func startSigningServices(ctx context.Context,
 		standardbeaconblockproposer.WithBlobSidecarSigner(signerSvc.(signer.BlobSidecarSigner)),
 		standardbeaconblockproposer.WithUnblindFromAllRelays(viper.GetBool("beaconblockproposer.unblind-from-all-relays")),
 		standardbeaconblockproposer.WithBuilderBoostFactor(viper.GetUint64("beaconblockproposer.builder-boost-factor")),
+		standardbeaconblockproposer.WithPrewarmAddresses(prewarmAddresses),
 	)
 	if err != nil {
 		return nil, nil, nil, nil, errors.Wrap(err, "failed to start beacon block proposer service")

--- a/services/beaconblockproposer/standard/metrics.go
+++ b/services/beaconblockproposer/standard/metrics.go
@@ -29,6 +29,7 @@ var (
 	beaconBlockProposalMarkTimer         prometheus.Histogram
 	beaconBlockProposalProcessLatestSlot prometheus.Gauge
 	beaconBlockProposalSource            *prometheus.CounterVec
+	prewarmTimer                         *prometheus.HistogramVec
 )
 
 func registerMetrics(ctx context.Context, monitor metrics.Service) error {
@@ -115,6 +116,20 @@ func registerPrometheusMetrics(_ context.Context) error {
 		return err
 	}
 
+	prewarmTimer = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "vouch",
+		Subsystem: "beaconblockproposer",
+		Name:      "prewarm_duration_seconds",
+		Help:      "The time taken to pre-warm a beacon node.  result can be either succeeded or failed.",
+		Buckets: []float64{
+			0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+			1.2, 1.4, 1.6, 1.8, 2.0,
+		},
+	}, []string{"address", "result"})
+	if err := prometheus.Register(prewarmTimer); err != nil {
+		return err
+	}
+
 	bestBidRelayCount = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "vouch",
 		Subsystem: "beaconblockproposer",
@@ -162,4 +177,13 @@ func monitorBeaconBlockProposalSource(source string) {
 	}
 
 	beaconBlockProposalSource.WithLabelValues(source).Inc()
+}
+
+// monitorPrewarmed is called when an attempt to pre-warm a beacon node completes.
+func monitorPrewarmed(address string, started time.Time, result string) {
+	if prewarmTimer == nil {
+		return
+	}
+
+	prewarmTimer.WithLabelValues(address, result).Observe(time.Since(started).Seconds())
 }

--- a/services/beaconblockproposer/standard/parameters.go
+++ b/services/beaconblockproposer/standard/parameters.go
@@ -43,6 +43,7 @@ type parameters struct {
 	blobSidecarSigner          signer.BlobSidecarSigner
 	unblindFromAllRelays       bool
 	builderBoostFactor         uint64
+	prewarmAddresses           []string
 }
 
 // Parameter is the interface for service parameters.
@@ -151,6 +152,14 @@ func WithUnblindFromAllRelays(unblindFromAll bool) Parameter {
 func WithBuilderBoostFactor(factor uint64) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.builderBoostFactor = factor
+	})
+}
+
+// WithPrewarmAddresses sets the addresses of the beacon nodes to pre-warm at the start of
+// a proposal slot.  If empty, pre-warming is disabled.
+func WithPrewarmAddresses(addresses []string) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.prewarmAddresses = addresses
 	})
 }
 

--- a/services/beaconblockproposer/standard/prewarm.go
+++ b/services/beaconblockproposer/standard/prewarm.go
@@ -1,0 +1,134 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/attestantio/vouch/services/beaconblockproposer"
+	"github.com/attestantio/vouch/util"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// prewarmTimeout bounds an individual pre-warm request.  The response is discarded either
+// way, so this exists only to stop a request outliving the slot to which it belongs.
+const prewarmTimeout = 2 * time.Second
+
+// prewarm asks each configured beacon node to produce a block for the proposal slot,
+// discarding the result.
+//
+// Beacon nodes can carry per-slot work that only block production triggers, for example
+// aggregating the attestation pool.  A node that has not produced a block for some time
+// pays that cost on its next request, which places it on the critical path of a real
+// proposal.  Issuing a throwaway request at the start of the slot moves the cost off that
+// path: it runs concurrently with the auction, and the request whose result is used finds
+// the work already carried out.
+//
+// The non-blinded endpoint is used deliberately, so that pre-warming cannot trigger a
+// builder auction.
+func (s *Service) prewarm(ctx context.Context, duty *beaconblockproposer.Duty) {
+	if len(s.prewarmAddresses) == 0 {
+		return
+	}
+
+	// The pre-warm is unrelated to the outcome of the proposal, so it neither inherits
+	// cancellation from it nor outlives its own deadline.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), prewarmTimeout)
+	defer cancel()
+
+	ctx, span := otel.Tracer("attestantio.vouch.services.beaconblockproposer.standard").Start(ctx, "Prewarm", trace.WithAttributes(
+		attribute.Int64("slot", util.SlotToInt64(duty.Slot())),
+	))
+	defer span.End()
+
+	var wg sync.WaitGroup
+	for _, address := range s.prewarmAddresses {
+		wg.Add(1)
+		go func(address string) {
+			defer wg.Done()
+			s.prewarmNode(ctx, address, duty)
+		}(address)
+	}
+	wg.Wait()
+}
+
+// prewarmNode pre-warms a single beacon node.  Failures are logged and otherwise ignored;
+// a pre-warm that does not happen costs latency, not correctness.
+func (s *Service) prewarmNode(ctx context.Context, address string, duty *beaconblockproposer.Duty) {
+	started := time.Now()
+	result := "failed"
+
+	ctx, span := otel.Tracer("attestantio.vouch.services.beaconblockproposer.standard").Start(ctx, "prewarmNode", trace.WithAttributes(
+		attribute.String("provider", address),
+	))
+	defer func() {
+		span.SetAttributes(attribute.String("result", result))
+		span.End()
+		monitorPrewarmed(address, started, result)
+	}()
+
+	log := s.log.With().Uint64("proposing_slot", uint64(duty.Slot())).Str("address", address).Logger()
+
+	url := fmt.Sprintf("%s/eth/v2/validator/blocks/%d?randao_reveal=%s",
+		prewarmBaseURL(address),
+		uint64(duty.Slot()),
+		duty.RANDAOReveal().String(),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Debug().Err(err).Msg("Failed to create pre-warm request")
+
+		return
+	}
+	req.Header.Set("Accept", "application/json")
+
+	res, err := s.prewarmClient.Do(req)
+	if err != nil {
+		log.Debug().Dur("elapsed", time.Since(started)).Err(err).Msg("Pre-warm request failed")
+
+		return
+	}
+	defer res.Body.Close()
+	// The block is not wanted, only the work the node carried out to build it.  The body is
+	// drained so that the connection can be re-used.
+	_, _ = io.Copy(io.Discard, res.Body)
+
+	span.SetAttributes(attribute.Int("status_code", res.StatusCode))
+	if res.StatusCode == http.StatusOK {
+		result = "succeeded"
+	}
+
+	log.Trace().
+		Int("status_code", res.StatusCode).
+		Dur("elapsed", time.Since(started)).
+		Msg("Pre-warmed beacon node")
+}
+
+// prewarmBaseURL turns a beacon node address from the configuration into a usable URL.
+func prewarmBaseURL(address string) string {
+	if strings.Contains(address, "://") {
+		return strings.TrimSuffix(address, "/")
+	}
+
+	return "http://" + strings.TrimSuffix(address, "/")
+}

--- a/services/beaconblockproposer/standard/prewarm.go
+++ b/services/beaconblockproposer/standard/prewarm.go
@@ -94,7 +94,7 @@ func (s *Service) prewarmNode(ctx context.Context, address string, duty *beaconb
 		duty.RANDAOReveal().String(),
 	)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to create pre-warm request")
 

--- a/services/beaconblockproposer/standard/prewarm_internal_test.go
+++ b/services/beaconblockproposer/standard/prewarm_internal_test.go
@@ -1,0 +1,184 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// prewarmService creates a service with only the fields that pre-warming uses.
+func prewarmService(addresses []string) *Service {
+	return &Service{
+		log:              zerolog.Nop(),
+		prewarmAddresses: addresses,
+		prewarmClient:    &http.Client{Timeout: prewarmTimeout},
+	}
+}
+
+func TestPrewarmBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  string
+		expected string
+	}{
+		{
+			name:     "HostAndPort",
+			address:  "localhost:5052",
+			expected: "http://localhost:5052",
+		},
+		{
+			name:     "HTTPScheme",
+			address:  "http://localhost:5052",
+			expected: "http://localhost:5052",
+		},
+		{
+			name:     "HTTPSScheme",
+			address:  "https://beacon.example.com",
+			expected: "https://beacon.example.com",
+		},
+		{
+			name:     "TrailingSlash",
+			address:  "localhost:5052/",
+			expected: "http://localhost:5052",
+		},
+		{
+			name:     "SchemeAndTrailingSlash",
+			address:  "http://localhost:5052/",
+			expected: "http://localhost:5052",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, prewarmBaseURL(test.address))
+		})
+	}
+}
+
+func TestPrewarmRequest(t *testing.T) {
+	ctx := context.Background()
+
+	var mu sync.Mutex
+	requests := make([]*url.URL, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.URL)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	randaoReveal := phase0.BLSSignature{0x01, 0x02, 0x03}
+	prewarmService([]string{server.URL}).prewarm(ctx, duty(12345, 2, randaoReveal, nil))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, requests, 1)
+	require.Equal(t, "/eth/v2/validator/blocks/12345", requests[0].Path)
+	require.Equal(t, randaoReveal.String(), requests[0].Query().Get("randao_reveal"))
+}
+
+func TestPrewarmNoAddresses(t *testing.T) {
+	ctx := context.Background()
+
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	prewarmService(nil).prewarm(ctx, duty(1, 2, phase0.BLSSignature{}, nil))
+
+	require.Equal(t, int32(0), hits.Load())
+}
+
+func TestPrewarmAllAddresses(t *testing.T) {
+	ctx := context.Background()
+
+	var first, second atomic.Int32
+	firstServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		first.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer firstServer.Close()
+	secondServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		second.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer secondServer.Close()
+
+	prewarmService([]string{firstServer.URL, secondServer.URL}).prewarm(ctx, duty(1, 2, phase0.BLSSignature{}, nil))
+
+	require.Equal(t, int32(1), first.Load())
+	require.Equal(t, int32(1), second.Load())
+}
+
+// TestPrewarmContinuesAfterFailure confirms that an unhealthy beacon node neither
+// stops the others from being pre-warmed nor propagates its failure.
+func TestPrewarmContinuesAfterFailure(t *testing.T) {
+	ctx := context.Background()
+
+	var hits atomic.Int32
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer healthy.Close()
+
+	erroring := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer erroring.Close()
+
+	// An address on which nothing is listening.
+	unreachable := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	unreachableAddress := unreachable.URL
+	unreachable.Close()
+
+	service := prewarmService([]string{erroring.URL, unreachableAddress, healthy.URL})
+	require.NotPanics(t, func() {
+		service.prewarm(ctx, duty(1, 2, phase0.BLSSignature{}, nil))
+	})
+
+	require.Equal(t, int32(1), hits.Load())
+}
+
+// TestPrewarmIgnoresContextCancellation confirms that pre-warming is not tied to the
+// lifetime of the proposal that triggered it.
+func TestPrewarmIgnoresContextCancellation(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	prewarmService([]string{server.URL}).prewarm(ctx, duty(1, 2, phase0.BLSSignature{}, nil))
+
+	require.Equal(t, int32(1), hits.Load())
+}

--- a/services/beaconblockproposer/standard/propose.go
+++ b/services/beaconblockproposer/standard/propose.go
@@ -58,6 +58,10 @@ func (s *Service) Propose(ctx context.Context, duty *beaconblockproposer.Duty) e
 
 		return err
 	}
+
+	// Pre-warming runs concurrently with the work below, so that the beacon nodes have
+	// carried out their per-slot block production work before they are asked for a block.
+	go s.prewarm(ctx, duty)
 	span.SetAttributes(attribute.Int64("slot", util.SlotToInt64(slot)))
 	log := s.log.With().Uint64("proposing_slot", uint64(slot)).Uint64("validator_index", uint64(duty.ValidatorIndex())).Logger()
 	log.Trace().Msg("Proposing")

--- a/services/beaconblockproposer/standard/service.go
+++ b/services/beaconblockproposer/standard/service.go
@@ -16,6 +16,7 @@ package standard
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/attestantio/go-block-relay/services/blockauctioneer"
@@ -51,6 +52,8 @@ type Service struct {
 	blobSidecarSigner          signer.BlobSidecarSigner
 	unblindFromAllRelays       bool
 	builderBoostFactor         uint64
+	prewarmAddresses           []string
+	prewarmClient              *http.Client
 }
 
 // New creates a new beacon block proposer.
@@ -84,6 +87,8 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		blobSidecarSigner:          parameters.blobSidecarSigner,
 		unblindFromAllRelays:       parameters.unblindFromAllRelays,
 		builderBoostFactor:         parameters.builderBoostFactor,
+		prewarmAddresses:           parameters.prewarmAddresses,
+		prewarmClient:              &http.Client{Timeout: prewarmTimeout},
 	}
 
 	return s, nil


### PR DESCRIPTION
## Problem

Beacon nodes can carry per-slot work that only block production triggers, most notably aggregating the attestation pool. A node that has not produced a block for some time pays that cost on its next request. Because proposals are rare, the request Vouch makes for a real duty is always the one that pays it, so the work lands on the critical path of every proposal.

## Evidence

Measured on a Lighthouse v8.2.2 node via `beacon_block_production_attestation_seconds`, using `skip_randao_verification` so that block production could be triggered on demand rather than waiting for duties:

| pool state | attestation packing |
|---|---|
| ~30 min since last block production (i.e. what a real duty hits) | **435.9 ms** |
| 15 s since last production | 86.0 ms |
| back-to-back | **27.4 ms** |

The cost scales with time since the last block production, which is the signature of re-aggregating the attestation backlog rather than of the packing algorithm itself (the inner max-cover timers accounted for only ~14 ms of the 435.9 ms). Real proposals are always in the first row.

On the affected node this meant `strategies.beaconblockproposal` timed out on it for **15 of 15** proposals over a seven-day window, always at exactly the soft timeout, while the two other beacon nodes answered in 70-286 ms:

```
"strategy":"beaconblockproposal","impl":"best","elapsed":500.2,
"responded":2,"errored":0,"timed_out":1,"message":"Soft timeout reached with responses"
```

## Change

Adds `beaconblockproposer.prewarm`, default `false`. When enabled, at the start of a slot in which Vouch is due to propose it asks each beacon node used for beacon block proposals to produce a block, and discards the result. The work then runs concurrently with the auction, and the request whose result is actually used finds it already carried out.

Design notes:

- Fires from the top of `Propose()`, which the controller schedules at `StartOfSlot(duty.Slot())`, so it overlaps the auction rather than adding latency. It also sits after `multiInstance.ShouldPropose()`, so a standby instance never pre-warms.
- Uses the non-blinded `/eth/v2/validator/blocks` endpoint, so pre-warming cannot trigger a builder auction.
- Reuses the RANDAO reveal already signed in `Prepare()`, so there is no additional signing and no dependence on `skip_randao_verification` (which is optional in the spec and not implemented everywhere).
- Bounded by `context.WithoutCancel` plus a 2 s deadline, so it is neither cancelled by the proposal completing nor able to outlive its slot.
- Failures are logged at debug and otherwise ignored: a pre-warm that does not happen costs latency, not correctness.
- Plain `net/http`; no new dependencies.

## Observability

- `vouch_beaconblockproposer_prewarm_duration_seconds{address,result}`, where `result` is `failed` unless the node returns 200.
- Spans `Prewarm` (attribute `slot`) and `prewarmNode` (attributes `provider`, `result`, `status_code`), which attach beneath the existing `Propose` span.

Both exist because the beacon node's own block-production metrics carry no labels, so they cannot distinguish a pre-warm from a real request.

## Known limitation

The 2 s deadline bounds Vouch, not the beacon node: aborting the HTTP request does not stop block production once it has started, so a pathologically slow pre-warm can still overlap the real request. The proposal itself is unaffected, degrading to the current behaviour of returning at the soft timeout with the remaining providers.

Pre-warming one slot earlier would remove that overlap entirely, at the cost of a slightly staler pool (86 ms rather than 27 ms in the table above) and an epoch-boundary case where the RANDAO reveal signed for slot N is not valid for slot N-1. That seemed the wrong default; this can be revisited if the overlap proves to matter in practice.

## Testing

`go build ./...`, `go vet` and `gofmt` are clean. `prewarm_internal_test.go` covers URL normalisation, request shape, the disabled guard, fan-out across all configured addresses, that an erroring or unreachable node does not prevent the others being pre-warmed, and that an already-cancelled parent context still pre-warms. Passes under `-race`.
